### PR TITLE
feat: add daily transcription usage quota (1h/day per user)

### DIFF
--- a/src/clients/openai-client.ts
+++ b/src/clients/openai-client.ts
@@ -20,7 +20,7 @@ export class OpenAIClient {
     filename: string;
     mimetype: string;
     prompt?: string;
-  }): Promise<string> {
+  }): Promise<{ text: string; durationSeconds: number }> {
     if (!client) {
       throw new Error("OpenAI client not initialized — call OpenAIClient.init() first");
     }
@@ -31,10 +31,10 @@ export class OpenAIClient {
       file,
       model: transcriptionModel,
       language: "en",
-      response_format: "json",
+      response_format: "verbose_json",
       ...(args.prompt ? { prompt: args.prompt } : {}),
     });
 
-    return response.text;
+    return { text: response.text, durationSeconds: response.duration ?? 0 };
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,9 @@ const configSchema = z.object({
   RELAY_URL: z.string().min(1, "RELAY_URL is required"),
   OPENAI_API_KEY: z.string().min(1, "OPENAI_API_KEY is required"),
   OPENAI_TRANSCRIPTION_MODEL: z.string().min(1).default("gpt-4o-mini-transcribe"),
+
+  // App-wide limits (hardcoded defaults, not sourced from env)
+  DAILY_TRANSCRIPTION_LIMIT_SECONDS: z.coerce.number().default(3600),
 });
 
 export type Config = z.infer<typeof configSchema>;

--- a/src/db/database-accessor.ts
+++ b/src/db/database-accessor.ts
@@ -1,6 +1,6 @@
 import { Collection } from "mongodb";
 import { oAuthDbClient, OAuthAccountCollection } from "./db-client.js";
