### PR TITLE
refactor: convert module exports to namespaced static classes

### DIFF
--- a/src/clients/github-client.ts
+++ b/src/clients/github-client.ts
@@ -13,65 +13,69 @@ const githubUserResponseSchema = z.object({
   login: z.string().nullable().optional(),
 });
 
-export async function exchangeCode(
-  code: string,
-  codeVerifier: string,
-  redirectUri: string,
-  clientId: string,
-  clientSecret: string
-): Promise<{ accessToken: string }> {
-  const tokenParams = new URLSearchParams({
-    client_id: clientId,
-    client_secret: clientSecret,
-    code,
-    redirect_uri: redirectUri,
-    code_verifier: codeVerifier,
-  });
+export class GithubClient {
+  private constructor() {}
 
-  const tokenResponse = await fetch("https://github.com/login/oauth/access_token", {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: tokenParams.toString(),
-  });
+  static async exchangeCode(
+    code: string,
+    codeVerifier: string,
+    redirectUri: string,
+    clientId: string,
+    clientSecret: string
+  ): Promise<{ accessToken: string }> {
+    const tokenParams = new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+      redirect_uri: redirectUri,
+      code_verifier: codeVerifier,
+    });
 
-  if (!tokenResponse.ok) {
-    throw new Error("GITHUB_TOKEN_EXCHANGE_FAILED");
+    const tokenResponse = await fetch("https://github.com/login/oauth/access_token", {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: tokenParams.toString(),
+    });
+
+    if (!tokenResponse.ok) {
+      throw new Error("GITHUB_TOKEN_EXCHANGE_FAILED");
+    }
+
+    const tokenJson = await tokenResponse.json();
+    const tokenParse = githubAccessTokenResponseSchema.safeParse(tokenJson);
+    if (!tokenParse.success || tokenParse.data.error || !tokenParse.data.access_token) {
+      throw new Error("INVALID_GITHUB_TOKEN_RESPONSE");
+    }
+
+    return { accessToken: tokenParse.data.access_token };
   }
 
-  const tokenJson = await tokenResponse.json();
-  const tokenParse = githubAccessTokenResponseSchema.safeParse(tokenJson);
-  if (!tokenParse.success || tokenParse.data.error || !tokenParse.data.access_token) {
-    throw new Error("INVALID_GITHUB_TOKEN_RESPONSE");
+  static async fetchUser(
+    accessToken: string
+  ): Promise<{ id: string; login: string | null }> {
+    const userResponse = await fetch("https://api.github.com/user", {
+      headers: {
+        Authorization: `token ${accessToken}`,
+        Accept: "application/json",
+      },
+    });
+
+    if (!userResponse.ok) {
+      throw new Error("GITHUB_USER_FETCH_FAILED");
+    }
+
+    const userJson = await userResponse.json();
+    const userParse = githubUserResponseSchema.safeParse(userJson);
+    if (!userParse.success) {
+      throw new Error("INVALID_GITHUB_USER_RESPONSE");
+    }
+
+    return {
+      id: String(userParse.data.id),
+      login: userParse.data.login ?? null,
+    };
   }
-
-  return { accessToken: tokenParse.data.access_token };
-}
-
-export async function fetchUser(
-  accessToken: string
-): Promise<{ id: string; login: string | null }> {
-  const userResponse = await fetch("https://api.github.com/user", {
-    headers: {
-      Authorization: `token ${accessToken}`,
-      Accept: "application/json",
-    },
-  });
-
-  if (!userResponse.ok) {
-    throw new Error("GITHUB_USER_FETCH_FAILED");
-  }
-
-  const userJson = await userResponse.json();
-  const userParse = githubUserResponseSchema.safeParse(userJson);
-  if (!userParse.success) {
-    throw new Error("INVALID_GITHUB_USER_RESPONSE");
-  }
-
-  return {
-    id: String(userParse.data.id),
-    login: userParse.data.login ?? null,
-  };
 }

--- a/src/clients/google-client.ts
+++ b/src/clients/google-client.ts
@@ -33,64 +33,68 @@ function decodeJwtPayload(idToken: string): unknown {
   return JSON.parse(payloadJson) as unknown;
 }
 
-export async function exchangeCode(
-  code: string,
-  codeVerifier: string,
-  redirectUri: string,
-  clientId: string,
-  clientSecret: string
-): Promise<{ accessToken: string; idToken: string; refreshToken?: string }> {
-  const tokenParams = new URLSearchParams({
-    code,
-    client_id: clientId,
-    client_secret: clientSecret,
-    redirect_uri: redirectUri,
-    grant_type: "authorization_code",
-    code_verifier: codeVerifier,
-  });
+export class GoogleClient {
+  private constructor() {}
 
-  const tokenResponse = await fetch("https://oauth2.googleapis.com/token", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: tokenParams.toString(),
-  });
+  static async exchangeCode(
+    code: string,
+    codeVerifier: string,
+    redirectUri: string,
+    clientId: string,
+    clientSecret: string
+  ): Promise<{ accessToken: string; idToken: string; refreshToken?: string }> {
+    const tokenParams = new URLSearchParams({
+      code,
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: redirectUri,
+      grant_type: "authorization_code",
+      code_verifier: codeVerifier,
+    });
 
-  if (!tokenResponse.ok) {
-    throw new Error("GOOGLE_TOKEN_EXCHANGE_FAILED");
+    const tokenResponse = await fetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: tokenParams.toString(),
+    });
+
+    if (!tokenResponse.ok) {
+      throw new Error("GOOGLE_TOKEN_EXCHANGE_FAILED");
+    }
+
+    const tokenJson = await tokenResponse.json();
+    const tokenParse = googleTokenResponseSchema.safeParse(tokenJson);
+    if (!tokenParse.success || tokenParse.data.error) {
+      throw new Error("INVALID_GOOGLE_TOKEN_RESPONSE");
+    }
+
+    return {
+      accessToken: tokenParse.data.access_token,
+      idToken: tokenParse.data.id_token,
+      refreshToken: tokenParse.data.refresh_token,
+    };
   }
 
-  const tokenJson = await tokenResponse.json();
-  const tokenParse = googleTokenResponseSchema.safeParse(tokenJson);
-  if (!tokenParse.success || tokenParse.data.error) {
-    throw new Error("INVALID_GOOGLE_TOKEN_RESPONSE");
+  static decodeIdToken(idToken: string, clientId: string): { sub: string; name?: string } {
+    const payloadRaw = decodeJwtPayload(idToken);
+    const payload = googleIdTokenPayloadSchema.safeParse(payloadRaw);
+    if (!payload.success) {
+      throw new Error("INVALID_GOOGLE_ID_TOKEN_PAYLOAD");
+    }
+
+    if (payload.data.aud !== clientId) {
+      throw new Error("GOOGLE_ID_TOKEN_AUDIENCE_MISMATCH");
+    }
+
+    if (payload.data.exp <= Math.floor(Date.now() / 1000)) {
+      throw new Error("GOOGLE_ID_TOKEN_EXPIRED");
+    }
+
+    return {
+      sub: payload.data.sub,
+      name: payload.data.name ?? payload.data.given_name,
+    };
   }
-
-  return {
-    accessToken: tokenParse.data.access_token,
-    idToken: tokenParse.data.id_token,
-    refreshToken: tokenParse.data.refresh_token,
-  };
-}
-
-export function decodeIdToken(idToken: string, clientId: string): { sub: string; name?: string } {
-  const payloadRaw = decodeJwtPayload(idToken);
-  const payload = googleIdTokenPayloadSchema.safeParse(payloadRaw);
-  if (!payload.success) {
-    throw new Error("INVALID_GOOGLE_ID_TOKEN_PAYLOAD");
-  }
-
-  if (payload.data.aud !== clientId) {
-    throw new Error("GOOGLE_ID_TOKEN_AUDIENCE_MISMATCH");
-  }
-
-  if (payload.data.exp <= Math.floor(Date.now() / 1000)) {
-    throw new Error("GOOGLE_ID_TOKEN_EXPIRED");
-  }
-
-  return {
-    sub: payload.data.sub,
-    name: payload.data.name ?? payload.data.given_name,
-  };
 }

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,31 +1,35 @@
 import { MongoClient, Db } from "mongodb";
 
-let client: MongoClient | null = null;
-let db: Db | null = null;
+export class DbClient {
+  private static client: MongoClient | null = null;
+  private static db: Db | null = null;
 
-export async function connectDb(uri: string): Promise<MongoClient> {
-  if (client) {
-    return client;
+  private constructor() {}
+
+  static async connect(uri: string): Promise<MongoClient> {
+    if (DbClient.client) {
+      return DbClient.client;
+    }
+
+    DbClient.client = new MongoClient(uri);
+    await DbClient.client.connect();
+    DbClient.db = DbClient.client.db();
+
+    return DbClient.client;
   }
 
-  client = new MongoClient(uri);
-  await client.connect();
-  db = client.db();
-
-  return client;
-}
-
-export function getDb(): Db {
-  if (!db) {
-    throw new Error("Database not connected. Call connectDb() first.");
+  static getDb(): Db {
+    if (!DbClient.db) {
+      throw new Error("Database not connected. Call connectDb() first.");
+    }
+    return DbClient.db;
   }
-  return db;
-}
 
-export async function closeDb(): Promise<void> {
-  if (client) {
-    await client.close();
-    client = null;
-    db = null;
+  static async close(): Promise<void> {
+    if (DbClient.client) {
+      await DbClient.client.close();
+      DbClient.client = null;
+      DbClient.db = null;
+    }
   }
 }

--- a/src/db/collections.ts
+++ b/src/db/collections.ts
@@ -1,38 +1,34 @@
 import { Collection } from "mongodb";
-import { getDb } from "./client.js";
+import { DbClient } from "./client.js";
 import { User, OAuthAccount, BridgeRegistration } from "../models/documents.js";
 
-export function users(): Collection<User> {
-  return getDb().collection<User>("users");
-}
+export class Collections {
+  private constructor() {}
 
-export function oauthAccounts(): Collection<OAuthAccount> {
-  return getDb().collection<OAuthAccount>("oauthAccounts");
-}
+  static users(): Collection<User> {
+    return DbClient.getDb().collection<User>("users");
+  }
 
-export function bridgeRegistrations(): Collection<BridgeRegistration> {
-  return getDb().collection<BridgeRegistration>("bridgeRegistrations");
-}
+  static oauthAccounts(): Collection<OAuthAccount> {
+    return DbClient.getDb().collection<OAuthAccount>("oauthAccounts");
+  }
 
-export async function ensureIndexes(): Promise<void> {
-  // Create indexes for oauthAccounts collection
-  const oauthAccountsCollection = oauthAccounts();
-  
-  // Unique compound index on (provider, providerUserId)
-  await oauthAccountsCollection.createIndex(
-    { provider: 1, providerUserId: 1 },
-    { unique: true }
-  );
-  
-  // Index on userId for lookups
-  await oauthAccountsCollection.createIndex({ userId: 1 });
-  
-  // Create unique index for bridgeRegistrations collection
-  const bridgeRegistrationsCollection = bridgeRegistrations();
-  
-  // Unique index on userId (one bridge per user)
-  await bridgeRegistrationsCollection.createIndex(
-    { userId: 1 },
-    { unique: true }
-  );
+  static bridgeRegistrations(): Collection<BridgeRegistration> {
+    return DbClient.getDb().collection<BridgeRegistration>("bridgeRegistrations");
+  }
+
+  static async ensureIndexes(): Promise<void> {
+    const oauthAccountsCollection = Collections.oauthAccounts();
+    await oauthAccountsCollection.createIndex(
+      { provider: 1, providerUserId: 1 },
+      { unique: true }
+    );
+    await oauthAccountsCollection.createIndex({ userId: 1 });
+
+    const bridgeRegistrationsCollection = Collections.bridgeRegistrations();
+    await bridgeRegistrationsCollection.createIndex(
+      { userId: 1 },
+      { unique: true }
+    );
+  }
 }

--- a/src/db/collections.ts
+++ b/src/db/collections.ts
@@ -2,7 +2,7 @@ import { Collection } from "mongodb";
 import { DbClient } from "./client.js";
 import { User, OAuthAccount, BridgeRegistration } from "../models/documents.js";
 
-export class Collections {
+export class DatabaseAccessor {
   private constructor() {}
 
   static users(): Collection<User> {
@@ -18,14 +18,14 @@ export class Collections {
   }
 
   static async ensureIndexes(): Promise<void> {
-    const oauthAccountsCollection = Collections.oauthAccounts();
+    const oauthAccountsCollection = DatabaseAccessor.oauthAccounts();
     await oauthAccountsCollection.createIndex(
       { provider: 1, providerUserId: 1 },
       { unique: true }
     );
     await oauthAccountsCollection.createIndex({ userId: 1 });
 
-    const bridgeRegistrationsCollection = Collections.bridgeRegistrations();
+    const bridgeRegistrationsCollection = DatabaseAccessor.bridgeRegistrations();
     await bridgeRegistrationsCollection.createIndex(
       { userId: 1 },
       { unique: true }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { loadConfig } from "./config.js";
 import { DbClient } from "./db/client.js";
-import { Collections } from "./db/collections.js";
+import { DatabaseAccessor } from "./db/collections.js";
 import { buildApp } from "./server.js";
 import { TokenService } from "./services/token-service.js";
 
@@ -12,7 +12,7 @@ async function main() {
   console.log("MongoDB connected");
 
   console.log("Creating indexes...");
-  await Collections.ensureIndexes();
+  await DatabaseAccessor.ensureIndexes();
   console.log("Indexes ready");
 
   TokenService.loadKeys(config.JWT_PRIVATE_KEY_PATH, config.JWT_PUBLIC_KEY_PATH);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,21 @@
 import { loadConfig } from "./config.js";
-import { connectDb, closeDb } from "./db/client.js";
-import { ensureIndexes } from "./db/collections.js";
+import { DbClient } from "./db/client.js";
+import { Collections } from "./db/collections.js";
 import { buildApp } from "./server.js";
-import { loadKeys } from "./services/token-service.js";
+import { TokenService } from "./services/token-service.js";
 
 async function main() {
   const config = loadConfig();
 
   console.log("Connecting to MongoDB...");
-  await connectDb(config.MONGODB_URI);
+  await DbClient.connect(config.MONGODB_URI);
   console.log("MongoDB connected");
 
   console.log("Creating indexes...");
-  await ensureIndexes();
+  await Collections.ensureIndexes();
   console.log("Indexes ready");
 
-  loadKeys(config.JWT_PRIVATE_KEY_PATH, config.JWT_PUBLIC_KEY_PATH);
+  TokenService.loadKeys(config.JWT_PRIVATE_KEY_PATH, config.JWT_PUBLIC_KEY_PATH);
   console.log("JWT keys loaded");
 
   const app = await buildApp();
@@ -29,7 +29,7 @@ async function main() {
     process.on(signal, async () => {
       console.log(`Received ${signal}, shutting down gracefully...`);
       await app.close();
-      await closeDb();
+      await DbClient.close();
       process.exit(0);
     });
   }

--- a/src/lib/state-store.ts
+++ b/src/lib/state-store.ts
@@ -4,22 +4,26 @@ import { LRUCache } from "lru-cache";
 const STATE_TTL_MS = 10 * 60 * 1000;
 const MAX_STATES = 10_000;
 
-const states = new LRUCache<string, true>({
-  max: MAX_STATES,
-  ttl: STATE_TTL_MS,
-});
+export class StateStore {
+  private static states = new LRUCache<string, true>({
+    max: MAX_STATES,
+    ttl: STATE_TTL_MS,
+  });
 
-export function createState(): string {
-  const state = crypto.randomBytes(32).toString("hex");
-  states.set(state, true);
-  return state;
-}
+  private constructor() {}
 
-export function validateState(state: string): boolean {
-  if (!states.has(state)) {
-    return false;
+  static createState(): string {
+    const state = crypto.randomBytes(32).toString("hex");
+    StateStore.states.set(state, true);
+    return state;
   }
 
-  states.delete(state);
-  return true;
+  static validateState(state: string): boolean {
+    if (!StateStore.states.has(state)) {
+      return false;
+    }
+
+    StateStore.states.delete(state);
+    return true;
+  }
 }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,5 +1,5 @@
 import { FastifyRequest, FastifyReply } from "fastify";
-import { verifyToken } from "../services/token-service.js";
+import { TokenService } from "../services/token-service.js";
 import {
   accessTokenPayloadSchema,
   type AccessTokenPayload,
@@ -25,7 +25,7 @@ export async function requireAuth(
   const token = authHeader.slice(7);
 
   try {
-    const raw = verifyToken(token);
+    const raw = TokenService.verifyToken(token);
     const result = accessTokenPayloadSchema.safeParse(raw);
     if (!result.success) {
       request.log.warn(

--- a/src/repositories/bridge-registration-repo.ts
+++ b/src/repositories/bridge-registration-repo.ts
@@ -1,43 +1,47 @@
 import { ObjectId, type UpdateResult } from "mongodb";
-import { bridgeRegistrations } from "../db/collections.js";
+import { Collections } from "../db/collections.js";
 import type { BridgeRegistration } from "../models/documents.js";
 
-export async function upsert(params: {
-  userId: ObjectId;
-  relayUrl: string;
-  roomCode: string;
-  publicKey: string;
-}): Promise<UpdateResult<BridgeRegistration>> {
-  return bridgeRegistrations().updateOne(
-    { userId: params.userId },
-    {
-      $set: {
-        relayUrl: params.relayUrl,
-        roomCode: params.roomCode,
-        publicKey: params.publicKey,
-        lastHeartbeat: new Date(),
+export class BridgeRegistrationRepository {
+  private constructor() {}
+
+  static async upsert(params: {
+    userId: ObjectId;
+    relayUrl: string;
+    roomCode: string;
+    publicKey: string;
+  }): Promise<UpdateResult<BridgeRegistration>> {
+    return Collections.bridgeRegistrations().updateOne(
+      { userId: params.userId },
+      {
+        $set: {
+          relayUrl: params.relayUrl,
+          roomCode: params.roomCode,
+          publicKey: params.publicKey,
+          lastHeartbeat: new Date(),
+        },
+        $setOnInsert: { createdAt: new Date() },
       },
-      $setOnInsert: { createdAt: new Date() },
-    },
-    { upsert: true }
-  );
-}
+      { upsert: true }
+    );
+  }
 
-export async function findByUserId(
-  userId: ObjectId
-): Promise<BridgeRegistration | null> {
-  return bridgeRegistrations().findOne({ userId });
-}
+  static async findByUserId(
+    userId: ObjectId
+  ): Promise<BridgeRegistration | null> {
+    return Collections.bridgeRegistrations().findOne({ userId });
+  }
 
-export async function deleteByUserId(userId: ObjectId): Promise<void> {
-  await bridgeRegistrations().deleteOne({ userId });
-}
+  static async deleteByUserId(userId: ObjectId): Promise<void> {
+    await Collections.bridgeRegistrations().deleteOne({ userId });
+  }
 
-export async function updateHeartbeat(userId: ObjectId): Promise<number> {
-  const result = await bridgeRegistrations().updateOne(
-    { userId },
-    { $set: { lastHeartbeat: new Date() } }
-  );
+  static async updateHeartbeat(userId: ObjectId): Promise<number> {
+    const result = await Collections.bridgeRegistrations().updateOne(
+      { userId },
+      { $set: { lastHeartbeat: new Date() } }
+    );
 
-  return result.matchedCount;
+    return result.matchedCount;
+  }
 }

--- a/src/repositories/bridge-registration-repo.ts
+++ b/src/repositories/bridge-registration-repo.ts
@@ -1,5 +1,5 @@
 import { ObjectId, type UpdateResult } from "mongodb";
-import { Collections } from "../db/collections.js";
+import { DatabaseAccessor } from "../db/collections.js";
 import type { BridgeRegistration } from "../models/documents.js";
 
 export class BridgeRegistrationRepository {
@@ -11,7 +11,7 @@ export class BridgeRegistrationRepository {
     roomCode: string;
     publicKey: string;
   }): Promise<UpdateResult<BridgeRegistration>> {
-    return Collections.bridgeRegistrations().updateOne(
+    return DatabaseAccessor.bridgeRegistrations().updateOne(
       { userId: params.userId },
       {
         $set: {
@@ -29,15 +29,15 @@ export class BridgeRegistrationRepository {
   static async findByUserId(
     userId: ObjectId
   ): Promise<BridgeRegistration | null> {
-    return Collections.bridgeRegistrations().findOne({ userId });
+    return DatabaseAccessor.bridgeRegistrations().findOne({ userId });
   }
 
   static async deleteByUserId(userId: ObjectId): Promise<void> {
-    await Collections.bridgeRegistrations().deleteOne({ userId });
+    await DatabaseAccessor.bridgeRegistrations().deleteOne({ userId });
   }
 
   static async updateHeartbeat(userId: ObjectId): Promise<number> {
-    const result = await Collections.bridgeRegistrations().updateOne(
+    const result = await DatabaseAccessor.bridgeRegistrations().updateOne(
       { userId },
       { $set: { lastHeartbeat: new Date() } }
     );

--- a/src/repositories/oauth-account-repo.ts
+++ b/src/repositories/oauth-account-repo.ts
@@ -1,64 +1,68 @@
 import { ObjectId } from "mongodb";
-import { oauthAccounts } from "../db/collections.js";
+import { Collections } from "../db/collections.js";
 import type { OAuthAccount } from "../models/documents.js";
 
-export async function findByProvider(
-  provider: string,
-  providerUserId: string
-): Promise<OAuthAccount | null> {
-  return oauthAccounts().findOne({ provider, providerUserId });
-}
+export class OAuthAccountRepository {
+  private constructor() {}
 
-export async function findByUserId(userId: ObjectId): Promise<OAuthAccount | null> {
-  return oauthAccounts().findOne({ userId });
-}
-
-export async function upsert(params: {
-  potentialUserId: ObjectId;
-  provider: string;
-  providerUserId: string;
-  providerUsername: string | null;
-  accessToken: string;
-  refreshToken?: string;
-}): Promise<OAuthAccount> {
-  const now = new Date();
-  const set: {
-    accessToken: string;
-    providerUsername: string | null;
-    updatedAt: Date;
-    refreshToken?: string;
-  } = {
-    accessToken: params.accessToken,
-    providerUsername: params.providerUsername,
-    updatedAt: now,
-  };
-
-  if (params.refreshToken !== undefined) {
-    set.refreshToken = params.refreshToken;
+  static async findByProvider(
+    provider: string,
+    providerUserId: string
+  ): Promise<OAuthAccount | null> {
+    return Collections.oauthAccounts().findOne({ provider, providerUserId });
   }
 
-  const result = await oauthAccounts().findOneAndUpdate(
-    {
-      provider: params.provider,
-      providerUserId: params.providerUserId,
-    },
-    {
-      $set: set,
-      $setOnInsert: {
-        _id: new ObjectId(),
-        userId: params.potentialUserId,
+  static async findByUserId(userId: ObjectId): Promise<OAuthAccount | null> {
+    return Collections.oauthAccounts().findOne({ userId });
+  }
+
+  static async upsert(params: {
+    potentialUserId: ObjectId;
+    provider: string;
+    providerUserId: string;
+    providerUsername: string | null;
+    accessToken: string;
+    refreshToken?: string;
+  }): Promise<OAuthAccount> {
+    const now = new Date();
+    const set: {
+      accessToken: string;
+      providerUsername: string | null;
+      updatedAt: Date;
+      refreshToken?: string;
+    } = {
+      accessToken: params.accessToken,
+      providerUsername: params.providerUsername,
+      updatedAt: now,
+    };
+
+    if (params.refreshToken !== undefined) {
+      set.refreshToken = params.refreshToken;
+    }
+
+    const result = await Collections.oauthAccounts().findOneAndUpdate(
+      {
         provider: params.provider,
         providerUserId: params.providerUserId,
-        createdAt: now,
-        refreshToken: params.refreshToken ?? null,
       },
-    },
-    { upsert: true, returnDocument: "after" }
-  );
+      {
+        $set: set,
+        $setOnInsert: {
+          _id: new ObjectId(),
+          userId: params.potentialUserId,
+          provider: params.provider,
+          providerUserId: params.providerUserId,
+          createdAt: now,
+          refreshToken: params.refreshToken ?? null,
+        },
+      },
+      { upsert: true, returnDocument: "after" }
+    );
 
-  if (!result) {
-    throw new Error("findOneAndUpdate with upsert returned null");
+    if (!result) {
+      throw new Error("findOneAndUpdate with upsert returned null");
+    }
+
+    return result;
   }
-
-  return result;
 }

--- a/src/repositories/oauth-account-repo.ts
+++ b/src/repositories/oauth-account-repo.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from "mongodb";
-import { Collections } from "../db/collections.js";
+import { DatabaseAccessor } from "../db/collections.js";
 import type { OAuthAccount } from "../models/documents.js";
 
 export class OAuthAccountRepository {
@@ -9,11 +9,11 @@ export class OAuthAccountRepository {
     provider: string,
     providerUserId: string
   ): Promise<OAuthAccount | null> {
-    return Collections.oauthAccounts().findOne({ provider, providerUserId });
+    return DatabaseAccessor.oauthAccounts().findOne({ provider, providerUserId });
   }
 
   static async findByUserId(userId: ObjectId): Promise<OAuthAccount | null> {
-    return Collections.oauthAccounts().findOne({ userId });
+    return DatabaseAccessor.oauthAccounts().findOne({ userId });
   }
 
   static async upsert(params: {
@@ -40,7 +40,7 @@ export class OAuthAccountRepository {
       set.refreshToken = params.refreshToken;
     }
 
-    const result = await Collections.oauthAccounts().findOneAndUpdate(
+    const result = await DatabaseAccessor.oauthAccounts().findOneAndUpdate(
       {
         provider: params.provider,
         providerUserId: params.providerUserId,

--- a/src/repositories/user-repo.ts
+++ b/src/repositories/user-repo.ts
@@ -1,27 +1,31 @@
 import { ObjectId } from "mongodb";
-import { users } from "../db/collections.js";
+import { Collections } from "../db/collections.js";
 import type { User } from "../models/documents.js";
 
-export async function findById(userId: ObjectId): Promise<User | null> {
-  return users().findOne({ _id: userId });
-}
+export class UserRepository {
+  private constructor() {}
 
-export async function create(id?: ObjectId): Promise<User> {
-  const now = new Date();
-  const user: User = {
-    _id: id ?? new ObjectId(),
-    tokenVersion: 0,
-    createdAt: now,
-    updatedAt: now,
-  };
+  static async findById(userId: ObjectId): Promise<User | null> {
+    return Collections.users().findOne({ _id: userId });
+  }
 
-  await users().insertOne(user);
-  return user;
-}
+  static async create(id?: ObjectId): Promise<User> {
+    const now = new Date();
+    const user: User = {
+      _id: id ?? new ObjectId(),
+      tokenVersion: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
 
-export async function incrementTokenVersion(userId: ObjectId): Promise<void> {
-  await users().updateOne(
-    { _id: userId },
-    { $inc: { tokenVersion: 1 }, $set: { updatedAt: new Date() } }
-  );
+    await Collections.users().insertOne(user);
+    return user;
+  }
+
+  static async incrementTokenVersion(userId: ObjectId): Promise<void> {
+    await Collections.users().updateOne(
+      { _id: userId },
+      { $inc: { tokenVersion: 1 }, $set: { updatedAt: new Date() } }
+    );
+  }
 }

--- a/src/repositories/user-repo.ts
+++ b/src/repositories/user-repo.ts
@@ -1,12 +1,12 @@
 import { ObjectId } from "mongodb";
-import { Collections } from "../db/collections.js";
+import { DatabaseAccessor } from "../db/collections.js";
 import type { User } from "../models/documents.js";
 
 export class UserRepository {
   private constructor() {}
 
   static async findById(userId: ObjectId): Promise<User | null> {
-    return Collections.users().findOne({ _id: userId });
+    return DatabaseAccessor.users().findOne({ _id: userId });
   }
 
   static async create(id?: ObjectId): Promise<User> {
@@ -18,12 +18,12 @@ export class UserRepository {
       updatedAt: now,
     };
 
-    await Collections.users().insertOne(user);
+    await DatabaseAccessor.users().insertOne(user);
     return user;
   }
 
   static async incrementTokenVersion(userId: ObjectId): Promise<void> {
-    await Collections.users().updateOne(
+    await DatabaseAccessor.users().updateOne(
       { _id: userId },
       { $inc: { tokenVersion: 1 }, $set: { updatedAt: new Date() } }
     );

--- a/src/routes/bridge.ts
+++ b/src/routes/bridge.ts
@@ -1,12 +1,7 @@
 import { FastifyPluginAsync } from "fastify";
 import { z } from "zod";
 import { requireAuth } from "../middleware/auth.js";
-import {
-  deregister,
-  findByUser,
-  heartbeat,
-  register,
-} from "../services/bridge-service.js";
+import { BridgeService } from "../services/bridge-service.js";
 
 const registerBodySchema = z.object({
   relayUrl: z.string().url().max(500),
@@ -27,7 +22,7 @@ export const bridgeRoutes: FastifyPluginAsync = async (fastify) => {
         });
       }
 
-      return register({
+      return BridgeService.register({
         userId: request.user!.userId,
         relayUrl: bodyResult.data.relayUrl,
         roomCode: bodyResult.data.roomCode,
@@ -40,7 +35,7 @@ export const bridgeRoutes: FastifyPluginAsync = async (fastify) => {
     "/bridge/heartbeat",
     { preHandler: [requireAuth] },
     async (request, reply) => {
-      const updated = await heartbeat(request.user!.userId);
+      const updated = await BridgeService.heartbeat(request.user!.userId);
       if (!updated) {
         return reply.status(404).send({ error: "no_bridge_registered" });
       }
@@ -53,7 +48,7 @@ export const bridgeRoutes: FastifyPluginAsync = async (fastify) => {
     "/bridge/deregister",
     { preHandler: [requireAuth] },
     async (request) => {
-      await deregister(request.user!.userId);
+      await BridgeService.deregister(request.user!.userId);
       return { ok: true };
     }
   );
@@ -62,7 +57,7 @@ export const bridgeRoutes: FastifyPluginAsync = async (fastify) => {
     "/bridge/mine",
     { preHandler: [requireAuth] },
     async (request, reply) => {
-      const registration = await findByUser(request.user!.userId);
+      const registration = await BridgeService.findByUser(request.user!.userId);
       if (!registration) {
         return reply.status(404).send({ error: "no_bridge_online" });
       }

--- a/src/routes/github.ts
+++ b/src/routes/github.ts
@@ -1,11 +1,8 @@
 import { FastifyPluginAsync } from "fastify";
 import { z } from "zod";
 import { loadConfig } from "../config.js";
-import { createState, validateState } from "../lib/state-store.js";
-import {
-  authenticateGithub,
-  AuthServiceError,
-} from "../services/auth-service.js";
+import { StateStore } from "../lib/state-store.js";
+import { AuthService, AuthServiceError } from "../services/auth-service.js";
 
 const githubInitQuerySchema = z.object({
   redirect_uri: z.string().min(1),
@@ -43,7 +40,7 @@ export const githubRoutes: FastifyPluginAsync = async (fastify) => {
 
     const { redirect_uri, code_challenge, code_challenge_method } = queryResult.data;
 
-    const state = createState();
+    const state = StateStore.createState();
     const authUrl = new URL("https://github.com/login/oauth/authorize");
     authUrl.searchParams.set("client_id", config.GITHUB_CLIENT_ID);
     authUrl.searchParams.set("redirect_uri", redirect_uri);
@@ -68,12 +65,12 @@ export const githubRoutes: FastifyPluginAsync = async (fastify) => {
     }
 
     const { code, codeVerifier, state, redirectUri } = bodyResult.data;
-    if (!validateState(state)) {
+    if (!StateStore.validateState(state)) {
       return reply.status(400).send({ error: "Invalid or expired state" });
     }
 
     try {
-      return await authenticateGithub({
+      return await AuthService.authenticateGithub({
         code,
         codeVerifier,
         redirectUri,

--- a/src/routes/google.ts
+++ b/src/routes/google.ts
@@ -1,11 +1,8 @@
 import { FastifyPluginAsync } from "fastify";
 import { z } from "zod";
 import { loadConfig } from "../config.js";
-import { createState, validateState } from "../lib/state-store.js";
-import {
-  authenticateGoogle,
-  AuthServiceError,
-} from "../services/auth-service.js";
+import { StateStore } from "../lib/state-store.js";
+import { AuthService, AuthServiceError } from "../services/auth-service.js";
 
 const googleInitQuerySchema = z.object({
   redirect_uri: z.string().min(1),
@@ -43,7 +40,7 @@ export const googleRoutes: FastifyPluginAsync = async (fastify) => {
 
     const { redirect_uri, code_challenge, code_challenge_method } = queryResult.data;
 
-    const state = createState();
+    const state = StateStore.createState();
     const authUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
     authUrl.searchParams.set("client_id", config.GOOGLE_CLIENT_ID);
     authUrl.searchParams.set("redirect_uri", redirect_uri);
@@ -71,12 +68,12 @@ export const googleRoutes: FastifyPluginAsync = async (fastify) => {
     }
 
     const { code, codeVerifier, state, redirectUri } = bodyResult.data;
-    if (!validateState(state)) {
+    if (!StateStore.validateState(state)) {
       return reply.status(400).send({ error: "Invalid or expired state" });
     }
 
     try {
-      return await authenticateGoogle({
+      return await AuthService.authenticateGoogle({
         code,
         codeVerifier,
         redirectUri,

--- a/src/routes/token.ts
+++ b/src/routes/token.ts
@@ -1,13 +1,8 @@
 import { FastifyPluginAsync } from "fastify";
 import { z } from "zod";
 import { requireAuth } from "../middleware/auth.js";
-import {
-  AuthServiceError,
-  findUserAuthProfile,
-  logoutUser,
-  refreshAuthTokens,
-} from "../services/auth-service.js";
-import { getPublicKey } from "../services/token-service.js";
+import { AuthService, AuthServiceError } from "../services/auth-service.js";
+import { TokenService } from "../services/token-service.js";
 
 const refreshBodySchema = z.object({
   refreshToken: z.string(),
@@ -24,7 +19,7 @@ export const tokenRoutes: FastifyPluginAsync = async (fastify) => {
     }
 
     try {
-      return await refreshAuthTokens(bodyResult.data.refreshToken);
+      return await AuthService.refreshAuthTokens(bodyResult.data.refreshToken);
     } catch (error) {
       if (error instanceof AuthServiceError && error.code === "UNAUTHORIZED") {
         request.log.warn(error, "Refresh token verification failed");
@@ -36,7 +31,7 @@ export const tokenRoutes: FastifyPluginAsync = async (fastify) => {
   });
 
   fastify.get("/auth/me", { preHandler: requireAuth }, async (request, reply) => {
-    const profile = await findUserAuthProfile(request.user!.userId);
+    const profile = await AuthService.findUserAuthProfile(request.user!.userId);
     if (!profile) {
       return reply.status(404).send({ error: "User not found" });
     }
@@ -47,14 +42,14 @@ export const tokenRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.post(
     "/auth/logout",
     { preHandler: requireAuth },
-    async (request, reply) => {
-      await logoutUser(request.user!.userId);
+    async (request) => {
+      await AuthService.logoutUser(request.user!.userId);
       return { success: true };
     }
   );
 
-  fastify.get("/auth/public-key", async (request, reply) => {
-    const key = getPublicKey();
+  fastify.get("/auth/public-key", async (_request, reply) => {
+    const key = TokenService.getPublicKey();
     return reply.type("text/plain").send(key);
   });
 };

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,27 +1,10 @@
 import { ObjectId } from "mongodb";
-import {
-  decodeIdToken,
-  exchangeCode as exchangeGoogleCode,
-} from "../clients/google-client.js";
-import {
-  exchangeCode as exchangeGithubCode,
-  fetchUser as fetchGithubUser,
-} from "../clients/github-client.js";
+import { GoogleClient } from "../clients/google-client.js";
+import { GithubClient } from "../clients/github-client.js";
 import { refreshTokenPayloadSchema } from "../models/jwt.js";
-import {
-  findByUserId,
-  upsert as upsertOauthAccount,
-} from "../repositories/oauth-account-repo.js";
-import {
-  create as createUser,
-  findById,
-  incrementTokenVersion,
-} from "../repositories/user-repo.js";
-import {
-  signAccessToken,
-  signRefreshToken,
-  verifyToken,
-} from "./token-service.js";
+import { OAuthAccountRepository } from "../repositories/oauth-account-repo.js";
+import { UserRepository } from "../repositories/user-repo.js";
+import { TokenService } from "./token-service.js";
 
 export class AuthServiceError extends Error {
   constructor(public readonly code: string, cause?: unknown) {
@@ -43,236 +26,239 @@ type AuthResult = {
   };
 };
 
-export async function authenticateGithub(params: {
-  code: string;
-  codeVerifier: string;
-  redirectUri: string;
-  clientId: string;
-  clientSecret: string;
-}): Promise<AuthResult> {
-  let accessToken: string;
+export class AuthService {
+  private constructor() {}
 
-  try {
-    const result = await exchangeGithubCode(
-      params.code,
-      params.codeVerifier,
-      params.redirectUri,
-      params.clientId,
-      params.clientSecret
-    );
-    accessToken = result.accessToken;
-  } catch (error) {
-    if (error instanceof Error && error.message === "GITHUB_TOKEN_EXCHANGE_FAILED") {
-      throw new AuthServiceError("GITHUB_TOKEN_EXCHANGE_FAILED", error);
+  static async authenticateGithub(params: {
+    code: string;
+    codeVerifier: string;
+    redirectUri: string;
+    clientId: string;
+    clientSecret: string;
+  }): Promise<AuthResult> {
+    let accessToken: string;
+
+    try {
+      const result = await GithubClient.exchangeCode(
+        params.code,
+        params.codeVerifier,
+        params.redirectUri,
+        params.clientId,
+        params.clientSecret
+      );
+      accessToken = result.accessToken;
+    } catch (error) {
+      if (error instanceof Error && error.message === "GITHUB_TOKEN_EXCHANGE_FAILED") {
+        throw new AuthServiceError("GITHUB_TOKEN_EXCHANGE_FAILED", error);
+      }
+      if (error instanceof Error && error.message === "INVALID_GITHUB_TOKEN_RESPONSE") {
+        throw new AuthServiceError("INVALID_GITHUB_TOKEN_RESPONSE", error);
+      }
+      throw error;
     }
-    if (error instanceof Error && error.message === "INVALID_GITHUB_TOKEN_RESPONSE") {
-      throw new AuthServiceError("INVALID_GITHUB_TOKEN_RESPONSE", error);
+
+    try {
+      const githubUser = await GithubClient.fetchUser(accessToken);
+      return AuthService.upsertFromOAuth({
+        provider: "github",
+        providerUserId: githubUser.id,
+        providerUsername: githubUser.login,
+        accessToken,
+        refreshToken: undefined,
+        persistRefreshToken: false,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message === "GITHUB_USER_FETCH_FAILED") {
+        throw new AuthServiceError("GITHUB_USER_FETCH_FAILED", error);
+      }
+      if (error instanceof Error && error.message === "INVALID_GITHUB_USER_RESPONSE") {
+        throw new AuthServiceError("INVALID_GITHUB_USER_RESPONSE", error);
+      }
+      throw error;
     }
-    throw error;
   }
 
-  try {
-    const githubUser = await fetchGithubUser(accessToken);
-    return upsertFromOAuth({
-      provider: "github",
-      providerUserId: githubUser.id,
-      providerUsername: githubUser.login,
-      accessToken,
-      refreshToken: undefined,
-      persistRefreshToken: false,
+  static async authenticateGoogle(params: {
+    code: string;
+    codeVerifier: string;
+    redirectUri: string;
+    clientId: string;
+    clientSecret: string;
+  }): Promise<AuthResult> {
+    let tokenData: { accessToken: string; idToken: string; refreshToken?: string };
+
+    try {
+      tokenData = await GoogleClient.exchangeCode(
+        params.code,
+        params.codeVerifier,
+        params.redirectUri,
+        params.clientId,
+        params.clientSecret
+      );
+    } catch (error) {
+      if (error instanceof Error && error.message === "GOOGLE_TOKEN_EXCHANGE_FAILED") {
+        throw new AuthServiceError("GOOGLE_TOKEN_EXCHANGE_FAILED", error);
+      }
+      if (error instanceof Error && error.message === "INVALID_GOOGLE_TOKEN_RESPONSE") {
+        throw new AuthServiceError("INVALID_GOOGLE_TOKEN_RESPONSE", error);
+      }
+      throw error;
+    }
+
+    let googleUser: { sub: string; name?: string };
+    try {
+      googleUser = GoogleClient.decodeIdToken(tokenData.idToken, params.clientId);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message === "INVALID_GOOGLE_ID_TOKEN_PAYLOAD"
+      ) {
+        throw new AuthServiceError("INVALID_GOOGLE_ID_TOKEN_PAYLOAD", error);
+      }
+      throw new AuthServiceError("INVALID_GOOGLE_ID_TOKEN", error);
+    }
+
+    return AuthService.upsertFromOAuth({
+      provider: "google",
+      providerUserId: googleUser.sub,
+      providerUsername: googleUser.name ?? null,
+      accessToken: tokenData.accessToken,
+      refreshToken: tokenData.refreshToken,
+      persistRefreshToken: tokenData.refreshToken !== undefined,
     });
-  } catch (error) {
-    if (error instanceof Error && error.message === "GITHUB_USER_FETCH_FAILED") {
-      throw new AuthServiceError("GITHUB_USER_FETCH_FAILED", error);
-    }
-    if (error instanceof Error && error.message === "INVALID_GITHUB_USER_RESPONSE") {
-      throw new AuthServiceError("INVALID_GITHUB_USER_RESPONSE", error);
-    }
-    throw error;
-  }
-}
-
-export async function authenticateGoogle(params: {
-  code: string;
-  codeVerifier: string;
-  redirectUri: string;
-  clientId: string;
-  clientSecret: string;
-}): Promise<AuthResult> {
-  let tokenData: { accessToken: string; idToken: string; refreshToken?: string };
-
-  try {
-    tokenData = await exchangeGoogleCode(
-      params.code,
-      params.codeVerifier,
-      params.redirectUri,
-      params.clientId,
-      params.clientSecret
-    );
-  } catch (error) {
-    if (error instanceof Error && error.message === "GOOGLE_TOKEN_EXCHANGE_FAILED") {
-      throw new AuthServiceError("GOOGLE_TOKEN_EXCHANGE_FAILED", error);
-    }
-    if (error instanceof Error && error.message === "INVALID_GOOGLE_TOKEN_RESPONSE") {
-      throw new AuthServiceError("INVALID_GOOGLE_TOKEN_RESPONSE", error);
-    }
-    throw error;
   }
 
-  let googleUser: { sub: string; name?: string };
-  try {
-    googleUser = decodeIdToken(tokenData.idToken, params.clientId);
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message === "INVALID_GOOGLE_ID_TOKEN_PAYLOAD"
-    ) {
-      throw new AuthServiceError("INVALID_GOOGLE_ID_TOKEN_PAYLOAD", error);
-    }
-    throw new AuthServiceError("INVALID_GOOGLE_ID_TOKEN", error);
-  }
+  static async upsertFromOAuth(params: {
+    provider: OAuthProvider;
+    providerUserId: string;
+    providerUsername: string | null;
+    accessToken: string;
+    refreshToken?: string;
+    persistRefreshToken: boolean;
+  }): Promise<AuthResult> {
+    const potentialUserId = new ObjectId();
 
-  return upsertFromOAuth({
-    provider: "google",
-    providerUserId: googleUser.sub,
-    providerUsername: googleUser.name ?? null,
-    accessToken: tokenData.accessToken,
-    refreshToken: tokenData.refreshToken,
-    persistRefreshToken: tokenData.refreshToken !== undefined,
-  });
-}
-
-export async function upsertFromOAuth(params: {
-  provider: OAuthProvider;
-  providerUserId: string;
-  providerUsername: string | null;
-  accessToken: string;
-  refreshToken?: string;
-  persistRefreshToken: boolean;
-}): Promise<AuthResult> {
-  const potentialUserId = new ObjectId();
-
-  const account = await upsertOauthAccount({
-    potentialUserId,
-    provider: params.provider,
-    providerUserId: params.providerUserId,
-    providerUsername: params.providerUsername,
-    accessToken: params.accessToken,
-    refreshToken: params.persistRefreshToken
-      ? (params.refreshToken ?? undefined)
-      : undefined,
-  });
-
-  const isNewUser = account.userId.equals(potentialUserId);
-  let tokenVersion = 0;
-
-  if (isNewUser) {
-    await createUser(potentialUserId);
-  } else {
-    const user = await findById(account.userId);
-    tokenVersion = user?.tokenVersion ?? 0;
-  }
-
-  return signTokensForUser({
-    userId: account.userId.toHexString(),
-    provider: params.provider,
-    providerUserId: params.providerUserId,
-    providerUsername: params.providerUsername,
-    tokenVersion,
-  });
-}
-
-export function signTokensForUser(params: {
-  userId: string;
-  provider: string;
-  providerUserId: string;
-  providerUsername: string | null;
-  tokenVersion: number;
-}): AuthResult {
-  const accessToken = signAccessToken({
-    userId: params.userId,
-    provider: params.provider,
-    providerUserId: params.providerUserId,
-  });
-  const refreshToken = signRefreshToken({
-    userId: params.userId,
-    tokenVersion: params.tokenVersion,
-  });
-
-  return {
-    accessToken,
-    refreshToken,
-    user: {
-      id: params.userId,
+    const account = await OAuthAccountRepository.upsert({
+      potentialUserId,
       provider: params.provider,
       providerUserId: params.providerUserId,
       providerUsername: params.providerUsername,
-    },
-  };
-}
+      accessToken: params.accessToken,
+      refreshToken: params.persistRefreshToken
+        ? (params.refreshToken ?? undefined)
+        : undefined,
+    });
 
-export async function refreshAuthTokens(refreshToken: string): Promise<AuthResult> {
-  let userId: string;
-  let tokenVersion: number;
-  try {
-    const raw = verifyToken(refreshToken);
-    const payload = refreshTokenPayloadSchema.parse(raw);
-    userId = payload.userId;
-    tokenVersion = payload.tokenVersion;
-  } catch (error) {
-    throw new AuthServiceError("UNAUTHORIZED", error);
+    const isNewUser = account.userId.equals(potentialUserId);
+    let tokenVersion = 0;
+
+    if (isNewUser) {
+      await UserRepository.create(potentialUserId);
+    } else {
+      const user = await UserRepository.findById(account.userId);
+      tokenVersion = user?.tokenVersion ?? 0;
+    }
+
+    return AuthService.signTokensForUser({
+      userId: account.userId.toHexString(),
+      provider: params.provider,
+      providerUserId: params.providerUserId,
+      providerUsername: params.providerUsername,
+      tokenVersion,
+    });
   }
 
-  const userObjectId = new ObjectId(userId);
-  const user = await findById(userObjectId);
-  if (!user) {
-    throw new AuthServiceError("UNAUTHORIZED");
+  static signTokensForUser(params: {
+    userId: string;
+    provider: string;
+    providerUserId: string;
+    providerUsername: string | null;
+    tokenVersion: number;
+  }): AuthResult {
+    const accessToken = TokenService.signAccessToken({
+      userId: params.userId,
+      provider: params.provider,
+      providerUserId: params.providerUserId,
+    });
+    const refreshToken = TokenService.signRefreshToken({
+      userId: params.userId,
+      tokenVersion: params.tokenVersion,
+    });
+
+    return {
+      accessToken,
+      refreshToken,
+      user: {
+        id: params.userId,
+        provider: params.provider,
+        providerUserId: params.providerUserId,
+        providerUsername: params.providerUsername,
+      },
+    };
   }
 
-  // Reject refresh tokens from before the last logout
-  if (user.tokenVersion !== tokenVersion) {
-    throw new AuthServiceError("UNAUTHORIZED");
+  static async refreshAuthTokens(refreshToken: string): Promise<AuthResult> {
+    let userId: string;
+    let tokenVersion: number;
+    try {
+      const raw = TokenService.verifyToken(refreshToken);
+      const payload = refreshTokenPayloadSchema.parse(raw);
+      userId = payload.userId;
+      tokenVersion = payload.tokenVersion;
+    } catch (error) {
+      throw new AuthServiceError("UNAUTHORIZED", error);
+    }
+
+    const userObjectId = new ObjectId(userId);
+    const user = await UserRepository.findById(userObjectId);
+    if (!user) {
+      throw new AuthServiceError("UNAUTHORIZED");
+    }
+
+    if (user.tokenVersion !== tokenVersion) {
+      throw new AuthServiceError("UNAUTHORIZED");
+    }
+
+    const oauthAccount = await OAuthAccountRepository.findByUserId(userObjectId);
+    if (!oauthAccount) {
+      throw new AuthServiceError("UNAUTHORIZED");
+    }
+
+    return AuthService.signTokensForUser({
+      userId,
+      provider: oauthAccount.provider,
+      providerUserId: oauthAccount.providerUserId,
+      providerUsername: oauthAccount.providerUsername,
+      tokenVersion: user.tokenVersion,
+    });
   }
 
-  const oauthAccount = await findByUserId(userObjectId);
-  if (!oauthAccount) {
-    throw new AuthServiceError("UNAUTHORIZED");
+  static async logoutUser(userId: string): Promise<void> {
+    await UserRepository.incrementTokenVersion(new ObjectId(userId));
   }
 
-  return signTokensForUser({
-    userId,
-    provider: oauthAccount.provider,
-    providerUserId: oauthAccount.providerUserId,
-    providerUsername: oauthAccount.providerUsername,
-    tokenVersion: user.tokenVersion,
-  });
-}
+  static async findUserAuthProfile(userId: string): Promise<{
+    id: string;
+    provider: string;
+    providerUserId: string;
+    providerUsername: string | null;
+  } | null> {
+    const userObjectId = new ObjectId(userId);
+    const user = await UserRepository.findById(userObjectId);
+    if (!user) {
+      return null;
+    }
 
-export async function logoutUser(userId: string): Promise<void> {
-  await incrementTokenVersion(new ObjectId(userId));
-}
+    const oauthAccount = await OAuthAccountRepository.findByUserId(userObjectId);
+    if (!oauthAccount) {
+      return null;
+    }
 
-export async function findUserAuthProfile(userId: string): Promise<{
-  id: string;
-  provider: string;
-  providerUserId: string;
-  providerUsername: string | null;
-} | null> {
-  const userObjectId = new ObjectId(userId);
-  const user = await findById(userObjectId);
-  if (!user) {
-    return null;
+    return {
+      id: userId,
+      provider: oauthAccount.provider,
+      providerUserId: oauthAccount.providerUserId,
+      providerUsername: oauthAccount.providerUsername,
+    };
   }
-
-  const oauthAccount = await findByUserId(userObjectId);
-  if (!oauthAccount) {
-    return null;
-  }
-
-  return {
-    id: userId,
-    provider: oauthAccount.provider,
-    providerUserId: oauthAccount.providerUserId,
-    providerUsername: oauthAccount.providerUsername,
-  };
 }

--- a/src/services/bridge-service.ts
+++ b/src/services/bridge-service.ts
@@ -1,59 +1,60 @@
 import { ObjectId } from "mongodb";
-import {
-  deleteByUserId,
-  findByUserId,
-  updateHeartbeat,
-  upsert,
-} from "../repositories/bridge-registration-repo.js";
+import { BridgeRegistrationRepository } from "../repositories/bridge-registration-repo.js";
 
-export async function register(params: {
-  userId: string;
-  relayUrl: string;
-  roomCode: string;
-  publicKey: string;
-}): Promise<{ bridgeId: string }> {
-  const userObjectId = new ObjectId(params.userId);
-  await upsert({
-    userId: userObjectId,
-    relayUrl: params.relayUrl,
-    roomCode: params.roomCode,
-    publicKey: params.publicKey,
-  });
+export class BridgeService {
+  private constructor() {}
 
-  const doc = await findByUserId(userObjectId);
-  return { bridgeId: doc!._id.toHexString() };
-}
+  static async register(params: {
+    userId: string;
+    relayUrl: string;
+    roomCode: string;
+    publicKey: string;
+  }): Promise<{ bridgeId: string }> {
+    const userObjectId = new ObjectId(params.userId);
+    await BridgeRegistrationRepository.upsert({
+      userId: userObjectId,
+      relayUrl: params.relayUrl,
+      roomCode: params.roomCode,
+      publicKey: params.publicKey,
+    });
 
-export async function heartbeat(userId: string): Promise<boolean> {
-  const matchedCount = await updateHeartbeat(new ObjectId(userId));
-  return matchedCount > 0;
-}
-
-export async function deregister(userId: string): Promise<void> {
-  await deleteByUserId(new ObjectId(userId));
-}
-
-export async function findByUser(userId: string): Promise<{
-  bridgeId: string;
-  relayUrl: string;
-  roomCode: string;
-  publicKey: string;
-} | null> {
-  const doc = await findByUserId(new ObjectId(userId));
-  if (!doc) {
-    return null;
+    const doc = await BridgeRegistrationRepository.findByUserId(userObjectId);
+    return { bridgeId: doc!._id.toHexString() };
   }
 
-  const ttlSeconds = 60;
-  const age = (Date.now() - doc.lastHeartbeat.getTime()) / 1000;
-  if (age > ttlSeconds) {
-    return null;
+  static async heartbeat(userId: string): Promise<boolean> {
+    const matchedCount = await BridgeRegistrationRepository.updateHeartbeat(
+      new ObjectId(userId)
+    );
+    return matchedCount > 0;
   }
 
-  return {
-    bridgeId: doc._id.toHexString(),
-    relayUrl: doc.relayUrl,
-    roomCode: doc.roomCode,
-    publicKey: doc.publicKey,
-  };
+  static async deregister(userId: string): Promise<void> {
+    await BridgeRegistrationRepository.deleteByUserId(new ObjectId(userId));
+  }
+
+  static async findByUser(userId: string): Promise<{
+    bridgeId: string;
+    relayUrl: string;
+    roomCode: string;
+    publicKey: string;
+  } | null> {
+    const doc = await BridgeRegistrationRepository.findByUserId(new ObjectId(userId));
+    if (!doc) {
+      return null;
+    }
+
+    const ttlSeconds = 60;
+    const age = (Date.now() - doc.lastHeartbeat.getTime()) / 1000;
+    if (age > ttlSeconds) {
+      return null;
+    }
+
+    return {
+      bridgeId: doc._id.toHexString(),
+      relayUrl: doc.relayUrl,
+      roomCode: doc.roomCode,
+      publicKey: doc.publicKey,
+    };
+  }
 }

--- a/src/services/token-service.ts
+++ b/src/services/token-service.ts
@@ -10,116 +10,117 @@ import {
   refreshTokenPayloadSchema,
 } from "../models/jwt.js";
 
-let privateKey: string | null = null;
-let publicKey: string | null = null;
+export class TokenService {
+  private static privateKey: string | null = null;
+  private static publicKey: string | null = null;
 
-export function generateKeyPair(privatePath: string, publicPath: string): void {
-  const { privateKey: priv, publicKey: pub } = crypto.generateKeyPairSync("rsa", {
-    modulusLength: 2048,
-    publicKeyEncoding: {
-      type: "spki",
-      format: "pem",
-    },
-    privateKeyEncoding: {
-      type: "pkcs8",
-      format: "pem",
-    },
-  });
+  private constructor() {}
 
-  fs.writeFileSync(privatePath, priv, { mode: 0o600 });
-  fs.writeFileSync(publicPath, pub);
-}
+  static generateKeyPair(privatePath: string, publicPath: string): void {
+    const { privateKey: priv, publicKey: pub } = crypto.generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      publicKeyEncoding: {
+        type: "spki",
+        format: "pem",
+      },
+      privateKeyEncoding: {
+        type: "pkcs8",
+        format: "pem",
+      },
+    });
 
-export function loadKeys(privatePath: string, publicPath: string): void {
-  privateKey = fs.readFileSync(privatePath, "utf-8");
-  publicKey = fs.readFileSync(publicPath, "utf-8");
-}
-
-export function signAccessToken(payload: {
-  userId: string;
-  provider: string;
-  providerUserId: string;
-}): string {
-  if (!privateKey) {
-    throw new Error("Private key not loaded. Call loadKeys() first.");
+    fs.writeFileSync(privatePath, priv, { mode: 0o600 });
+    fs.writeFileSync(publicPath, pub);
   }
 
-  const now = Math.floor(Date.now() / 1000);
-  const expiresIn = 15 * 60;
-
-  const tokenPayload: AccessTokenPayload = accessTokenPayloadSchema.parse({
-    tokenType: "access",
-    userId: payload.userId,
-    provider: payload.provider,
-    providerUserId: payload.providerUserId,
-    iss: "auth-backend",
-    aud: "mobile",
-    iat: now,
-    exp: now + expiresIn,
-  });
-
-  return jwt.sign(tokenPayload, privateKey, { algorithm: "RS256" });
-}
-
-export function signRefreshToken(payload: { userId: string; tokenVersion: number }): string {
-  if (!privateKey) {
-    throw new Error("Private key not loaded. Call loadKeys() first.");
+  static loadKeys(privatePath: string, publicPath: string): void {
+    TokenService.privateKey = fs.readFileSync(privatePath, "utf-8");
+    TokenService.publicKey = fs.readFileSync(publicPath, "utf-8");
   }
 
-  const now = Math.floor(Date.now() / 1000);
-  const expiresIn = 30 * 24 * 60 * 60;
+  static signAccessToken(payload: {
+    userId: string;
+    provider: string;
+    providerUserId: string;
+  }): string {
+    if (!TokenService.privateKey) {
+      throw new Error("Private key not loaded. Call loadKeys() first.");
+    }
 
-  const tokenPayload: RefreshTokenPayload = refreshTokenPayloadSchema.parse({
-    tokenType: "refresh",
-    userId: payload.userId,
-    tokenVersion: payload.tokenVersion,
-    iss: "auth-backend",
-    aud: "mobile",
-    iat: now,
-    exp: now + expiresIn,
-  });
+    const now = Math.floor(Date.now() / 1000);
+    const expiresIn = 15 * 60;
 
-  return jwt.sign(tokenPayload, privateKey, { algorithm: "RS256" });
-}
+    const tokenPayload: AccessTokenPayload = accessTokenPayloadSchema.parse({
+      tokenType: "access",
+      userId: payload.userId,
+      provider: payload.provider,
+      providerUserId: payload.providerUserId,
+      iss: "auth-backend",
+      aud: "mobile",
+      iat: now,
+      exp: now + expiresIn,
+    });
 
-export function signBridgeToken(payload: { userId: string }): string {
-  if (!privateKey) {
-    throw new Error("Private key not loaded. Call loadKeys() first.");
+    return jwt.sign(tokenPayload, TokenService.privateKey, { algorithm: "RS256" });
   }
 
-  const now = Math.floor(Date.now() / 1000);
-  const expiresIn = 24 * 60 * 60;
+  static signRefreshToken(payload: { userId: string; tokenVersion: number }): string {
+    if (!TokenService.privateKey) {
+      throw new Error("Private key not loaded. Call loadKeys() first.");
+    }
 
-  const tokenPayload: BridgeTokenPayload = bridgeTokenPayloadSchema.parse({
-    tokenType: "bridge",
-    userId: payload.userId,
-    iss: "auth-backend",
-    aud: "bridge",
-    iat: now,
-    exp: now + expiresIn,
-  });
+    const now = Math.floor(Date.now() / 1000);
+    const expiresIn = 30 * 24 * 60 * 60;
 
-  return jwt.sign(tokenPayload, privateKey, { algorithm: "RS256" });
-}
+    const tokenPayload: RefreshTokenPayload = refreshTokenPayloadSchema.parse({
+      tokenType: "refresh",
+      userId: payload.userId,
+      tokenVersion: payload.tokenVersion,
+      iss: "auth-backend",
+      aud: "mobile",
+      iat: now,
+      exp: now + expiresIn,
+    });
 
-export function verifyToken(token: string): Record<string, unknown> {
-  if (!publicKey) {
-    throw new Error("Public key not loaded. Call loadKeys() first.");
+    return jwt.sign(tokenPayload, TokenService.privateKey, { algorithm: "RS256" });
   }
 
-  return jwt.verify(token, publicKey, {
-    algorithms: ["RS256"],
-    issuer: "auth-backend",
-  }) as Record<
-    string,
-    unknown
-  >;
-}
+  static signBridgeToken(payload: { userId: string }): string {
+    if (!TokenService.privateKey) {
+      throw new Error("Private key not loaded. Call loadKeys() first.");
+    }
 
-export function getPublicKey(): string {
-  if (!publicKey) {
-    throw new Error("Public key not loaded. Call loadKeys() first.");
+    const now = Math.floor(Date.now() / 1000);
+    const expiresIn = 24 * 60 * 60;
+
+    const tokenPayload: BridgeTokenPayload = bridgeTokenPayloadSchema.parse({
+      tokenType: "bridge",
+      userId: payload.userId,
+      iss: "auth-backend",
+      aud: "bridge",
+      iat: now,
+      exp: now + expiresIn,
+    });
+
+    return jwt.sign(tokenPayload, TokenService.privateKey, { algorithm: "RS256" });
   }
 
-  return publicKey;
+  static verifyToken(token: string): Record<string, unknown> {
+    if (!TokenService.publicKey) {
+      throw new Error("Public key not loaded. Call loadKeys() first.");
+    }
+
+    return jwt.verify(token, TokenService.publicKey, {
+      algorithms: ["RS256"],
+      issuer: "auth-backend",
+    }) as Record<string, unknown>;
+  }
+
+  static getPublicKey(): string {
+    if (!TokenService.publicKey) {
+      throw new Error("Public key not loaded. Call loadKeys() first.");
+    }
+
+    return TokenService.publicKey;
+  }
 }

--- a/tests/auth/token.test.ts
+++ b/tests/auth/token.test.ts
@@ -83,8 +83,8 @@ describe("Token routes", () => {
 
     it("returns 401 for a valid-format token referencing a non-existent user", async () => {
       // Sign a refresh token for a userId that doesn't exist in the DB
-      const { signRefreshToken } = await import("../../src/services/token-service.js");
-      const ghostToken = signRefreshToken({
+      const { TokenService } = await import("../../src/services/token-service.js");
+      const ghostToken = TokenService.signRefreshToken({
         userId: "000000000000000000000000",
         tokenVersion: 0,
       });

--- a/tests/bridge/registry.test.ts
+++ b/tests/bridge/registry.test.ts
@@ -2,7 +2,7 @@ import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { ObjectId } from "mongodb";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
-import { Collections } from "../../src/db/collections.js";
+import { DatabaseAccessor } from "../../src/db/collections.js";
 
 const VALID_BRIDGE_PAYLOAD = {
   relayUrl: "wss://relay.example.com/ws",
@@ -84,7 +84,7 @@ describe("Bridge registry routes", () => {
       assert.ok(body.bridgeId, "Should return a bridgeId");
 
       // Verify the document was persisted
-      const doc = await Collections.bridgeRegistrations().findOne({
+      const doc = await DatabaseAccessor.bridgeRegistrations().findOne({
         userId: new ObjectId(user.userId),
       });
       assert.ok(doc, "Bridge registration should exist in DB");
@@ -126,13 +126,13 @@ describe("Bridge registry routes", () => {
       assert.equal(res.statusCode, 200);
 
       // Should still have exactly one document for this user
-      const count = await Collections.bridgeRegistrations().countDocuments({
+      const count = await DatabaseAccessor.bridgeRegistrations().countDocuments({
         userId: new ObjectId(user.userId),
       });
       assert.equal(count, 1, "Should have exactly one bridge registration");
 
       // Should reflect the updated relayUrl
-      const doc = await Collections.bridgeRegistrations().findOne({
+      const doc = await DatabaseAccessor.bridgeRegistrations().findOne({
         userId: new ObjectId(user.userId),
       });
       assert.equal(doc!.relayUrl, updatedPayload.relayUrl);
@@ -156,7 +156,7 @@ describe("Bridge registry routes", () => {
         payload: JSON.stringify(VALID_BRIDGE_PAYLOAD),
       });
 
-      const before = await Collections.bridgeRegistrations().findOne({
+      const before = await DatabaseAccessor.bridgeRegistrations().findOne({
         userId: new ObjectId(user.userId),
       });
       const beforeTime = before!.lastHeartbeat.getTime();
@@ -173,7 +173,7 @@ describe("Bridge registry routes", () => {
       assert.equal(res.statusCode, 200);
       assert.deepEqual(res.json(), { ok: true });
 
-      const after = await Collections.bridgeRegistrations().findOne({
+      const after = await DatabaseAccessor.bridgeRegistrations().findOne({
         userId: new ObjectId(user.userId),
       });
       assert.ok(
@@ -248,7 +248,7 @@ describe("Bridge registry routes", () => {
       const user = await ctx.createUser();
 
       // Insert a stale bridge registration directly into the DB
-      await Collections.bridgeRegistrations().insertOne({
+      await DatabaseAccessor.bridgeRegistrations().insertOne({
         _id: new ObjectId(),
         userId: new ObjectId(user.userId),
         relayUrl: VALID_BRIDGE_PAYLOAD.relayUrl,
@@ -296,7 +296,7 @@ describe("Bridge registry routes", () => {
       assert.deepEqual(res.json(), { ok: true });
 
       // Verify the document was removed
-      const doc = await Collections.bridgeRegistrations().findOne({
+      const doc = await DatabaseAccessor.bridgeRegistrations().findOne({
         userId: new ObjectId(user.userId),
       });
       assert.equal(doc, null, "Bridge registration should be deleted");
@@ -356,7 +356,7 @@ describe("Bridge registry routes", () => {
       assert.equal(res.statusCode, 404);
 
       // User A's registration should still be intact
-      const doc = await Collections.bridgeRegistrations().findOne({
+      const doc = await DatabaseAccessor.bridgeRegistrations().findOne({
         userId: new ObjectId(userA.userId),
       });
       assert.ok(doc, "User A's bridge registration should still exist");

--- a/tests/bridge/registry.test.ts
+++ b/tests/bridge/registry.test.ts
@@ -2,7 +2,7 @@ import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { ObjectId } from "mongodb";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
-import { bridgeRegistrations } from "../../src/db/collections.js";
+import { Collections } from "../../src/db/collections.js";
 
 const VALID_BRIDGE_PAYLOAD = {
   relayUrl: "wss://relay.example.com/ws",
@@ -84,7 +84,7 @@ describe("Bridge registry routes", () => {
       assert.ok(body.bridgeId, "Should return a bridgeId");
 
       // Verify the document was persisted
-      const doc = await bridgeRegistrations().findOne({
+      const doc = await Collections.bridgeRegistrations().findOne({
         userId: new ObjectId(user.userId),
       });
       assert.ok(doc, "Bridge registration should exist in DB");
@@ -126,13 +126,13 @@ describe("Bridge registry routes", () => {
       assert.equal(res.statusCode, 200);
 
       // Should still have exactly one document for this user
-      const count = await bridgeRegistrations().countDocuments({
+      const count = await Collections.bridgeRegistrations().countDocuments({
         userId: new ObjectId(user.userId),
       });
       assert.equal(count, 1, "Should have exactly one bridge registration");
 
       // Should reflect the updated relayUrl
-      const doc = await bridgeRegistrations().findOne({
+      const doc = await Collections.bridgeRegistrations().findOne({
         userId: new ObjectId(user.userId),
       });
       assert.equal(doc!.relayUrl, updatedPayload.relayUrl);
@@ -156,7 +156,7 @@ describe("Bridge registry routes", () => {
         payload: JSON.stringify(VALID_BRIDGE_PAYLOAD),
       });
 
-      const before = await bridgeRegistrations().findOne({
+      const before = await Collections.bridgeRegistrations().findOne({
         userId: new ObjectId(user.userId),
       });
       const beforeTime = before!.lastHeartbeat.getTime();
@@ -173,7 +173,7 @@ describe("Bridge registry routes", () => {
       assert.equal(res.statusCode, 200);
       assert.deepEqual(res.json(), { ok: true });
 
-      const after = await bridgeRegistrations().findOne({
+      const after = await Collections.bridgeRegistrations().findOne({
         userId: new ObjectId(user.userId),
       });
       assert.ok(
@@ -248,7 +248,7 @@ describe("Bridge registry routes", () => {
       const user = await ctx.createUser();
 
       // Insert a stale bridge registration directly into the DB
-      await bridgeRegistrations().insertOne({
+      await Collections.bridgeRegistrations().insertOne({
         _id: new ObjectId(),
         userId: new ObjectId(user.userId),
         relayUrl: VALID_BRIDGE_PAYLOAD.relayUrl,
@@ -296,7 +296,7 @@ describe("Bridge registry routes", () => {
       assert.deepEqual(res.json(), { ok: true });
 
       // Verify the document was removed
-      const doc = await bridgeRegistrations().findOne({
+      const doc = await Collections.bridgeRegistrations().findOne({
         userId: new ObjectId(user.userId),
       });
       assert.equal(doc, null, "Bridge registration should be deleted");
@@ -356,7 +356,7 @@ describe("Bridge registry routes", () => {
       assert.equal(res.statusCode, 404);
 
       // User A's registration should still be intact
-      const doc = await bridgeRegistrations().findOne({
+      const doc = await Collections.bridgeRegistrations().findOne({
         userId: new ObjectId(userA.userId),
       });
       assert.ok(doc, "User A's bridge registration should still exist");

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -1,15 +1,7 @@
-import { connectDb, closeDb } from "../../src/db/client.js";
-import {
-  ensureIndexes,
-  users,
-  oauthAccounts,
-} from "../../src/db/collections.js";
+import { DbClient } from "../../src/db/client.js";
+import { Collections } from "../../src/db/collections.js";
 import { buildApp } from "../../src/server.js";
-import {
-  loadKeys,
-  signAccessToken,
-  signRefreshToken,
-} from "../../src/services/token-service.js";
+import { TokenService } from "../../src/services/token-service.js";
 import { ObjectId } from "mongodb";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -65,12 +57,12 @@ export async function createTestApp(): Promise<TestContext> {
   process.env.RELAY_URL ??= "ws://localhost:8080";
 
   // Load JWT keys into the jwt module's in-memory cache
-  loadKeys(privatePath, publicPath);
+  TokenService.loadKeys(privatePath, publicPath);
 
   // Connect to test MongoDB and start with a clean slate
-  const mongoClient = await connectDb(mongoUri);
+  const mongoClient = await DbClient.connect(mongoUri);
   await mongoClient.db().dropDatabase();
-  await ensureIndexes();
+  await Collections.ensureIndexes();
 
   // Build and ready the Fastify app
   const app = await buildApp();
@@ -85,8 +77,8 @@ export async function createTestApp(): Promise<TestContext> {
     const userId = new ObjectId();
     const now = new Date();
 
-    await users().insertOne({ _id: userId, tokenVersion: 0, createdAt: now, updatedAt: now });
-    await oauthAccounts().insertOne({
+    await Collections.users().insertOne({ _id: userId, tokenVersion: 0, createdAt: now, updatedAt: now });
+    await Collections.oauthAccounts().insertOne({
       _id: new ObjectId(),
       userId,
       provider,
@@ -99,12 +91,12 @@ export async function createTestApp(): Promise<TestContext> {
     });
 
     const userIdStr = userId.toHexString();
-    const accessToken = signAccessToken({
+    const accessToken = TokenService.signAccessToken({
       userId: userIdStr,
       provider,
       providerUserId,
     });
-    const refreshToken = signRefreshToken({ userId: userIdStr, tokenVersion: 0 });
+    const refreshToken = TokenService.signRefreshToken({ userId: userIdStr, tokenVersion: 0 });
 
     return { userId: userIdStr, accessToken, refreshToken, provider, providerUserId };
   }
@@ -129,7 +121,7 @@ export async function createTestApp(): Promise<TestContext> {
   async function cleanup(): Promise<void> {
     await app.close();
     await mongoClient.db().dropDatabase();
-    await closeDb();
+    await DbClient.close();
     fs.rmSync(tmpDir, { recursive: true });
   }
 

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -1,5 +1,5 @@
 import { DbClient } from "../../src/db/client.js";
-import { Collections } from "../../src/db/collections.js";
+import { DatabaseAccessor } from "../../src/db/collections.js";
 import { buildApp } from "../../src/server.js";
 import { TokenService } from "../../src/services/token-service.js";
 import { ObjectId } from "mongodb";
@@ -62,7 +62,7 @@ export async function createTestApp(): Promise<TestContext> {
   // Connect to test MongoDB and start with a clean slate
   const mongoClient = await DbClient.connect(mongoUri);
   await mongoClient.db().dropDatabase();
-  await Collections.ensureIndexes();
+  await DatabaseAccessor.ensureIndexes();
 
   // Build and ready the Fastify app
   const app = await buildApp();
@@ -77,8 +77,8 @@ export async function createTestApp(): Promise<TestContext> {
     const userId = new ObjectId();
     const now = new Date();
 
-    await Collections.users().insertOne({ _id: userId, tokenVersion: 0, createdAt: now, updatedAt: now });
-    await Collections.oauthAccounts().insertOne({
+    await DatabaseAccessor.users().insertOne({ _id: userId, tokenVersion: 0, createdAt: now, updatedAt: now });
+    await DatabaseAccessor.oauthAccounts().insertOne({
       _id: new ObjectId(),
       userId,
       provider,


### PR DESCRIPTION
## Summary

- Convert all 11 service/repository/client/db modules from bare function exports to static classes with private constructors
- Gives namespaced access (e.g. `BridgeRegistrationRepository.upsert()` instead of `upsert()`)
- Module-level mutable state (DB connections, JWT keys, LRU cache) moved to `private static` class fields
- Updated all 7 consumer files and 3 test files to use the new class-based imports

## Classes introduced

| Module | Class |
|--------|-------|
| `db/client.ts` | `DbClient` |
| `db/collections.ts` | `Collections` |
| `repositories/bridge-registration-repo.ts` | `BridgeRegistrationRepository` |
| `repositories/oauth-account-repo.ts` | `OAuthAccountRepository` |
| `repositories/user-repo.ts` | `UserRepository` |
| `clients/github-client.ts` | `GithubClient` |
| `clients/google-client.ts` | `GoogleClient` |
| `lib/state-store.ts` | `StateStore` |
| `services/token-service.ts` | `TokenService` |
| `services/auth-service.ts` | `AuthService` |
| `services/bridge-service.ts` | `BridgeService` |

## Verification

- `npx tsc --noEmit` passes
- All 46 tests pass
- No behavioral changes — pure structural refactoring