### PR TITLE
fix: stop persisting OAuth provider tokens in database

### DIFF
--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -16,8 +16,6 @@ export const oauthAccountSchema = z.object({
   provider: z.string(),
   providerUserId: z.string(),
   providerUsername: z.string().nullable(),
-  accessToken: z.string().nullable(),
-  refreshToken: z.string().nullable(),
   createdAt: z.date(),
   updatedAt: z.date(),
 });

--- a/src/repositories/oauth-account-repo.ts
+++ b/src/repositories/oauth-account-repo.ts
@@ -21,24 +21,8 @@ export class OAuthAccountRepository {
     provider: string;
     providerUserId: string;
     providerUsername: string | null;
-    accessToken: string;
-    refreshToken?: string;
   }): Promise<OAuthAccount> {
     const now = new Date();
-    const set: {
-      accessToken: string;
-      providerUsername: string | null;
-      updatedAt: Date;
-      refreshToken?: string;
-    } = {
-      accessToken: params.accessToken,
-      providerUsername: params.providerUsername,
-      updatedAt: now,
-    };
-
-    if (params.refreshToken !== undefined) {
-      set.refreshToken = params.refreshToken;
-    }
 
     const result = await DatabaseAccessor.oauthAccounts().findOneAndUpdate(
       {
@@ -46,14 +30,16 @@ export class OAuthAccountRepository {
         providerUserId: params.providerUserId,
       },
       {
-        $set: set,
+        $set: {
+          providerUsername: params.providerUsername,
+          updatedAt: now,
+        },
         $setOnInsert: {
           _id: new ObjectId(),
           userId: params.potentialUserId,
           provider: params.provider,
           providerUserId: params.providerUserId,
           createdAt: now,
-          refreshToken: params.refreshToken ?? null,
         },
       },
       { upsert: true, returnDocument: "after" },

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -66,9 +66,6 @@ export class AuthService {
         provider: "github",
         providerUserId: githubUser.id,
         providerUsername: githubUser.login,
-        accessToken,
-        refreshToken: undefined,
-        persistRefreshToken: false,
       });
     } catch (error) {
       if (error instanceof Error && error.message === "GITHUB_USER_FETCH_FAILED") {
@@ -126,9 +123,6 @@ export class AuthService {
       provider: "google",
       providerUserId: googleUser.sub,
       providerUsername: googleUser.name ?? null,
-      accessToken: tokenData.accessToken,
-      refreshToken: tokenData.refreshToken,
-      persistRefreshToken: tokenData.refreshToken !== undefined,
     });
   }
 
@@ -136,9 +130,6 @@ export class AuthService {
     provider: OAuthProvider;
     providerUserId: string;
     providerUsername: string | null;
-    accessToken: string;
-    refreshToken?: string;
-    persistRefreshToken: boolean;
   }): Promise<AuthResult> {
     const potentialUserId = new ObjectId();
 
@@ -147,8 +138,6 @@ export class AuthService {
       provider: params.provider,
       providerUserId: params.providerUserId,
       providerUsername: params.providerUsername,
-      accessToken: params.accessToken,
-      refreshToken: params.persistRefreshToken ? (params.refreshToken ?? undefined) : undefined,
     });
 
     const isNewUser = account.userId.equals(potentialUserId);


### PR DESCRIPTION
## Summary

- Remove `accessToken` and `refreshToken` from the `OAuthAccount` schema, repository upsert, and auth service
- Provider tokens are now used only in-memory during the OAuth callback to fetch user profile data, then discarded
- They were never read back after initial login — storing them was unnecessary exposure

## Why

Provider tokens are credential equivalents. If the database is compromised, an attacker could use stored GitHub/Google tokens to access users' provider accounts. Since we don't make provider API calls after login, there's no reason to persist them.

## Changes

- `src/models/documents.ts` — removed `accessToken` and `refreshToken` from `oauthAccountSchema`
- `src/repositories/oauth-account-repo.ts` — removed token params from `upsert()`, simplified `$set` and `$setOnInsert`
- `src/services/auth-service.ts` — removed token params from `upsertFromOAuth()` and both OAuth authenticate methods

All 36 tests pass. Zero lint errors.