### PR TITLE
chore: add Contributor License Agreement (CLA)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,41 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://github.com/sesori-ai/sesori_auth_server/blob/master/CLA.md'
+          branch: 'master'
+          allowlist: bot*,dependabot*,github-actions*,*[bot],web-flow
+          custom-notsigned-prcomment: |
+            Thank you for your contribution! Before we can merge this PR, we need you to sign our [Contributor License Agreement (CLA)](https://github.com/sesori-ai/sesori_auth_server/blob/master/CLA.md).
+
+            **To sign the CLA**, please comment on this PR with:
+            ```
+            I have read the CLA Document and I hereby sign the CLA
+            ```
+
+            This is a one-time requirement. Once signed, all your future contributions will be automatically accepted.
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-allsigned-prcomment: |
+            All contributors have signed the CLA. Thank you!
+          lock-pullrequest-aftermerge: false

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,59 @@
+# Contributor License Agreement
+
+In order to clarify the intellectual property license granted with Contributions from any person or entity, Digitalblock Labs LTD ("Owner"), a company registered in the British Virgin Islands, must have a Contributor License Agreement ("Agreement") on file that has been signed by each Contributor, indicating agreement to the license terms below. This license is for your protection as a Contributor as well as the protection of the Owner and the Project; it does not change your rights to use your own Contributions for any other purpose.
+
+You accept and agree to the following terms and conditions for Your present and future Contributions submitted to the Project. Except for the license granted herein to the Owner and recipients of software distributed by the Owner, You reserve all right, title, and interest in and to Your Contributions.
+
+## 1. Definitions
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized by the copyright owner that is making this Agreement with the Owner. For legal entities, the entity making a Contribution and all other entities that control, are controlled by, or are under common control with that entity are considered to be a single Contributor. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to the Owner for inclusion in, or documentation of, the Sesori project (https://github.com/sesori-ai/sesori_auth_server) and any associated repositories owned or managed by the Owner (the "Work"). For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Owner or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Owner for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the Owner and to recipients of software distributed by the Owner a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the Owner and to recipients of software distributed by the Owner a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was submitted. If any entity institutes patent litigation against You or any other entity (including a cross-claim or counterclaim in a lawsuit) alleging that your Contribution, or the Work to which you have contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that Contribution or Work shall terminate as of the date such litigation is filed.
+
+## 4. Representations
+
+You represent that You are legally entitled to grant the above licenses. If Your employer(s) has rights to intellectual property that You create that includes Your Contributions, You represent that You have received permission to make Contributions on behalf of that employer, that Your employer has waived such rights for Your Contributions to the Project, or that Your employer has executed a separate agreement with the Owner.
+
+## 5. Original Work
+
+You represent that each of Your Contributions is Your original creation (see Section 7 for submissions on behalf of others). You represent that Your Contribution submissions include complete details of any third-party license or other restriction (including, but not limited to, related patents and trademarks) of which You are personally aware and which are associated with any part of Your Contributions.
+
+## 6. No Warranty
+
+You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. You may provide support for free, for a fee, or not at all. Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Third-Party Work
+
+Should You wish to submit work that is not Your original creation, You may submit it to the Owner separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which You are personally aware, and conspicuously marking the work as "Submitted on behalf of a third-party: [named here]".
+
+## 8. Notification
+
+You agree to notify the Owner of any facts or circumstances of which You become aware that would make these representations inaccurate in any respect.
+
+## 9. Governing Law
+
+This Agreement shall be governed by and construed in accordance with the laws of the British Virgin Islands, without regard to conflict of laws principles. Any disputes arising under or in connection with this Agreement shall be subject to the exclusive jurisdiction of the courts of the British Virgin Islands.
+
+## 10. Entire Agreement
+
+This Agreement constitutes the entire agreement between the parties with respect to the subject matter hereof and supersedes all prior or contemporaneous understandings, agreements, representations, and warranties, whether written or oral, regarding such subject matter.
+
+---
+
+## How to Sign
+
+To sign the CLA, please comment on a pull request with:
+
+```
+I have read the CLA Document and I hereby sign the CLA
+```
+
+The CLA Assistant bot will automatically track your agreement. This is a one-time requirement. If you have any questions, please open an issue.

--- a/signatures/cla.json
+++ b/signatures/cla.json
@@ -1,0 +1,3 @@
+{
+  "signedContributors": []
+}


### PR DESCRIPTION
## Summary

- Add CLA based on the Google/Apache Individual Contributor License Agreement template
- Add GitHub Actions CLA workflow (`contributor-assistant/github-action@v2.6.1`) to enforce signing on all PRs
- Add `signatures/cla.json` to track contributor signatures

## CLA Details

- **Owner:** Digitalblock Labs LTD (British Virgin Islands)
- **Template:** Google/Apache ICLA (industry standard)
- **Scope:** Scoped to this repository and associated repos
- **Sections:** Copyright license, Patent license (with defensive termination), Representations, Original work, No warranty (AS IS), Third-party work, Notification, Governing law (BVI), Entire agreement
- **Allowlist:** Bots only — all human contributors must sign