### PR TITLE
test: fix broken tests and extend auth coverage

### DIFF
--- a/tests/auth/github.test.ts
+++ b/tests/auth/github.test.ts
@@ -1,16 +1,23 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
+import { FakeOAuthClient } from "../helpers/fake-oauth-client.js";
 
 // A valid 43-character PKCE code_challenge (URL-safe base64, no padding)
 const VALID_CODE_CHALLENGE = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
 const VALID_REDIRECT_URI = "myapp://oauth/callback";
+const FAKE_IDENTITY = {
+  providerUserId: "github-user-123",
+  providerUsername: "fake-github-user",
+};
 
 describe("GitHub OAuth routes", () => {
   let ctx: TestContext;
 
   before(async () => {
-    ctx = await createTestApp();
+    ctx = await createTestApp({
+      githubClient: new FakeOAuthClient(FAKE_IDENTITY),
+    });
   });
 
   after(async () => {
@@ -87,6 +94,123 @@ describe("GitHub OAuth routes", () => {
   // ── POST /auth/github/callback ──────────────────────────────────────────────
 
   describe("POST /auth/github/callback", () => {
+    it("completes full OAuth callback flow for first-time login", async () => {
+      const initRes = await ctx.app.inject({
+        method: "GET",
+        url: `/auth/github?redirect_uri=${encodeURIComponent(VALID_REDIRECT_URI)}&code_challenge=${VALID_CODE_CHALLENGE}`,
+      });
+      assert.equal(initRes.statusCode, 200);
+      const { state } = initRes.json<{ authUrl: string; state: string }>();
+
+      const callbackRes = await ctx.app.inject({
+        method: "POST",
+        url: "/auth/github/callback",
+        headers: { "content-type": "application/json" },
+        payload: JSON.stringify({
+          code: "fake-auth-code",
+          codeVerifier: "fake-code-verifier",
+          state,
+          redirectUri: VALID_REDIRECT_URI,
+        }),
+      });
+
+      assert.equal(callbackRes.statusCode, 200);
+      const body = callbackRes.json<{
+        accessToken: string;
+        refreshToken: string;
+        user: { id: string; provider: string; providerUserId: string; providerUsername: string | null };
+      }>();
+      assert.ok(body.accessToken, "Should return access token");
+      assert.ok(body.refreshToken, "Should return refresh token");
+      assert.ok(body.user.id, "Should return user id");
+      assert.equal(body.user.provider, "github");
+      assert.equal(body.user.providerUserId, FAKE_IDENTITY.providerUserId);
+      assert.equal(body.user.providerUsername, FAKE_IDENTITY.providerUsername);
+    });
+
+    it("returns same user on repeat login with same provider account", async () => {
+      const initRes1 = await ctx.app.inject({
+        method: "GET",
+        url: `/auth/github?redirect_uri=${encodeURIComponent(VALID_REDIRECT_URI)}&code_challenge=${VALID_CODE_CHALLENGE}`,
+      });
+      assert.equal(initRes1.statusCode, 200);
+      const { state: state1 } = initRes1.json<{ authUrl: string; state: string }>();
+
+      const callbackRes1 = await ctx.app.inject({
+        method: "POST",
+        url: "/auth/github/callback",
+        headers: { "content-type": "application/json" },
+        payload: JSON.stringify({
+          code: "fake-auth-code-1",
+          codeVerifier: "fake-code-verifier-1",
+          state: state1,
+          redirectUri: VALID_REDIRECT_URI,
+        }),
+      });
+      assert.equal(callbackRes1.statusCode, 200);
+      const firstUserId = callbackRes1.json<{ user: { id: string } }>().user.id;
+
+      const initRes2 = await ctx.app.inject({
+        method: "GET",
+        url: `/auth/github?redirect_uri=${encodeURIComponent(VALID_REDIRECT_URI)}&code_challenge=${VALID_CODE_CHALLENGE}`,
+      });
+      assert.equal(initRes2.statusCode, 200);
+      const { state: state2 } = initRes2.json<{ authUrl: string; state: string }>();
+
+      const callbackRes2 = await ctx.app.inject({
+        method: "POST",
+        url: "/auth/github/callback",
+        headers: { "content-type": "application/json" },
+        payload: JSON.stringify({
+          code: "fake-auth-code-2",
+          codeVerifier: "fake-code-verifier-2",
+          state: state2,
+          redirectUri: VALID_REDIRECT_URI,
+        }),
+      });
+      assert.equal(callbackRes2.statusCode, 200);
+      const secondUserId = callbackRes2.json<{ user: { id: string } }>().user.id;
+
+      assert.equal(secondUserId, firstUserId);
+    });
+
+    it("rejects reused state token (consumed on first use)", async () => {
+      const initRes = await ctx.app.inject({
+        method: "GET",
+        url: `/auth/github?redirect_uri=${encodeURIComponent(VALID_REDIRECT_URI)}&code_challenge=${VALID_CODE_CHALLENGE}`,
+      });
+      assert.equal(initRes.statusCode, 200);
+      const { state } = initRes.json<{ authUrl: string; state: string }>();
+
+      const firstCallback = await ctx.app.inject({
+        method: "POST",
+        url: "/auth/github/callback",
+        headers: { "content-type": "application/json" },
+        payload: JSON.stringify({
+          code: "fake-auth-code-first",
+          codeVerifier: "fake-code-verifier-first",
+          state,
+          redirectUri: VALID_REDIRECT_URI,
+        }),
+      });
+      assert.equal(firstCallback.statusCode, 200);
+
+      const secondCallback = await ctx.app.inject({
+        method: "POST",
+        url: "/auth/github/callback",
+        headers: { "content-type": "application/json" },
+        payload: JSON.stringify({
+          code: "fake-auth-code-second",
+          codeVerifier: "fake-code-verifier-second",
+          state,
+          redirectUri: VALID_REDIRECT_URI,
+        }),
+      });
+
+      assert.equal(secondCallback.statusCode, 400);
+      assert.equal(secondCallback.json<{ error: string }>().error, "bad_request");
+    });
+
     it("returns 400 when state was never issued by this server", async () => {
       const res = await ctx.app.inject({
         method: "POST",

--- a/tests/auth/token.test.ts
+++ b/tests/auth/token.test.ts
@@ -79,9 +79,7 @@ describe("Token routes", () => {
     });
 
     it("returns 401 for a valid-format token referencing a non-existent user", async () => {
-      // Sign a refresh token for a userId that doesn't exist in the DB
-      const { TokenService } = await import("../../src/services/token-service.js");
-      const ghostToken = TokenService.signRefreshToken({
+      const ghostToken = ctx.tokenService.signRefreshToken({
         userId: "000000000000000000000000",
         tokenVersion: 0,
       });
@@ -94,6 +92,27 @@ describe("Token routes", () => {
       });
 
       assert.equal(res.statusCode, 401);
+    });
+
+    it("returns 401 for refresh after logout (tokenVersion incremented)", async () => {
+      const user = await ctx.createUser();
+
+      const logoutRes = await ctx.app.inject({
+        method: "POST",
+        url: "/auth/logout",
+        headers: { authorization: `Bearer ${user.accessToken}` },
+      });
+      assert.equal(logoutRes.statusCode, 200);
+
+      const refreshRes = await ctx.app.inject({
+        method: "POST",
+        url: "/auth/refresh",
+        headers: { "content-type": "application/json" },
+        payload: JSON.stringify({ refreshToken: user.refreshToken }),
+      });
+
+      assert.equal(refreshRes.statusCode, 401);
+      assert.equal(refreshRes.json<{ error: string }>().error, "unauthenticated");
     });
 
     it("returns 400 when refreshToken field is missing from body", async () => {
@@ -156,6 +175,55 @@ describe("Token routes", () => {
       });
 
       assert.equal(res.statusCode, 401);
+    });
+
+    it("returns 401 for an expired access token on protected route", async () => {
+      const user = await ctx.createUser();
+      const expiredAccessToken = ctx.createExpiredAccessToken({
+        userId: user.userId,
+        provider: user.provider,
+        providerUserId: user.providerUserId,
+      });
+
+      const res = await ctx.app.inject({
+        method: "GET",
+        url: "/auth/me",
+        headers: { authorization: `Bearer ${expiredAccessToken}` },
+      });
+
+      assert.equal(res.statusCode, 401);
+      assert.equal(res.json<{ error: string }>().error, "unauthenticated");
+    });
+
+    it("returns 401 when access token has wrong audience", async () => {
+      const user = await ctx.createUser();
+      const bridgeToken = ctx.tokenService.signBridgeToken({ userId: user.userId });
+
+      const res = await ctx.app.inject({
+        method: "GET",
+        url: "/auth/me",
+        headers: { authorization: `Bearer ${bridgeToken}` },
+      });
+
+      assert.equal(res.statusCode, 401);
+      assert.equal(res.json<{ error: string }>().error, "unauthenticated");
+    });
+
+    it("returns 404 for /auth/me when access token user no longer exists", async () => {
+      const ghostAccessToken = ctx.tokenService.signAccessToken({
+        userId: "000000000000000000000000",
+        provider: "github",
+        providerUserId: "ghost-provider-user",
+      });
+
+      const res = await ctx.app.inject({
+        method: "GET",
+        url: "/auth/me",
+        headers: { authorization: `Bearer ${ghostAccessToken}` },
+      });
+
+      assert.equal(res.statusCode, 404);
+      assert.equal(res.json<{ error: string }>().error, "not_found");
     });
   });
 

--- a/tests/helpers/fake-oauth-client.ts
+++ b/tests/helpers/fake-oauth-client.ts
@@ -1,0 +1,20 @@
+import { OAuthClient } from "../../src/clients/auth/oauth-client.js";
+import type { OAuthExchangeParams, OAuthIdentity, OAuthTokens } from "../../src/types/oauth.js";
+
+export class FakeOAuthClient extends OAuthClient {
+  protected readonly tokenEndpoint = "http://fake";
+  readonly #identity: OAuthIdentity;
+
+  constructor(identity: OAuthIdentity) {
+    super();
+    this.#identity = identity;
+  }
+
+  protected async exchangeCode(_params: OAuthExchangeParams): Promise<OAuthTokens> {
+    return { token: "fake-token" };
+  }
+
+  protected async resolveIdentity(_tokens: OAuthTokens, _params: OAuthExchangeParams): Promise<OAuthIdentity> {
+    return this.#identity;
+  }
+}

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -1,11 +1,24 @@
-import { closeDb, oAuthDbClient } from "../../src/db/db-client.js";
-import { DatabaseAccessor } from "../../src/db/database-accessor.js";
-import { buildApp } from "../../src/server.js";
-import { TokenService } from "../../src/services/token-service.js";
-import { ObjectId } from "mongodb";
 import * as crypto from "node:crypto";
 import jwt from "jsonwebtoken";
 import type { FastifyInstance } from "fastify";
+import { ObjectId } from "mongodb";
+import { GithubClient } from "../../src/clients/auth/github-client.js";
+import { GoogleClient } from "../../src/clients/auth/google-client.js";
+import type { OAuthClient } from "../../src/clients/auth/oauth-client.js";
+import { OpenAIClient } from "../../src/clients/openai-client.js";
+import type { User, OAuthAccount } from "../../src/models/documents.js";
+import { MongoDbAccessor } from "../../src/db/mongo-db-accessor.js";
+import { MongoDbConnector } from "../../src/db/mongo-db-connector.js";
+import { MongoDbDatabase, AuthDbCollection } from "../../src/types/mongo.js";
+import { StateStore } from "../../src/lib/state-store.js";
+import { GlossaryEntryRepository } from "../../src/repositories/glossary-entry-repo.js";
+import { OAuthAccountRepository } from "../../src/repositories/oauth-account-repo.js";
+import { UserRepository } from "../../src/repositories/user-repo.js";
+import { buildApp } from "../../src/server.js";
+import { AuthService } from "../../src/services/auth-service.js";
+import { TokenService } from "../../src/services/token-service.js";
+import { VoiceService } from "../../src/services/voice-service.js";
+import { loadConfig } from "../../src/config.js";
 
 export type TestUser = {
   userId: string;
@@ -17,12 +30,21 @@ export type TestUser = {
 
 export type TestContext = {
   app: FastifyInstance;
+  tokenService: TokenService;
   cleanup: () => Promise<void>;
   createUser: (opts?: { provider?: string; providerUserId?: string }) => Promise<TestUser>;
   createExpiredRefreshToken: (userId: string) => string;
+  createExpiredAccessToken: (opts: { userId: string; provider: string; providerUserId: string }) => string;
 };
 
-export async function createTestApp(): Promise<TestContext> {
+export type TestAppOverrides = {
+  githubClient?: OAuthClient;
+  googleClient?: OAuthClient;
+};
+
+export type { OAuthClient };
+
+export async function createTestApp(overrides?: TestAppOverrides): Promise<TestContext> {
   const { privateKey: privPem, publicKey: pubPem } = crypto.generateKeyPairSync("rsa", {
     modulusLength: 2048,
     publicKeyEncoding: { type: "spki", format: "pem" },
@@ -37,17 +59,42 @@ export async function createTestApp(): Promise<TestContext> {
   process.env.GITHUB_CLIENT_SECRET ??= "test-github-client-secret";
   process.env.GOOGLE_CLIENT_ID ??= "test-google-client-id";
   process.env.GOOGLE_CLIENT_SECRET ??= "test-google-client-secret";
+  process.env.ALLOWED_REDIRECT_URIS ??= "myapp://oauth/callback";
   process.env.RELAY_URL ??= "ws://localhost:8080";
   process.env.OPENAI_API_KEY ??= "test-openai-api-key";
   process.env.OPENAI_TRANSCRIPTION_MODEL ??= "gpt-4o-mini-transcribe";
 
-  TokenService.setKeys(privPem, pubPem);
+  const config = loadConfig();
 
-  const db = oAuthDbClient.getDatabase();
-  await db.dropDatabase();
-  await DatabaseAccessor.ensureIndexes();
+  const dbConnector = new MongoDbConnector({ connectionString: mongoUri });
+  const dbAccessor = new MongoDbAccessor(dbConnector);
 
-  const app = await buildApp();
+  await dbAccessor.getDb(MongoDbDatabase.Auth).dropDatabase();
+  await dbAccessor.ensureIndexes();
+
+  const userRepo = new UserRepository(dbAccessor);
+  const oauthAccountRepo = new OAuthAccountRepository(dbAccessor);
+  const glossaryRepo = new GlossaryEntryRepository(dbAccessor);
+
+  const tokenService = new TokenService(privPem, pubPem);
+  const stateStore = new StateStore();
+
+  const openai = new OpenAIClient({ apiKey: "test-key", model: "gpt-4o-mini-transcribe" });
+  const githubClient = overrides?.githubClient ?? new GithubClient();
+  const googleClient = overrides?.googleClient ?? new GoogleClient();
+
+  const authService = new AuthService({ tokenService, userRepo, oauthAccountRepo });
+  const voiceService = new VoiceService({ openai, glossaryRepo });
+
+  const app = await buildApp({
+    config,
+    authService,
+    tokenService,
+    voiceService,
+    stateStore,
+    githubClient: githubClient as GithubClient,
+    googleClient: googleClient as GoogleClient,
+  });
   await app.ready();
 
   async function createUser(opts: { provider?: string; providerUserId?: string } = {}): Promise<TestUser> {
@@ -56,13 +103,13 @@ export async function createTestApp(): Promise<TestContext> {
     const userId = new ObjectId();
     const now = new Date();
 
-    await DatabaseAccessor.users().insertOne({
+    await dbAccessor.getCollection<User>(MongoDbDatabase.Auth, AuthDbCollection.Users).insertOne({
       _id: userId,
       tokenVersion: 0,
       createdAt: now,
       updatedAt: now,
     });
-    await DatabaseAccessor.oauthAccounts().insertOne({
+    await dbAccessor.getCollection<OAuthAccount>(MongoDbDatabase.Auth, AuthDbCollection.OAuthAccounts).insertOne({
       _id: new ObjectId(),
       userId,
       provider,
@@ -73,12 +120,12 @@ export async function createTestApp(): Promise<TestContext> {
     });
 
     const userIdStr = userId.toHexString();
-    const accessToken = TokenService.signAccessToken({
+    const accessToken = tokenService.signAccessToken({
       userId: userIdStr,
       provider,
       providerUserId,
     });
-    const refreshToken = TokenService.signRefreshToken({
+    const refreshToken = tokenService.signRefreshToken({
       userId: userIdStr,
       tokenVersion: 0,
     });
@@ -109,12 +156,29 @@ export async function createTestApp(): Promise<TestContext> {
     );
   }
 
-  async function cleanup(): Promise<void> {
-    await app.close();
-    const db = oAuthDbClient.getDatabase();
-    await db.dropDatabase();
-    await closeDb();
+  function createExpiredAccessToken(opts: { userId: string; provider: string; providerUserId: string }): string {
+    const now = Math.floor(Date.now() / 1000);
+    return jwt.sign(
+      {
+        tokenType: "access",
+        userId: opts.userId,
+        provider: opts.provider,
+        providerUserId: opts.providerUserId,
+        iss: "auth-backend",
+        aud: "mobile",
+        iat: now - 7200,
+        exp: now - 3600,
+      },
+      privPem,
+      { algorithm: "RS256" },
+    );
   }
 
-  return { app, cleanup, createUser, createExpiredRefreshToken };
+  async function cleanup(): Promise<void> {
+    await app.close();
+    await dbAccessor.getDb(MongoDbDatabase.Auth).dropDatabase();
+    await dbConnector.close();
+  }
+
+  return { app, tokenService, cleanup, createUser, createExpiredRefreshToken, createExpiredAccessToken };
 }

--- a/tests/voice/transcribe.test.ts
+++ b/tests/voice/transcribe.test.ts
@@ -90,7 +90,7 @@ describe("POST /voice/transcribe", () => {
   it("returns transcribed text on success", async () => {
     const user = await ctx.createUser();
 
-    mock.method(OpenAIClient, "transcribe", async () => "Hello world, this is a test.");
+    mock.method(OpenAIClient.prototype, "transcribe", async () => "Hello world, this is a test.");
 
     const { body, contentType } = buildMultipartPayload({
       fieldName: "audio",
@@ -128,7 +128,7 @@ describe("POST /voice/transcribe", () => {
 
     let capturedPrompt: string | undefined;
     mock.method(
-      OpenAIClient,
+      OpenAIClient.prototype,
       "transcribe",
       async (args: { fileBuffer: Buffer; filename: string; mimetype: string; prompt?: string }) => {
         capturedPrompt = args.prompt;
@@ -164,7 +164,7 @@ describe("POST /voice/transcribe", () => {
 
     let capturedPrompt: string | undefined;
     mock.method(
-      OpenAIClient,
+      OpenAIClient.prototype,
       "transcribe",
       async (args: { fileBuffer: Buffer; filename: string; mimetype: string; prompt?: string }) => {
         capturedPrompt = args.prompt;
@@ -196,7 +196,7 @@ describe("POST /voice/transcribe", () => {
   it("returns 500 when OpenAI returns empty text", async () => {
     const user = await ctx.createUser();
 
-    mock.method(OpenAIClient, "transcribe", async () => "");
+    mock.method(OpenAIClient.prototype, "transcribe", async () => "");
 
     const { body, contentType } = buildMultipartPayload({
       fieldName: "audio",
@@ -221,7 +221,7 @@ describe("POST /voice/transcribe", () => {
   it("returns 500 when OpenAI throws an error", async () => {
     const user = await ctx.createUser();
 
-    mock.method(OpenAIClient, "transcribe", async () => {
+    mock.method(OpenAIClient.prototype, "transcribe", async () => {
       throw new Error("OpenAI API rate limit exceeded");
     });
 


### PR DESCRIPTION
## Summary

Depends on #12. Fixes test breakage introduced by the DI refactor and adds missing auth coverage identified by the 5-reviewer code review.

## Fixes

- **TokenService**: Tests used static `TokenService.signRefreshToken()` — now use `ctx.tokenService` instance from test context
- **OpenAIClient mocks**: Tests mocked on class instead of prototype — `mock.method(OpenAIClient.prototype, ...)` fixes the stub
- **StateStore isolation**: Tests now create a fresh `StateStore` per suite instead of sharing the singleton

## New Test Infrastructure

- **FakeOAuthClient** (`tests/helpers/fake-oauth-client.ts`): Extends `OAuthClient` to return configurable identities without external API calls
- **TestAppOverrides**: `createTestApp()` accepts optional `githubClient`/`googleClient` overrides for DI-level faking
- **`createExpiredAccessToken()`**: Helper for testing protected route expiry
- **Typed collection inserts**: `createUser()` uses `Collection<User>` / `Collection<OAuthAccount>` for compile-time safety

## New Test Cases

| Test | File | What it covers |
|------|------|----------------|
| First-time OAuth callback success | `github.test.ts` | Full flow: GET state → POST callback → tokens + user |
| Repeat login same user | `github.test.ts` | Same providerUserId → same user.id |
| Consumed state rejection | `github.test.ts` | State used twice → 400 |
| Refresh after logout | `token.test.ts` | tokenVersion bump invalidates old refresh tokens |
| Expired access token | `token.test.ts` | 401 on protected route with expired JWT |
| Wrong audience token | `token.test.ts` | Bridge token rejected as access token |
| Missing user on /auth/me | `token.test.ts` | 404 when backing records deleted |