### PR TITLE
feat: allow localhost/loopback redirect URIs

### DIFF
--- a/src/lib/redirect-uri.ts
+++ b/src/lib/redirect-uri.ts
@@ -1,0 +1,13 @@
+export function isAllowedRedirectUri(redirectUri: string, allowedRedirectUris: string[]): boolean {
+  if (allowedRedirectUris.includes(redirectUri)) {
+    return true;
+  }
+
+  try {
+    const url = new URL(redirectUri);
+    const hostname = url.hostname;
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+  } catch {
+    return false;
+  }
+}

--- a/src/routes/github.ts
+++ b/src/routes/github.ts
@@ -4,6 +4,7 @@ import type { GithubClient } from "../clients/auth/github-client.js";
 import { OAuthProviderName } from "../types/oauth.js";
 import type { Config } from "../config.js";
 import { BadRequestError } from "../lib/errors.js";
+import { isAllowedRedirectUri } from "../lib/redirect-uri.js";
 import type { StateStore } from "../lib/state-store.js";
 import type { OAuthInitQuery, OAuthInitReply, OAuthCallbackBody, AuthTokensReply } from "../models/api.js";
 import type { AuthService } from "../services/auth-service.js";
@@ -38,7 +39,7 @@ export const githubRoutes: FastifyPluginAsync<GithubRouteOptions> = async (fasti
     }
 
     const { redirect_uri, code_challenge, code_challenge_method } = queryResult.data;
-    if (!config.ALLOWED_REDIRECT_URIS.includes(redirect_uri)) {
+    if (!isAllowedRedirectUri(redirect_uri, config.ALLOWED_REDIRECT_URIS)) {
       throw new BadRequestError({ debugMessage: "Redirect URI not allowed" });
     }
 
@@ -64,7 +65,7 @@ export const githubRoutes: FastifyPluginAsync<GithubRouteOptions> = async (fasti
     }
 
     const { code, codeVerifier, state, redirectUri } = bodyResult.data;
-    if (!config.ALLOWED_REDIRECT_URIS.includes(redirectUri)) {
+    if (!isAllowedRedirectUri(redirectUri, config.ALLOWED_REDIRECT_URIS)) {
       throw new BadRequestError({ debugMessage: "Redirect URI not allowed" });
     }
 

--- a/src/routes/google.ts
+++ b/src/routes/google.ts
@@ -4,6 +4,7 @@ import type { GoogleClient } from "../clients/auth/google-client.js";
 import { OAuthProviderName } from "../types/oauth.js";
 import type { Config } from "../config.js";
 import { BadRequestError } from "../lib/errors.js";
+import { isAllowedRedirectUri } from "../lib/redirect-uri.js";
 import type { StateStore } from "../lib/state-store.js";
 import type { OAuthInitQuery, OAuthInitReply, OAuthCallbackBody, AuthTokensReply } from "../models/api.js";
 import type { AuthService } from "../services/auth-service.js";
@@ -38,7 +39,7 @@ export const googleRoutes: FastifyPluginAsync<GoogleRouteOptions> = async (fasti
     }
 
     const { redirect_uri, code_challenge, code_challenge_method } = queryResult.data;
-    if (!config.ALLOWED_REDIRECT_URIS.includes(redirect_uri)) {
+    if (!isAllowedRedirectUri(redirect_uri, config.ALLOWED_REDIRECT_URIS)) {
       throw new BadRequestError({ debugMessage: "Redirect URI not allowed" });
     }
 
@@ -67,7 +68,7 @@ export const googleRoutes: FastifyPluginAsync<GoogleRouteOptions> = async (fasti
     }
 
     const { code, codeVerifier, state, redirectUri } = bodyResult.data;
-    if (!config.ALLOWED_REDIRECT_URIS.includes(redirectUri)) {
+    if (!isAllowedRedirectUri(redirectUri, config.ALLOWED_REDIRECT_URIS)) {
       throw new BadRequestError({ debugMessage: "Redirect URI not allowed" });
     }
 

--- a/tests/auth/github.test.ts
+++ b/tests/auth/github.test.ts
@@ -89,6 +89,39 @@ describe("GitHub OAuth routes", () => {
 
       assert.equal(res.statusCode, 400);
     });
+
+    it("allows localhost redirect URI even if not in allow-list", async () => {
+      const localhostUri = "http://localhost:3000/callback";
+      const res = await ctx.app.inject({
+        method: "GET",
+        url: `/auth/github?redirect_uri=${encodeURIComponent(localhostUri)}&code_challenge=${VALID_CODE_CHALLENGE}&code_challenge_method=S256`,
+      });
+
+      assert.equal(res.statusCode, 200);
+      const body = res.json<{ authUrl: string; state: string }>();
+      const url = new URL(body.authUrl);
+      assert.equal(url.searchParams.get("redirect_uri"), localhostUri);
+    });
+
+    it("allows 127.0.0.1 redirect URI even if not in allow-list", async () => {
+      const loopbackUri = "http://127.0.0.1:8080/callback";
+      const res = await ctx.app.inject({
+        method: "GET",
+        url: `/auth/github?redirect_uri=${encodeURIComponent(loopbackUri)}&code_challenge=${VALID_CODE_CHALLENGE}&code_challenge_method=S256`,
+      });
+
+      assert.equal(res.statusCode, 200);
+    });
+
+    it("rejects a remote redirect URI not in allow-list", async () => {
+      const remoteUri = "https://evil.com/callback";
+      const res = await ctx.app.inject({
+        method: "GET",
+        url: `/auth/github?redirect_uri=${encodeURIComponent(remoteUri)}&code_challenge=${VALID_CODE_CHALLENGE}&code_challenge_method=S256`,
+      });
+
+      assert.equal(res.statusCode, 400);
+    });
   });
 
   // ── POST /auth/github/callback ──────────────────────────────────────────────

--- a/tests/auth/google.test.ts
+++ b/tests/auth/google.test.ts
@@ -86,6 +86,39 @@ describe("Google OAuth routes", () => {
 
       assert.equal(res.statusCode, 400);
     });
+
+    it("allows localhost redirect URI even if not in allow-list", async () => {
+      const localhostUri = "http://localhost:3000/callback";
+      const res = await ctx.app.inject({
+        method: "GET",
+        url: `/auth/google?redirect_uri=${encodeURIComponent(localhostUri)}&code_challenge=${VALID_CODE_CHALLENGE}&code_challenge_method=S256`,
+      });
+
+      assert.equal(res.statusCode, 200);
+      const body = res.json<{ authUrl: string; state: string }>();
+      const url = new URL(body.authUrl);
+      assert.equal(url.searchParams.get("redirect_uri"), localhostUri);
+    });
+
+    it("allows 127.0.0.1 redirect URI even if not in allow-list", async () => {
+      const loopbackUri = "http://127.0.0.1:8080/callback";
+      const res = await ctx.app.inject({
+        method: "GET",
+        url: `/auth/google?redirect_uri=${encodeURIComponent(loopbackUri)}&code_challenge=${VALID_CODE_CHALLENGE}&code_challenge_method=S256`,
+      });
+
+      assert.equal(res.statusCode, 200);
+    });
+
+    it("rejects a remote redirect URI not in allow-list", async () => {
+      const remoteUri = "https://evil.com/callback";
+      const res = await ctx.app.inject({
+        method: "GET",
+        url: `/auth/google?redirect_uri=${encodeURIComponent(remoteUri)}&code_challenge=${VALID_CODE_CHALLENGE}&code_challenge_method=S256`,
+      });
+
+      assert.equal(res.statusCode, 400);
+    });
   });
 
   // ── POST /auth/google/callback ──────────────────────────────────────────────