-import { User, OAuthAccount, GlossaryEntry, TranscriptionUsage } from "../models/documents.js";
+import { User, OAuthAccount, GlossaryEntry, DailyUsage } from "../models/documents.js";
 
 export class DatabaseAccessor {
   private constructor() {}
@@ -17,8 +17,8 @@ export class DatabaseAccessor {
     return oAuthDbClient.getCollection(OAuthAccountCollection.GlossaryEntries);
   }
 
-  static transcriptionUsage(): Collection<TranscriptionUsage> {
-    return oAuthDbClient.getCollection(OAuthAccountCollection.TranscriptionUsage);
+  static dailyUsage(): Collection<DailyUsage> {
+    return oAuthDbClient.getCollection(OAuthAccountCollection.DailyUsage);
   }
 
   static async ensureIndexes(): Promise<void> {
@@ -30,7 +30,7 @@ export class DatabaseAccessor {
     await glossaryEntriesCollection.createIndex({ userId: 1, word: 1 }, { unique: true });
     await glossaryEntriesCollection.createIndex({ userId: 1 });
 
-    const transcriptionUsageCollection = DatabaseAccessor.transcriptionUsage();
-    await transcriptionUsageCollection.createIndex({ userId: 1, date: 1 }, { unique: true });
+    const dailyUsageCollection = DatabaseAccessor.dailyUsage();
+    await dailyUsageCollection.createIndex({ userId: 1, date: 1 }, { unique: true });
   }
 }

--- a/src/db/database-accessor.ts
+++ b/src/db/database-accessor.ts
@@ -1,6 +1,6 @@
 import { Collection } from "mongodb";
 import { oAuthDbClient, OAuthAccountCollection } from "./db-client.js";
-import { User, OAuthAccount, GlossaryEntry } from "../models/documents.js";
+import { User, OAuthAccount, GlossaryEntry, TranscriptionUsage } from "../models/documents.js";
 
 export class DatabaseAccessor {
   private constructor() {}
@@ -17,6 +17,10 @@ export class DatabaseAccessor {
     return oAuthDbClient.getCollection(OAuthAccountCollection.GlossaryEntries);
   }
 
+  static transcriptionUsage(): Collection<TranscriptionUsage> {
+    return oAuthDbClient.getCollection(OAuthAccountCollection.TranscriptionUsage);
+  }
+
   static async ensureIndexes(): Promise<void> {
     const oauthAccountsCollection = DatabaseAccessor.oauthAccounts();
     await oauthAccountsCollection.createIndex({ provider: 1, providerUserId: 1 }, { unique: true });
@@ -25,5 +29,8 @@ export class DatabaseAccessor {
     const glossaryEntriesCollection = DatabaseAccessor.glossaryEntries();
     await glossaryEntriesCollection.createIndex({ userId: 1, word: 1 }, { unique: true });
     await glossaryEntriesCollection.createIndex({ userId: 1 });
+
+    const transcriptionUsageCollection = DatabaseAccessor.transcriptionUsage();
+    await transcriptionUsageCollection.createIndex({ userId: 1, date: 1 }, { unique: true });
   }
 }

--- a/src/db/db-client.ts
+++ b/src/db/db-client.ts
@@ -1,6 +1,6 @@
 import { Collection, Db } from "mongodb";
 import { getMongoDbConnector, MongoDBDatabase } from "./mongo-db-connector.js";
-import { User, OAuthAccount, GlossaryEntry, TranscriptionUsage } from "../models/documents.js";
+import { User, OAuthAccount, GlossaryEntry, DailyUsage } from "../models/documents.js";
 
 export { MongoDBDatabase } from "./mongo-db-connector.js";
 export { closeMongoDbConnector as closeDb } from "./mongo-db-connector.js";
@@ -9,7 +9,7 @@ export enum OAuthAccountCollection {
   Users = "users",
   OAuthAccounts = "oauthAccounts",
   GlossaryEntries = "glossaryEntries",
-  TranscriptionUsage = "transcriptionUsage",
+  DailyUsage = "dailyUsage",
 }
 
 type DatabaseCollectionMap = {
@@ -22,7 +22,7 @@ type CollectionDocumentMap = {
   [OAuthAccountCollection.Users]: User;
   [OAuthAccountCollection.OAuthAccounts]: OAuthAccount;
   [OAuthAccountCollection.GlossaryEntries]: GlossaryEntry;
-  [OAuthAccountCollection.TranscriptionUsage]: TranscriptionUsage;
+  [OAuthAccountCollection.DailyUsage]: DailyUsage;
 };
 
 class DbClient<D extends MongoDBDatabase> {

--- a/src/db/db-client.ts
+++ b/src/db/db-client.ts
@@ -1,6 +1,6 @@
 import { Collection, Db } from "mongodb";
 import { getMongoDbConnector, MongoDBDatabase } from "./mongo-db-connector.js";
-import { User, OAuthAccount, GlossaryEntry } from "../models/documents.js";
+import { User, OAuthAccount, GlossaryEntry, TranscriptionUsage } from "../models/documents.js";
 
 export { MongoDBDatabase } from "./mongo-db-connector.js";
 export { closeMongoDbConnector as closeDb } from "./mongo-db-connector.js";
@@ -9,6 +9,7 @@ export enum OAuthAccountCollection {
   Users = "users",
   OAuthAccounts = "oauthAccounts",
   GlossaryEntries = "glossaryEntries",
+  TranscriptionUsage = "transcriptionUsage",
 }
 
 type DatabaseCollectionMap = {
@@ -21,6 +22,7 @@ type CollectionDocumentMap = {
   [OAuthAccountCollection.Users]: User;
   [OAuthAccountCollection.OAuthAccounts]: OAuthAccount;
   [OAuthAccountCollection.GlossaryEntries]: GlossaryEntry;
+  [OAuthAccountCollection.TranscriptionUsage]: TranscriptionUsage;
 };
 
 class DbClient<D extends MongoDBDatabase> {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,4 +1,6 @@
 export class ApiError extends Error {
+  public responseBody?: Record<string, unknown>;
+
   constructor(
     message: string,
     public readonly errorCode: number,
@@ -36,8 +38,9 @@ export class InternalServerError extends ApiError {
 }
 
 export class QuotaExceededError extends ApiError {
-  constructor(opts?: { debugMessage?: string; nestedError?: unknown }) {
-    super("quota_exceeded", 429, opts?.debugMessage, opts?.nestedError);
+  constructor(opts: { service: string; debugMessage?: string; nestedError?: unknown }) {
+    super("quota_exceeded", 429, opts.debugMessage, opts.nestedError);
+    this.responseBody = { service: opts.service };
   }
 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -35,6 +35,12 @@ export class InternalServerError extends ApiError {
   }
 }
 
+export class QuotaExceededError extends ApiError {
+  constructor(opts?: { debugMessage?: string; nestedError?: unknown }) {
+    super("quota_exceeded", 429, opts?.debugMessage, opts?.nestedError);
+  }
+}
+
 export class BadGatewayError extends ApiError {
   constructor(opts?: { debugMessage?: string; nestedError?: unknown }) {
     super("bad_gateway", 502, opts?.debugMessage, opts?.nestedError);

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -47,6 +47,7 @@ export type HealthReply = {
 
 export type TranscribeReply = {
   text: string;
+  dailySecondsRemaining: number;
 };
 
 export type GlossaryListReply = {

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -30,3 +30,14 @@ export const glossaryEntrySchema = z.object({
 });
 
 export type GlossaryEntry = z.infer<typeof glossaryEntrySchema>;
+
+export const transcriptionUsageSchema = z.object({
+  _id: z.instanceof(ObjectId),
+  userId: z.instanceof(ObjectId),
+  date: z.string(),
+  usedSeconds: z.number(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type TranscriptionUsage = z.infer<typeof transcriptionUsageSchema>;

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -31,13 +31,13 @@ export const glossaryEntrySchema = z.object({
 
 export type GlossaryEntry = z.infer<typeof glossaryEntrySchema>;
 
-export const transcriptionUsageSchema = z.object({
+export const dailyUsageSchema = z.object({
   _id: z.instanceof(ObjectId),
   userId: z.instanceof(ObjectId),
   date: z.string(),
-  usedSeconds: z.number(),
+  transcriptionSeconds: z.number(),
   createdAt: z.date(),
   updatedAt: z.date(),
 });
 
-export type TranscriptionUsage = z.infer<typeof transcriptionUsageSchema>;
+export type DailyUsage = z.infer<typeof dailyUsageSchema>;

--- a/src/repositories/daily-usage-repo.ts
+++ b/src/repositories/daily-usage-repo.ts
@@ -5,31 +5,31 @@ export function todayUtcDateKey(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-export class TranscriptionUsageRepository {
+export class DailyUsageRepository {
   private constructor() {}
 
-  static async getDailyUsedSeconds(userId: ObjectId): Promise<number> {
-    const doc = await DatabaseAccessor.transcriptionUsage().findOne({
+  static async getDailyTranscriptionSeconds(userId: ObjectId): Promise<number> {
+    const doc = await DatabaseAccessor.dailyUsage().findOne({
       userId,
       date: todayUtcDateKey(),
     });
-    return doc?.usedSeconds ?? 0;
+    return doc?.transcriptionSeconds ?? 0;
   }
 
-  static async incrementDailyUsage(userId: ObjectId, seconds: number): Promise<number> {
+  static async incrementTranscriptionSeconds(userId: ObjectId, seconds: number): Promise<number> {
     const now = new Date();
-    const result = await DatabaseAccessor.transcriptionUsage().findOneAndUpdate(
+    const result = await DatabaseAccessor.dailyUsage().findOneAndUpdate(
       { userId, date: todayUtcDateKey() },
       {
-        $inc: { usedSeconds: seconds },
+        $inc: { transcriptionSeconds: seconds },
         $setOnInsert: { _id: new ObjectId(), userId, createdAt: now },
         $set: { updatedAt: now },
       },
       { upsert: true, returnDocument: "after" },
     );
     if (!result) {
-      throw new Error("Failed to upsert transcription usage document");
+      throw new Error("Failed to upsert daily usage document");
     }
-    return result.usedSeconds;
+    return result.transcriptionSeconds;
   }
 }

--- a/src/repositories/transcription-usage-repo.ts
+++ b/src/repositories/transcription-usage-repo.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from "mongodb";
 import { DatabaseAccessor } from "../db/database-accessor.js";
 
-function todayUtcDateKey(): string {
+export function todayUtcDateKey(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
@@ -27,6 +27,9 @@ export class TranscriptionUsageRepository {
       },
       { upsert: true, returnDocument: "after" },
     );
-    return result!.usedSeconds;
+    if (!result) {
+      throw new Error("Failed to upsert transcription usage document");
+    }
+    return result.usedSeconds;
   }
 }

--- a/src/repositories/transcription-usage-repo.ts
+++ b/src/repositories/transcription-usage-repo.ts
@@ -1,0 +1,32 @@
+import { ObjectId } from "mongodb";
+import { DatabaseAccessor } from "../db/database-accessor.js";
+
+function todayUtcDateKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export class TranscriptionUsageRepository {
+  private constructor() {}
+
+  static async getDailyUsedSeconds(userId: ObjectId): Promise<number> {
+    const doc = await DatabaseAccessor.transcriptionUsage().findOne({
+      userId,
+      date: todayUtcDateKey(),
+    });
+    return doc?.usedSeconds ?? 0;
+  }
+
+  static async incrementDailyUsage(userId: ObjectId, seconds: number): Promise<number> {
+    const now = new Date();
+    const result = await DatabaseAccessor.transcriptionUsage().findOneAndUpdate(
+      { userId, date: todayUtcDateKey() },
+      {
+        $inc: { usedSeconds: seconds },
+        $setOnInsert: { _id: new ObjectId(), userId, createdAt: now },
+        $set: { updatedAt: now },
+      },
+      { upsert: true, returnDocument: "after" },
+    );
+    return result!.usedSeconds;
+  }
+}

--- a/src/routes/voice.ts
+++ b/src/routes/voice.ts
@@ -2,7 +2,7 @@ import { FastifyPluginAsync } from "fastify";
 import multipart from "@fastify/multipart";
 import { ObjectId } from "mongodb";
 import { z } from "zod";
-import { BadRequestError, InternalServerError, QuotaExceededError } from "../lib/errors.js";
+import { ApiError, BadRequestError, InternalServerError } from "../lib/errors.js";
 import { requireAuth } from "../middleware/auth.js";
 import type {
   TranscribeReply,
@@ -64,12 +64,7 @@ export const voiceRoutes: FastifyPluginAsync = async (fastify) => {
 
       return { text: result.text, dailySecondsRemaining: result.dailySecondsRemaining };
     } catch (error) {
-      if (
-        error instanceof BadRequestError ||
-        error instanceof InternalServerError ||
-        error instanceof QuotaExceededError
-      )
-        throw error;
+      if (error instanceof ApiError) throw error;
       throw new InternalServerError({
         debugMessage: "Transcription failed",
         nestedError: error,

--- a/src/routes/voice.ts
+++ b/src/routes/voice.ts
@@ -2,7 +2,7 @@ import { FastifyPluginAsync } from "fastify";
 import multipart from "@fastify/multipart";
 import { ObjectId } from "mongodb";
 import { z } from "zod";
-import { BadRequestError, InternalServerError } from "../lib/errors.js";
+import { BadRequestError, InternalServerError, QuotaExceededError } from "../lib/errors.js";
 import { requireAuth } from "../middleware/auth.js";
 import type {
   TranscribeReply,
@@ -51,20 +51,25 @@ export const voiceRoutes: FastifyPluginAsync = async (fastify) => {
     const userId = new ObjectId(request.user!.userId);
 
     try {
-      const text = await VoiceService.transcribe({
+      const result = await VoiceService.transcribe({
         userId,
         fileBuffer: buffer,
         filename: file.filename,
         mimetype: file.mimetype,
       });
 
-      if (!text || text.trim().length === 0) {
+      if (!result.text || result.text.trim().length === 0) {
         throw new InternalServerError({ debugMessage: "Transcription returned empty text" });
       }
 
-      return { text };
+      return { text: result.text, dailySecondsRemaining: result.dailySecondsRemaining };
     } catch (error) {
-      if (error instanceof BadRequestError || error instanceof InternalServerError) throw error;
+      if (
+        error instanceof BadRequestError ||
+        error instanceof InternalServerError ||
+        error instanceof QuotaExceededError
+      )
+        throw error;
       throw new InternalServerError({
         debugMessage: "Transcription failed",
         nestedError: error,

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,7 @@ export async function buildApp(): Promise<FastifyInstance> {
       if (error.debugMessage || error.nestedError) {
         console.error(`[${error.name}] ${error.debugMessage ?? error.message}`, error.nestedError ?? "");
       }
-      return reply.status(error.errorCode).send({ error: error.message });
+      return reply.status(error.errorCode).send({ error: error.message, ...error.responseBody });
     }
 
     console.error("[UnhandledError]", error);

--- a/src/services/voice-service.ts
+++ b/src/services/voice-service.ts
@@ -1,11 +1,11 @@
 import { ObjectId } from "mongodb";
 import { GlossaryEntryRepository } from "../repositories/glossary-entry-repo.js";
-import { TranscriptionUsageRepository } from "../repositories/transcription-usage-repo.js";
+import { DailyUsageRepository } from "../repositories/daily-usage-repo.js";
 import { OpenAIClient } from "../clients/openai-client.js";
 import { QuotaExceededError } from "../lib/errors.js";
+import { loadConfig } from "../config.js";
 
 const MAX_GLOSSARY_SIZE = 500;
-const DAILY_TRANSCRIPTION_LIMIT_SECONDS = 3600;
 
 export class VoiceService {
   private constructor() {}
@@ -16,10 +16,13 @@ export class VoiceService {
     filename: string;
     mimetype: string;
   }): Promise<{ text: string; dailySecondsRemaining: number }> {
-    const usedSeconds = await TranscriptionUsageRepository.getDailyUsedSeconds(args.userId);
+    const { DAILY_TRANSCRIPTION_LIMIT_SECONDS } = loadConfig();
+
+    const usedSeconds = await DailyUsageRepository.getDailyTranscriptionSeconds(args.userId);
 
     if (usedSeconds >= DAILY_TRANSCRIPTION_LIMIT_SECONDS) {
       throw new QuotaExceededError({
+        service: "transcription",
         debugMessage: `Daily transcription limit reached: ${usedSeconds}/${DAILY_TRANSCRIPTION_LIMIT_SECONDS}s`,
       });
     }
@@ -34,8 +37,13 @@ export class VoiceService {
       prompt: prompt ?? undefined,
     });
 
-    const newTotal = await TranscriptionUsageRepository.incrementDailyUsage(args.userId, durationSeconds);
-    const remaining = Math.max(0, DAILY_TRANSCRIPTION_LIMIT_SECONDS - newTotal);
+    let remaining = Math.max(0, DAILY_TRANSCRIPTION_LIMIT_SECONDS - usedSeconds - durationSeconds);
+    try {
+      const newTotal = await DailyUsageRepository.incrementTranscriptionSeconds(args.userId, durationSeconds);
+      remaining = Math.max(0, DAILY_TRANSCRIPTION_LIMIT_SECONDS - newTotal);
+    } catch (error) {
+      console.error("[VoiceService] Failed to record transcription usage", error);
+    }
 
     return { text, dailySecondsRemaining: remaining };
   }

--- a/src/services/voice-service.ts
+++ b/src/services/voice-service.ts
@@ -1,8 +1,11 @@
 import { ObjectId } from "mongodb";
 import { GlossaryEntryRepository } from "../repositories/glossary-entry-repo.js";
+import { TranscriptionUsageRepository } from "../repositories/transcription-usage-repo.js";
 import { OpenAIClient } from "../clients/openai-client.js";
+import { QuotaExceededError } from "../lib/errors.js";
 
 const MAX_GLOSSARY_SIZE = 500;
+const DAILY_TRANSCRIPTION_LIMIT_SECONDS = 3600;
 
 export class VoiceService {
   private constructor() {}
@@ -12,16 +15,29 @@ export class VoiceService {
     fileBuffer: Buffer;
     filename: string;
     mimetype: string;
-  }): Promise<string> {
+  }): Promise<{ text: string; dailySecondsRemaining: number }> {
+    const usedSeconds = await TranscriptionUsageRepository.getDailyUsedSeconds(args.userId);
+
+    if (usedSeconds >= DAILY_TRANSCRIPTION_LIMIT_SECONDS) {
+      throw new QuotaExceededError({
+        debugMessage: `Daily transcription limit reached: ${usedSeconds}/${DAILY_TRANSCRIPTION_LIMIT_SECONDS}s`,
+      });
+    }
+
     const glossaryWords = await VoiceService.getGlossaryWords(args.userId);
     const prompt = VoiceService.buildTranscriptionPrompt(glossaryWords);
 
-    return OpenAIClient.transcribe({
+    const { text, durationSeconds } = await OpenAIClient.transcribe({
       fileBuffer: args.fileBuffer,
       filename: args.filename,
       mimetype: args.mimetype,
       prompt: prompt ?? undefined,
     });
+
+    const newTotal = await TranscriptionUsageRepository.incrementDailyUsage(args.userId, durationSeconds);
+    const remaining = Math.max(0, DAILY_TRANSCRIPTION_LIMIT_SECONDS - newTotal);
+
+    return { text, dailySecondsRemaining: remaining };
   }
 
   static async getGlossaryWords(userId: ObjectId): Promise<string[]> {

--- a/tests/voice/transcribe.test.ts
+++ b/tests/voice/transcribe.test.ts
@@ -4,6 +4,9 @@ import { ObjectId } from "mongodb";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
 import { OpenAIClient } from "../../src/clients/openai-client.js";
 import { DatabaseAccessor } from "../../src/db/database-accessor.js";
+import { VoiceService } from "../../src/services/voice-service.js";
+import { BadGatewayError } from "../../src/lib/errors.js";
+import { todayUtcDateKey } from "../../src/repositories/transcription-usage-repo.js";
 
 const BOUNDARY = "----TestBoundary9876543210";
 
@@ -25,10 +28,6 @@ function buildMultipartPayload(args: { fieldName: string; filename: string; cont
     body: Buffer.concat(parts),
     contentType: `multipart/form-data; boundary=${BOUNDARY}`,
   };
-}
-
-function todayUtcDateKey(): string {
-  return new Date().toISOString().slice(0, 10);
 }
 
 describe("POST /voice/transcribe", () => {
@@ -231,6 +230,34 @@ describe("POST /voice/transcribe", () => {
     });
 
     assert.equal(res.statusCode, 500);
+  });
+
+  it("preserves original status code when service throws an ApiError subclass", async () => {
+    const user = await ctx.createUser();
+
+    mock.method(VoiceService, "transcribe", async () => {
+      throw new BadGatewayError({ debugMessage: "Upstream provider unavailable" });
+    });
+
+    const { body, contentType } = buildMultipartPayload({
+      fieldName: "audio",
+      filename: "test.m4a",
+      content: Buffer.from("fake-audio-data-for-testing"),
+      contentType: "audio/m4a",
+    });
+
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/voice/transcribe",
+      headers: {
+        authorization: `Bearer ${user.accessToken}`,
+        "content-type": contentType,
+      },
+      payload: body,
+    });
+
+    assert.equal(res.statusCode, 502);
+    assert.deepEqual(res.json(), { error: "bad_gateway" });
   });
 
   it("returns 500 when OpenAI throws an error", async () => {

--- a/tests/voice/transcribe.test.ts
+++ b/tests/voice/transcribe.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, before, after, mock, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import { ObjectId } from "mongodb";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
 import { OpenAIClient } from "../../src/clients/openai-client.js";
+import { DatabaseAccessor } from "../../src/db/database-accessor.js";
 
 const BOUNDARY = "----TestBoundary9876543210";
 
@@ -23,6 +25,10 @@ function buildMultipartPayload(args: { fieldName: string; filename: string; cont
     body: Buffer.concat(parts),
     contentType: `multipart/form-data; boundary=${BOUNDARY}`,
   };
+}
+
+function todayUtcDateKey(): string {
+  return new Date().toISOString().slice(0, 10);
 }
 
 describe("POST /voice/transcribe", () => {
@@ -87,10 +93,13 @@ describe("POST /voice/transcribe", () => {
     assert.equal(res.statusCode, 400);
   });
 
-  it("returns transcribed text on success", async () => {
+  it("returns transcribed text and dailySecondsRemaining on success", async () => {
     const user = await ctx.createUser();
 
-    mock.method(OpenAIClient, "transcribe", async () => "Hello world, this is a test.");
+    mock.method(OpenAIClient, "transcribe", async () => ({
+      text: "Hello world, this is a test.",
+      durationSeconds: 10,
+    }));
 
     const { body, contentType } = buildMultipartPayload({
       fieldName: "audio",
@@ -110,7 +119,10 @@ describe("POST /voice/transcribe", () => {
     });
 
     assert.equal(res.statusCode, 200);
-    assert.deepEqual(res.json(), { text: "Hello world, this is a test." });
+    const json = res.json();
+    assert.equal(json.text, "Hello world, this is a test.");
+    assert.equal(typeof json.dailySecondsRemaining, "number");
+    assert.equal(json.dailySecondsRemaining, 3590);
   });
 
   it("passes glossary words in the prompt to OpenAI", async () => {
@@ -132,7 +144,7 @@ describe("POST /voice/transcribe", () => {
       "transcribe",
       async (args: { fileBuffer: Buffer; filename: string; mimetype: string; prompt?: string }) => {
         capturedPrompt = args.prompt;
-        return "Sesori uses XChaCha20 encryption.";
+        return { text: "Sesori uses XChaCha20 encryption.", durationSeconds: 5 };
       },
     );
 
@@ -168,7 +180,7 @@ describe("POST /voice/transcribe", () => {
       "transcribe",
       async (args: { fileBuffer: Buffer; filename: string; mimetype: string; prompt?: string }) => {
         capturedPrompt = args.prompt;
-        return "Hello world.";
+        return { text: "Hello world.", durationSeconds: 3 };
       },
     );
 
@@ -196,7 +208,10 @@ describe("POST /voice/transcribe", () => {
   it("returns 500 when OpenAI returns empty text", async () => {
     const user = await ctx.createUser();
 
-    mock.method(OpenAIClient, "transcribe", async () => "");
+    mock.method(OpenAIClient, "transcribe", async () => ({
+      text: "",
+      durationSeconds: 0,
+    }));
 
     const { body, contentType } = buildMultipartPayload({
       fieldName: "audio",
@@ -243,5 +258,157 @@ describe("POST /voice/transcribe", () => {
     });
 
     assert.equal(res.statusCode, 500);
+  });
+
+  it("returns 429 when daily transcription quota is exceeded", async () => {
+    const user = await ctx.createUser();
+    const userId = new ObjectId(user.userId);
+
+    await DatabaseAccessor.transcriptionUsage().insertOne({
+      _id: new ObjectId(),
+      userId,
+      date: todayUtcDateKey(),
+      usedSeconds: 3600,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    mock.method(OpenAIClient, "transcribe", async () => ({
+      text: "Should not reach here.",
+      durationSeconds: 5,
+    }));
+
+    const { body, contentType } = buildMultipartPayload({
+      fieldName: "audio",
+      filename: "test.m4a",
+      content: Buffer.from("fake-audio-data-for-testing"),
+      contentType: "audio/m4a",
+    });
+
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/voice/transcribe",
+      headers: {
+        authorization: `Bearer ${user.accessToken}`,
+        "content-type": contentType,
+      },
+      payload: body,
+    });
+
+    assert.equal(res.statusCode, 429);
+    assert.deepEqual(res.json(), { error: "quota_exceeded" });
+  });
+
+  it("tracks usage in the database after successful transcription", async () => {
+    const user = await ctx.createUser();
+    const userId = new ObjectId(user.userId);
+
+    mock.method(OpenAIClient, "transcribe", async () => ({
+      text: "Tracked transcription.",
+      durationSeconds: 42.5,
+    }));
+
+    const { body, contentType } = buildMultipartPayload({
+      fieldName: "audio",
+      filename: "test.m4a",
+      content: Buffer.from("fake-audio-data-for-testing"),
+      contentType: "audio/m4a",
+    });
+
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/voice/transcribe",
+      headers: {
+        authorization: `Bearer ${user.accessToken}`,
+        "content-type": contentType,
+      },
+      payload: body,
+    });
+
+    assert.equal(res.statusCode, 200);
+
+    const usageDoc = await DatabaseAccessor.transcriptionUsage().findOne({
+      userId,
+      date: todayUtcDateKey(),
+    });
+
+    assert.ok(usageDoc, "Usage document should exist after transcription");
+    assert.equal(usageDoc.usedSeconds, 42.5);
+  });
+
+  it("accumulates usage across multiple transcriptions", async () => {
+    const user = await ctx.createUser();
+    const userId = new ObjectId(user.userId);
+
+    mock.method(OpenAIClient, "transcribe", async () => ({
+      text: "First transcription.",
+      durationSeconds: 100,
+    }));
+
+    const payload = buildMultipartPayload({
+      fieldName: "audio",
+      filename: "test.m4a",
+      content: Buffer.from("fake-audio-data-for-testing"),
+      contentType: "audio/m4a",
+    });
+
+    const headers = {
+      authorization: `Bearer ${user.accessToken}`,
+      "content-type": payload.contentType,
+    };
+
+    const res1 = await ctx.app.inject({ method: "POST", url: "/voice/transcribe", headers, payload: payload.body });
+    assert.equal(res1.statusCode, 200);
+    assert.equal(res1.json().dailySecondsRemaining, 3500);
+
+    const res2 = await ctx.app.inject({ method: "POST", url: "/voice/transcribe", headers, payload: payload.body });
+    assert.equal(res2.statusCode, 200);
+    assert.equal(res2.json().dailySecondsRemaining, 3400);
+
+    const usageDoc = await DatabaseAccessor.transcriptionUsage().findOne({
+      userId,
+      date: todayUtcDateKey(),
+    });
+    assert.ok(usageDoc);
+    assert.equal(usageDoc.usedSeconds, 200);
+  });
+
+  it("allows transcription when under quota but near limit", async () => {
+    const user = await ctx.createUser();
+    const userId = new ObjectId(user.userId);
+
+    await DatabaseAccessor.transcriptionUsage().insertOne({
+      _id: new ObjectId(),
+      userId,
+      date: todayUtcDateKey(),
+      usedSeconds: 3590,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    mock.method(OpenAIClient, "transcribe", async () => ({
+      text: "Allowed near limit.",
+      durationSeconds: 30,
+    }));
+
+    const { body, contentType } = buildMultipartPayload({
+      fieldName: "audio",
+      filename: "test.m4a",
+      content: Buffer.from("fake-audio-data-for-testing"),
+      contentType: "audio/m4a",
+    });
+
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/voice/transcribe",
+      headers: {
+        authorization: `Bearer ${user.accessToken}`,
+        "content-type": contentType,
+      },
+      payload: body,
+    });
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.json().dailySecondsRemaining, 0);
   });
 });

--- a/tests/voice/transcribe.test.ts
+++ b/tests/voice/transcribe.test.ts
@@ -6,7 +6,8 @@ import { OpenAIClient } from "../../src/clients/openai-client.js";
 import { DatabaseAccessor } from "../../src/db/database-accessor.js";
 import { VoiceService } from "../../src/services/voice-service.js";
 import { BadGatewayError } from "../../src/lib/errors.js";
-import { todayUtcDateKey } from "../../src/repositories/transcription-usage-repo.js";
+import { todayUtcDateKey } from "../../src/repositories/daily-usage-repo.js";
+import { DailyUsageRepository } from "../../src/repositories/daily-usage-repo.js";
 
 const BOUNDARY = "----TestBoundary9876543210";
 
@@ -291,11 +292,11 @@ describe("POST /voice/transcribe", () => {
     const user = await ctx.createUser();
     const userId = new ObjectId(user.userId);
 
-    await DatabaseAccessor.transcriptionUsage().insertOne({
+    await DatabaseAccessor.dailyUsage().insertOne({
       _id: new ObjectId(),
       userId,
       date: todayUtcDateKey(),
-      usedSeconds: 3600,
+      transcriptionSeconds: 3600,
       createdAt: new Date(),
       updatedAt: new Date(),
     });
@@ -323,7 +324,40 @@ describe("POST /voice/transcribe", () => {
     });
 
     assert.equal(res.statusCode, 429);
-    assert.deepEqual(res.json(), { error: "quota_exceeded" });
+    assert.deepEqual(res.json(), { error: "quota_exceeded", service: "transcription" });
+  });
+
+  it("returns 200 even if usage recording fails", async () => {
+    const user = await ctx.createUser();
+
+    mock.method(OpenAIClient, "transcribe", async () => ({
+      text: "Transcription succeeded.",
+      durationSeconds: 15,
+    }));
+    mock.method(DailyUsageRepository, "incrementTranscriptionSeconds", async () => {
+      throw new Error("MongoDB connection lost");
+    });
+
+    const { body, contentType } = buildMultipartPayload({
+      fieldName: "audio",
+      filename: "test.m4a",
+      content: Buffer.from("fake-audio-data-for-testing"),
+      contentType: "audio/m4a",
+    });
+
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/voice/transcribe",
+      headers: {
+        authorization: `Bearer ${user.accessToken}`,
+        "content-type": contentType,
+      },
+      payload: body,
+    });
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.json().text, "Transcription succeeded.");
+    assert.equal(typeof res.json().dailySecondsRemaining, "number");
   });
 
   it("tracks usage in the database after successful transcription", async () => {
@@ -354,13 +388,13 @@ describe("POST /voice/transcribe", () => {
 
     assert.equal(res.statusCode, 200);
 
-    const usageDoc = await DatabaseAccessor.transcriptionUsage().findOne({
+    const usageDoc = await DatabaseAccessor.dailyUsage().findOne({
       userId,
       date: todayUtcDateKey(),
     });
 
     assert.ok(usageDoc, "Usage document should exist after transcription");
-    assert.equal(usageDoc.usedSeconds, 42.5);
+    assert.equal(usageDoc.transcriptionSeconds, 42.5);
   });
 
   it("accumulates usage across multiple transcriptions", async () => {
@@ -392,23 +426,23 @@ describe("POST /voice/transcribe", () => {
     assert.equal(res2.statusCode, 200);
     assert.equal(res2.json().dailySecondsRemaining, 3400);
 
-    const usageDoc = await DatabaseAccessor.transcriptionUsage().findOne({
+    const usageDoc = await DatabaseAccessor.dailyUsage().findOne({
       userId,
       date: todayUtcDateKey(),
     });
     assert.ok(usageDoc);
-    assert.equal(usageDoc.usedSeconds, 200);
+    assert.equal(usageDoc.transcriptionSeconds, 200);
   });
 
   it("allows transcription when under quota but near limit", async () => {
     const user = await ctx.createUser();
     const userId = new ObjectId(user.userId);
 
-    await DatabaseAccessor.transcriptionUsage().insertOne({
+    await DatabaseAccessor.dailyUsage().insertOne({
       _id: new ObjectId(),
       userId,
       date: todayUtcDateKey(),
-      usedSeconds: 3590,
+      transcriptionSeconds: 3590,
       createdAt: new Date(),
       updatedAt: new Date(),
     });


### PR DESCRIPTION
## Summary

- **Track per-user voice-to-text usage** in a new `transcriptionUsage` MongoDB collection (one document per user per UTC day, atomic `$inc` updates)
- **Reject requests upfront with 429** when the daily limit (3600 seconds) is reached, using a new `QuotaExceededError`
- **Return `dailySecondsRemaining`** in every successful transcription response so clients can display quota progress

## Details

**Quota enforcement flow:**
1. Before transcription — query today's `usedSeconds` for the user. If ≥ 3600 → 429 `quota_exceeded`
2. After transcription — atomically increment `usedSeconds` by actual audio duration (from OpenAI `verbose_json`)
3. Daily reset is implicit — each UTC day gets a new document, no cron needed

**Files changed (9 modified, 1 new):**
- `src/repositories/transcription-usage-repo.ts` — **new** repo with `getDailyUsedSeconds()` + `incrementDailyUsage()`
- `src/lib/errors.ts` — added `QuotaExceededError` (HTTP 429)
- `src/models/documents.ts` — added `TranscriptionUsage` Zod schema
- `src/models/api.ts` — `TranscribeReply` now includes `dailySecondsRemaining`
- `src/db/db-client.ts` + `src/db/database-accessor.ts` — collection registration + unique index on `(userId, date)`
- `src/clients/openai-client.ts` — switched to `verbose_json` to get audio duration
- `src/services/voice-service.ts` — quota check before, usage recording after, limit constant `DAILY_TRANSCRIPTION_LIMIT_SECONDS = 3600`
- `src/routes/voice.ts` — wired up new response shape + error passthrough

**Tests:** 5 new tests covering quota exceeded (429), usage tracking, accumulation across requests, near-limit allowance. All 61 tests pass.