### PR TITLE
fix: use json response_format for gpt-4o-mini-transcribe compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "jsonwebtoken": "^9.0.3",
         "lru-cache": "^11.2.7",
         "mongodb": "^7.1.0",
+        "music-metadata": "^11.12.3",
         "openai": "^6.29.0",
         "zod": "^4.3.6"
       },
@@ -31,6 +32,16 @@
       },
       "engines": {
         "node": ">=22.22.0"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -881,6 +892,29 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1327,6 +1361,15 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -1359,7 +1402,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1845,6 +1887,24 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-type": {
+      "version": "21.3.3",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.3.tgz",
+      "integrity": "sha512-pNwbwz8c3aZ+GvbJnIsCnDjKvgCZLHxkFWLEFxU3RMa+Ey++ZSEfisvsWQMcdys6PpxQjWUOIDi1fifXsW3YRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/find-my-way": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.5.0.tgz",
@@ -1891,9 +1951,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1937,6 +1997,26 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -2208,6 +2288,15 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
@@ -2294,6 +2383,37 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/music-metadata": {
+      "version": "11.12.3",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.12.3.tgz",
+      "integrity": "sha512-n6hSTZkuD59qWgHh6IP5dtDlDZQXoxk/bcA85Jywg8Z1iFrlNgl2+GTFgjZyn52W5UgQpV42V4XqrQZZAMbZTQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Borewit"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://buymeacoffee.com/borewit"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.2",
+        "@tokenizer/token": "^0.3.0",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "file-type": "^21.3.1",
+        "media-typer": "^1.1.0",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0",
+        "win-guid": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -2710,6 +2830,22 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/strtok3": {
+      "version": "10.3.4",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
+      "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -2762,6 +2898,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/tr46": {
@@ -2860,6 +3014,18 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -2914,6 +3080,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/win-guid": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/win-guid/-/win-guid-0.2.1.tgz",
+      "integrity": "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==",
+      "license": "MIT"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jsonwebtoken": "^9.0.3",
     "lru-cache": "^11.2.7",
     "mongodb": "^7.1.0",
+    "music-metadata": "^11.12.3",
     "openai": "^6.29.0",
     "zod": "^4.3.6"
   },

--- a/src/clients/openai-client.ts
+++ b/src/clients/openai-client.ts
@@ -1,4 +1,5 @@
 import OpenAI, { toFile } from "openai";
+import { parseBuffer } from "music-metadata";
 
 let client: OpenAI | null = null;
 let transcriptionModel: string = "gpt-4o-mini-transcribe";
@@ -27,14 +28,26 @@ export class OpenAIClient {
 
     const file = await toFile(args.fileBuffer, args.filename, { type: args.mimetype });
 
-    const response = await client.audio.transcriptions.create({
-      file,
-      model: transcriptionModel,
-      language: "en",
-      response_format: "verbose_json",
-      ...(args.prompt ? { prompt: args.prompt } : {}),
-    });
+    const [response, durationSeconds] = await Promise.all([
+      client.audio.transcriptions.create({
+        file,
+        model: transcriptionModel,
+        language: "en",
+        response_format: "json",
+        ...(args.prompt ? { prompt: args.prompt } : {}),
+      }),
+      OpenAIClient.parseAudioDuration(args.fileBuffer, args.mimetype),
+    ]);
 
-    return { text: response.text, durationSeconds: response.duration ?? 0 };
+    return { text: response.text, durationSeconds };
+  }
+
+  private static async parseAudioDuration(buffer: Buffer, mimeType: string): Promise<number> {
+    try {
+      const metadata = await parseBuffer(buffer, { mimeType });
+      return metadata.format.duration ?? 0;
+    } catch {
+      return 0;
+    }
   }
 }

--- a/src/clients/openai-client.ts
+++ b/src/clients/openai-client.ts
@@ -45,7 +45,7 @@ export class OpenAIClient {
   private static async parseAudioDuration(buffer: Buffer, mimeType: string): Promise<number> {
     try {
       const metadata = await parseBuffer(buffer, { mimeType });
-      if (metadata.format.duration != null && metadata.format.duration > 0) {
+      if (metadata.format.duration !== undefined && metadata.format.duration > 0) {
         return metadata.format.duration;
       }
       console.warn(

--- a/src/clients/openai-client.ts
+++ b/src/clients/openai-client.ts
@@ -45,9 +45,31 @@ export class OpenAIClient {
   private static async parseAudioDuration(buffer: Buffer, mimeType: string): Promise<number> {
     try {
       const metadata = await parseBuffer(buffer, { mimeType });
-      return metadata.format.duration ?? 0;
-    } catch {
-      return 0;
+      if (metadata.format.duration != null && metadata.format.duration > 0) {
+        return metadata.format.duration;
+      }
+      console.warn(
+        `[OpenAIClient] Audio metadata missing duration (mime=${mimeType}, size=${buffer.length}), using size-based estimate`,
+      );
+    } catch (error) {
+      console.error(
+        `[OpenAIClient] Failed to parse audio metadata (mime=${mimeType}, size=${buffer.length}), using size-based estimate`,
+        error,
+      );
     }
+
+    return OpenAIClient.estimateDurationFromSize(buffer.length, mimeType);
+  }
+
+  /**
+   * Conservative byte-rate estimate for voice recordings.
+   * - Uncompressed (WAV/PCM): ~96 KB/s  (16-bit, 48 kHz, mono)
+   * - Compressed (MP3/AAC/Opus/WebM): ~16 KB/s  (128 kbps)
+   * Uses Math.ceil so we never under-count against the daily quota.
+   */
+  private static estimateDurationFromSize(bytes: number, mimeType: string): number {
+    const isUncompressed = mimeType.includes("wav") || mimeType.includes("pcm");
+    const bytesPerSecond = isUncompressed ? 96_000 : 16_000;
+    return Math.ceil(bytes / bytesPerSecond);
   }
 }


### PR DESCRIPTION
## Summary

- **Fix**: `gpt-4o-mini-transcribe` rejects `response_format: "verbose_json"` — switch to `"json"`
- **Duration tracking preserved**: Parse audio duration client-side via `music-metadata` (runs in parallel with the API call via `Promise.all`) so daily quota tracking continues to work
- **npm audit fix**: Resolved 1 high-severity vulnerability (`flatted` bump)

## Changes

- `src/clients/openai-client.ts` — `response_format: "verbose_json"` → `"json"`, added `parseAudioDuration()` using `music-metadata`
- `package.json` / `package-lock.json` — added `music-metadata` dependency, audit fix