--- a/tests/lib/redirect-uri.test.ts
+++ b/tests/lib/redirect-uri.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isAllowedRedirectUri } from "../../src/lib/redirect-uri.js";
+
+const ALLOWED = ["myapp://oauth/callback"];
+
+describe("isAllowedRedirectUri", () => {
+  it("allows a URI that is in the allow-list", () => {
+    assert.equal(isAllowedRedirectUri("myapp://oauth/callback", ALLOWED), true);
+  });
+
+  it("rejects a URI that is not in the allow-list and not localhost", () => {
+    assert.equal(isAllowedRedirectUri("https://evil.com/callback", ALLOWED), false);
+  });
+
+  it("allows http://localhost redirect", () => {
+    assert.equal(isAllowedRedirectUri("http://localhost:3000/callback", ALLOWED), true);
+  });
+
+  it("allows http://localhost without port", () => {
+    assert.equal(isAllowedRedirectUri("http://localhost/callback", ALLOWED), true);
+  });
+
+  it("allows http://127.0.0.1 redirect", () => {
+    assert.equal(isAllowedRedirectUri("http://127.0.0.1:8080/callback", ALLOWED), true);
+  });
+
+  it("allows http://127.0.0.1 without port", () => {
+    assert.equal(isAllowedRedirectUri("http://127.0.0.1/callback", ALLOWED), true);
+  });
+
+  it("allows http://[::1] redirect", () => {
+    assert.equal(isAllowedRedirectUri("http://[::1]:3000/callback", ALLOWED), true);
+  });
+
+  it("allows http://[::1] without port", () => {
+    assert.equal(isAllowedRedirectUri("http://[::1]/callback", ALLOWED), true);
+  });
+
+  it("rejects an invalid URI that is not in the allow-list", () => {
+    assert.equal(isAllowedRedirectUri("not-a-valid-url", ALLOWED), false);
+  });
+
+  it("rejects a remote host even if it contains 'localhost' in the path", () => {
+    assert.equal(isAllowedRedirectUri("https://evil.com/localhost", ALLOWED), false);
+  });
+
+  it("rejects a subdomain of localhost", () => {
+    assert.equal(isAllowedRedirectUri("http://sub.localhost:3000/callback", ALLOWED), false);
+  });
+
+  it("allows with an empty allow-list if URI is localhost", () => {
+    assert.equal(isAllowedRedirectUri("http://localhost:3000/callback", []), true);
+  });
+
+  it("rejects with an empty allow-list if URI is not localhost", () => {
+    assert.equal(isAllowedRedirectUri("https://example.com/callback", []), false);
+  });
+});


### PR DESCRIPTION
## Summary
- Extracted redirect URI validation into a shared `isAllowedRedirectUri()` helper (`src/lib/redirect-uri.ts`)
- URIs targeting `localhost`, `127.0.0.1`, or `[::1]` are now always accepted, preventing unexpected remote redirects while keeping local development frictionless
- Updated both GitHub and Google OAuth routes (init + callback) to use the new helper

## Test plan
- [x] 13 unit tests for `isAllowedRedirectUri` covering: allow-listed URIs, localhost/127.0.0.1/::1 with and without ports, rejection of remote hosts, subdomains of localhost, invalid URIs, and edge cases
- [x] 3 new integration tests each for GitHub and Google routes: localhost allowed, 127.0.0.1 allowed, remote URI rejected
- [ ] CI integration tests pass with MongoDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)