### PR TITLE
fix: debounce bridge status push notifications to prevent flicker spam

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { OAuthAccountRepository } from "./repositories/oauth-account-repo.js";
 import { UserRepository } from "./repositories/user-repo.js";
 import { buildApp } from "./server.js";
 import { AuthService } from "./services/auth-service.js";
+import { BridgeStateTracker } from "./services/bridge-state-tracker.js";
 import { NotificationService } from "./services/notification-service.js";
 import { SessionMetadataService } from "./services/session-metadata-service.js";
 import { TokenService } from "./services/token-service.js";
@@ -71,6 +72,7 @@ async function main() {
   }
 
   const notificationService = new NotificationService(deviceTokenRepo, messaging);
+  const bridgeStateTracker = new BridgeStateTracker(notificationService);
 
   const openai = new OpenAIClient({ apiKey: config.OPENAI_API_KEY, model: config.OPENAI_TRANSCRIPTION_MODEL });
   console.log(`OpenAI client initialized (model: ${config.OPENAI_TRANSCRIPTION_MODEL})`);
@@ -100,6 +102,7 @@ async function main() {
     sessionMetadataService,
     deviceTokenRepo,
     notificationService,
+    bridgeStateTracker,
     stateStore,
     githubClient,
     googleClient,
@@ -112,6 +115,7 @@ async function main() {
   for (const signal of signals) {
     process.on(signal, async () => {
       console.log(`Received ${signal}, shutting down gracefully...`);
+      bridgeStateTracker.dispose();
       await app.close();
       await dbConnector.close();
       process.exit(0);

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -9,11 +9,13 @@ import {
   type BridgeStatusBody,
 } from "../models/api.js";
 import type { DeviceTokenRepository } from "../repositories/device-token-repo.js";
+import type { BridgeStateTracker } from "../services/bridge-state-tracker.js";
 import type { NotificationService } from "../services/notification-service.js";
 
 export type NotificationRouteOptions = {
   deviceTokenRepo: DeviceTokenRepository;
   notificationService: NotificationService;
+  bridgeStateTracker: BridgeStateTracker;
   requireAuth: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
   requireRelayAuth: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
 };
@@ -24,7 +26,7 @@ function getUserId(request: FastifyRequest): string {
 }
 
 export const notificationRoutes: FastifyPluginAsync<NotificationRouteOptions> = async (fastify, opts) => {
-  const { deviceTokenRepo, notificationService, requireAuth, requireRelayAuth } = opts;
+  const { deviceTokenRepo, notificationService, bridgeStateTracker, requireAuth, requireRelayAuth } = opts;
 
   fastify.post<{ Body: RegisterTokenBody; Reply: { ok: true } }>(
     "/notifications/register-token",
@@ -76,23 +78,7 @@ export const notificationRoutes: FastifyPluginAsync<NotificationRouteOptions> = 
         throw new BadRequestError({ debugMessage: "Invalid request body", nestedError: bodyResult.error.issues });
       }
 
-      if (bodyResult.data.status === "disconnected") {
-        await notificationService.sendToUser(bodyResult.data.userId, {
-          category: "connection_status",
-          title: "Bridge Offline",
-          body: "Your bridge has disconnected. AI sessions are paused.",
-          collapseKey: "connection_status",
-        });
-      }
-
-      if (bodyResult.data.status === "connected") {
-        await notificationService.sendToUser(bodyResult.data.userId, {
-          category: "connection_status",
-          title: "Bridge Online",
-          body: "Your bridge has reconnected.",
-          collapseKey: "connection_status",
-        });
-      }
+      bridgeStateTracker.handleStatusChange(bodyResult.data.userId, bodyResult.data.status);
 
       return { ok: true };
     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import { createRelayAuthMiddleware } from "./middleware/relay-auth.js";
 import type { HealthReply } from "./models/api.js";
 import type { DeviceTokenRepository } from "./repositories/device-token-repo.js";
 import type { AuthService } from "./services/auth-service.js";
+import type { BridgeStateTracker } from "./services/bridge-state-tracker.js";
 import type { NotificationService } from "./services/notification-service.js";
 import type { TokenService } from "./services/token-service.js";
 import type { VoiceService } from "./services/voice-service.js";
@@ -30,6 +31,7 @@ export type AppServices = {
   sessionMetadataService: SessionMetadataService;
   deviceTokenRepo: DeviceTokenRepository;
   notificationService: NotificationService;
+  bridgeStateTracker: BridgeStateTracker;
   stateStore: StateStore;
   githubClient: GithubClient;
   googleClient: GoogleClient;
@@ -95,6 +97,7 @@ export async function buildApp(services: AppServices): Promise<FastifyInstance> 
   await app.register(notificationRoutes, {
     deviceTokenRepo: services.deviceTokenRepo,
     notificationService: services.notificationService,
+    bridgeStateTracker: services.bridgeStateTracker,
     requireAuth,
     requireRelayAuth,
   });

--- a/src/services/bridge-state-tracker.ts
+++ b/src/services/bridge-state-tracker.ts
@@ -1,0 +1,105 @@
+import type { BridgeStatusBody } from "../models/api.js";
+import type { NotificationPayload, NotificationService } from "./notification-service.js";
+
+type BridgeStatus = BridgeStatusBody["status"];
+
+type BridgeStateEntry = {
+  pendingStatus: BridgeStatus | null;
+  lastNotifiedStatus: BridgeStatus | null;
+  timer: ReturnType<typeof setTimeout> | null;
+  generation: number;
+};
+
+export class BridgeStateTracker {
+  readonly #notificationService: NotificationService;
+  readonly #debounceMs: number;
+  readonly #state = new Map<string, BridgeStateEntry>();
+
+  constructor(notificationService: NotificationService, debounceMs: number = 60_000) {
+    this.#notificationService = notificationService;
+    this.#debounceMs = debounceMs;
+  }
+
+  handleStatusChange(userId: string, status: BridgeStatus): void {
+    const entry = this.#getOrCreateEntry(userId);
+
+    if (status === entry.pendingStatus) {
+      return;
+    }
+
+    if (entry.timer) {
+      clearTimeout(entry.timer);
+      entry.timer = null;
+      entry.pendingStatus = null;
+    }
+
+    if (status === entry.lastNotifiedStatus) {
+      return;
+    }
+
+    entry.generation += 1;
+    const capturedGeneration = entry.generation;
+    entry.pendingStatus = status;
+    entry.timer = setTimeout(async () => {
+      if (entry.generation !== capturedGeneration) {
+        return;
+      }
+
+      try {
+        await this.#notificationService.sendToUser(userId, this.#buildPayload(status));
+      } catch (err) {
+        console.warn("Bridge notification failed", { userId, status, err });
+      } finally {
+        if (entry.generation === capturedGeneration) {
+          entry.lastNotifiedStatus = status;
+          entry.pendingStatus = null;
+          entry.timer = null;
+        }
+      }
+    }, this.#debounceMs);
+  }
+
+  dispose(): void {
+    for (const entry of this.#state.values()) {
+      if (entry.timer) {
+        clearTimeout(entry.timer);
+      }
+    }
+
+    this.#state.clear();
+  }
+
+  #getOrCreateEntry(userId: string): BridgeStateEntry {
+    const existingEntry = this.#state.get(userId);
+    if (existingEntry) {
+      return existingEntry;
+    }
+
+    const entry: BridgeStateEntry = {
+      pendingStatus: null,
+      lastNotifiedStatus: null,
+      timer: null,
+      generation: 0,
+    };
+    this.#state.set(userId, entry);
+    return entry;
+  }
+
+  #buildPayload(status: BridgeStatus): NotificationPayload {
+    if (status === "connected") {
+      return {
+        category: "connection_status",
+        title: "Bridge Online",
+        body: "Your bridge has reconnected.",
+        collapseKey: "connection_status",
+      };
+    }
+
+    return {
+      category: "connection_status",
+      title: "Bridge Offline",
+      body: "Your bridge has disconnected. AI sessions are paused.",
+      collapseKey: "connection_status",
+    };
+  }
+}

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -18,6 +18,7 @@ import { OAuthAccountRepository } from "../../src/repositories/oauth-account-rep
 import { UserRepository } from "../../src/repositories/user-repo.js";
 import { buildApp } from "../../src/server.js";
 import { AuthService } from "../../src/services/auth-service.js";
+import { BridgeStateTracker } from "../../src/services/bridge-state-tracker.js";
 import { NotificationService } from "../../src/services/notification-service.js";
 import { SessionMetadataService } from "../../src/services/session-metadata-service.js";
 import { TokenService } from "../../src/services/token-service.js";
@@ -51,6 +52,7 @@ export type TestAppOverrides = {
   githubClient?: OAuthClient;
   googleClient?: OAuthClient;
   notificationService?: NotificationService;
+  bridgeStateTracker?: BridgeStateTracker;
   sessionMetadataService?: SessionMetadataService;
 };
 
@@ -117,6 +119,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
   const authService = new AuthService({ tokenService, userRepo, oauthAccountRepo });
   const voiceService = new VoiceService({ openai, glossaryRepo, dailyUsageRepo });
   const notificationService = overrides?.notificationService ?? new NotificationService(deviceTokenRepo, null);
+  const bridgeStateTracker = overrides?.bridgeStateTracker ?? new BridgeStateTracker(notificationService);
   const sessionMetadataService =
     overrides?.sessionMetadataService ?? new SessionMetadataService({ openai, dailyUsageRepo, model: "gpt-4o-mini" });
 
@@ -128,6 +131,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
     sessionMetadataService,
     deviceTokenRepo,
     notificationService,
+    bridgeStateTracker,
     stateStore,
     githubClient: githubClient as GithubClient,
     googleClient: googleClient as GoogleClient,
@@ -212,6 +216,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
   }
 
   async function cleanup(): Promise<void> {
+    bridgeStateTracker.dispose();
     await app.close();
     await dbAccessor.getDb(MongoDbDatabase.Auth).dropDatabase();
     await dbConnector.close();

--- a/tests/notifications/bridge-state-tracker.test.ts
+++ b/tests/notifications/bridge-state-tracker.test.ts
@@ -1,0 +1,347 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it, mock } from "node:test";
+import { BridgeStateTracker } from "../../src/services/bridge-state-tracker.js";
+import type { NotificationPayload, NotificationService } from "../../src/services/notification-service.js";
+
+type SendCall = {
+  userId: string;
+  payload: NotificationPayload;
+};
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+const DEBOUNCE_MS = 60_000;
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>["resolve"];
+  let reject!: Deferred<T>["reject"];
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function connectedPayload(): NotificationPayload {
+  return {
+    category: "connection_status",
+    title: "Bridge Online",
+    body: "Your bridge has reconnected.",
+    collapseKey: "connection_status",
+  };
+}
+
+function disconnectedPayload(): NotificationPayload {
+  return {
+    category: "connection_status",
+    title: "Bridge Offline",
+    body: "Your bridge has disconnected. AI sessions are paused.",
+    collapseKey: "connection_status",
+  };
+}
+
+describe("BridgeStateTracker", () => {
+  beforeEach(() => {
+    mock.timers.enable({ apis: ["setTimeout"] });
+  });
+
+  afterEach(() => {
+    mock.timers.reset();
+  });
+
+  it("stable connected notifies after debounce", async () => {
+    const sendCalls: SendCall[] = [];
+    const notificationServiceMock = {
+      sendToUser: async (userId: string, payload: NotificationPayload) => {
+        sendCalls.push({ userId, payload });
+        return { devicesNotified: 1 };
+      },
+    } as unknown as NotificationService;
+    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+
+    tracker.handleStatusChange("user-1", "connected");
+
+    mock.timers.tick(DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    assert.deepEqual(sendCalls, [{ userId: "user-1", payload: connectedPayload() }]);
+  });
+
+  it("stable disconnected notifies after debounce", async () => {
+    const sendCalls: SendCall[] = [];
+    const notificationServiceMock = {
+      sendToUser: async (userId: string, payload: NotificationPayload) => {
+        sendCalls.push({ userId, payload });
+        return { devicesNotified: 1 };
+      },
+    } as unknown as NotificationService;
+    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+
+    tracker.handleStatusChange("user-1", "disconnected");
+
+    mock.timers.tick(DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    assert.deepEqual(sendCalls, [{ userId: "user-1", payload: disconnectedPayload() }]);
+  });
+
+  it("flicker absorbed no notification", async () => {
+    const sendCalls: SendCall[] = [];
+    const notificationServiceMock = {
+      sendToUser: async (userId: string, payload: NotificationPayload) => {
+        sendCalls.push({ userId, payload });
+        return { devicesNotified: 1 };
+      },
+    } as unknown as NotificationService;
+    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+
+    tracker.handleStatusChange("user-1", "connected");
+    mock.timers.tick(30_000);
+    tracker.handleStatusChange("user-1", "disconnected");
+    mock.timers.tick(30_000);
+    tracker.handleStatusChange("user-1", "connected");
+
+    mock.timers.tick(DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    assert.equal(sendCalls.length, 1);
+    assert.deepEqual(sendCalls[0], { userId: "user-1", payload: connectedPayload() });
+  });
+
+  it("rapid flicker only final state notifies", async () => {
+    const sendCalls: SendCall[] = [];
+    const notificationServiceMock = {
+      sendToUser: async (userId: string, payload: NotificationPayload) => {
+        sendCalls.push({ userId, payload });
+        return { devicesNotified: 1 };
+      },
+    } as unknown as NotificationService;
+    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+
+    tracker.handleStatusChange("user-1", "connected");
+    mock.timers.tick(5_000);
+    tracker.handleStatusChange("user-1", "disconnected");
+    mock.timers.tick(5_000);
+    tracker.handleStatusChange("user-1", "connected");
+    mock.timers.tick(5_000);
+    tracker.handleStatusChange("user-1", "disconnected");
+
+    mock.timers.tick(DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    assert.deepEqual(sendCalls, [{ userId: "user-1", payload: disconnectedPayload() }]);
+  });
+
+  it("same status repeated timer not restarted", async () => {
+    const sendCalls: SendCall[] = [];
+    const notificationServiceMock = {
+      sendToUser: async (userId: string, payload: NotificationPayload) => {
+        sendCalls.push({ userId, payload });
+        return { devicesNotified: 1 };
+      },
+    } as unknown as NotificationService;
+    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+
+    tracker.handleStatusChange("user-1", "connected");
+    mock.timers.tick(30_000);
+    tracker.handleStatusChange("user-1", "connected");
+    mock.timers.tick(30_000);
+    await flushMicrotasks();
+
+    assert.deepEqual(sendCalls, [{ userId: "user-1", payload: connectedPayload() }]);
+  });
+
+  it("redundant after notification skipped", async () => {
+    const sendCalls: SendCall[] = [];
+    const notificationServiceMock = {
+      sendToUser: async (userId: string, payload: NotificationPayload) => {
+        sendCalls.push({ userId, payload });
+        return { devicesNotified: 1 };
+      },
+    } as unknown as NotificationService;
+    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+
+    tracker.handleStatusChange("user-1", "connected");
+    mock.timers.tick(DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    tracker.handleStatusChange("user-1", "connected");
+    mock.timers.tick(DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    assert.deepEqual(sendCalls, [{ userId: "user-1", payload: connectedPayload() }]);
+  });
+
+  it("multi-user isolation", async () => {
+    const sendCalls: SendCall[] = [];
+    const notificationServiceMock = {
+      sendToUser: async (userId: string, payload: NotificationPayload) => {
+        sendCalls.push({ userId, payload });
+        return { devicesNotified: 1 };
+      },
+    } as unknown as NotificationService;
+    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+
+    tracker.handleStatusChange("user-a", "connected");
+    tracker.handleStatusChange("user-b", "disconnected");
+
+    mock.timers.tick(DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    assert.deepEqual(sendCalls, [
+      { userId: "user-a", payload: connectedPayload() },
+      { userId: "user-b", payload: disconnectedPayload() },
+    ]);
+  });
+
+  it("return-to-notified-state cancels silently", async () => {
+    const sendCalls: SendCall[] = [];
+    const notificationServiceMock = {
+      sendToUser: async (userId: string, payload: NotificationPayload) => {
+        sendCalls.push({ userId, payload });
+        return { devicesNotified: 1 };
+      },
+    } as unknown as NotificationService;
+    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+
+    tracker.handleStatusChange("user-1", "connected");
+    mock.timers.tick(DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    tracker.handleStatusChange("user-1", "disconnected");
+    mock.timers.tick(30_000);
+    tracker.handleStatusChange("user-1", "connected");
+    mock.timers.tick(DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    assert.deepEqual(sendCalls, [{ userId: "user-1", payload: connectedPayload() }]);
+  });
+
+  it("dispose clears all pending timers", async () => {
+    const sendCalls: SendCall[] = [];
+    const notificationServiceMock = {
+      sendToUser: async (userId: string, payload: NotificationPayload) => {
+        sendCalls.push({ userId, payload });
+        return { devicesNotified: 1 };
+      },
+    } as unknown as NotificationService;
+    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+
+    tracker.handleStatusChange("user-1", "connected");
+    tracker.handleStatusChange("user-2", "disconnected");
+    tracker.handleStatusChange("user-3", "connected");
+    tracker.dispose();
+
+    mock.timers.tick(DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    assert.equal(sendCalls.length, 0);
+  });
+
+  it("notification payload correctness", async () => {
+    const sendCalls: SendCall[] = [];
+    const notificationServiceMock = {
+      sendToUser: async (userId: string, payload: NotificationPayload) => {
+        sendCalls.push({ userId, payload });
+        return { devicesNotified: 1 };
+      },
+    } as unknown as NotificationService;
+    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+
+    tracker.handleStatusChange("user-1", "connected");
+    tracker.handleStatusChange("user-2", "disconnected");
+    mock.timers.tick(DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    assert.deepEqual(sendCalls, [
+      { userId: "user-1", payload: connectedPayload() },
+      { userId: "user-2", payload: disconnectedPayload() },
+    ]);
+  });
+
+  it("sendToUser rejection is caught and new status change still works", async () => {
+    const sendCalls: SendCall[] = [];
+    let shouldReject = true;
+    const notificationServiceMock = {
+      sendToUser: async (userId: string, payload: NotificationPayload) => {
+        sendCalls.push({ userId, payload });
+        if (shouldReject) {
+          throw new Error("send failed");
+        }
+
+        return { devicesNotified: 1 };
+      },
+    } as unknown as NotificationService;
+    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+
+    tracker.handleStatusChange("user-1", "connected");
+    mock.timers.tick(DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    shouldReject = false;
+    tracker.handleStatusChange("user-1", "disconnected");
+    mock.timers.tick(DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    assert.deepEqual(sendCalls, [
+      { userId: "user-1", payload: connectedPayload() },
+      { userId: "user-1", payload: disconnectedPayload() },
+    ]);
+  });
+
+  it("stale async completion does not overwrite newer state", async () => {
+    const sendCalls: SendCall[] = [];
+    const firstSend = createDeferred<{ devicesNotified: number }>();
+    let invocation = 0;
+    const notificationServiceMock = {
+      sendToUser: (userId: string, payload: NotificationPayload) => {
+        sendCalls.push({ userId, payload });
+        invocation += 1;
+
+        if (invocation === 1) {
+          return firstSend.promise;
+        }
+
+        return Promise.resolve({ devicesNotified: 1 });
+      },
+    } as unknown as NotificationService;
+    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+
+    tracker.handleStatusChange("user-1", "connected");
+    mock.timers.tick(DEBOUNCE_MS);
+
+    tracker.handleStatusChange("user-1", "disconnected");
+    firstSend.resolve({ devicesNotified: 1 });
+    await flushMicrotasks();
+
+    mock.timers.tick(DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    assert.deepEqual(sendCalls, [
+      { userId: "user-1", payload: connectedPayload() },
+      { userId: "user-1", payload: disconnectedPayload() },
+    ]);
+  });
+
+  it("dispose is idempotent", () => {
+    const notificationServiceMock = {
+      sendToUser: async () => ({ devicesNotified: 1 }),
+    } as unknown as NotificationService;
+    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+
+    tracker.dispose();
+
+    assert.doesNotThrow(() => {
+      tracker.dispose();
+    });
+  });
+});

--- a/tests/notifications/routes.test.ts
+++ b/tests/notifications/routes.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { after, before, beforeEach, describe, it } from "node:test";
 import { DeviceTokenRepository } from "../../src/repositories/device-token-repo.js";
+import type { BridgeStateTracker } from "../../src/services/bridge-state-tracker.js";
 import type { NotificationService } from "../../src/services/notification-service.js";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
 
@@ -9,10 +10,16 @@ type SendCall = {
   payload: unknown;
 };
 
+type TrackerCall = {
+  userId: string;
+  status: string;
+};
+
 describe("Notification routes", () => {
   let ctx: TestContext;
   let deviceTokenRepo: DeviceTokenRepository;
   const sendCalls: SendCall[] = [];
+  const trackerCalls: TrackerCall[] = [];
 
   const notificationServiceMock = {
     sendToUser: async (userId: string, payload: unknown) => {
@@ -21,13 +28,24 @@ describe("Notification routes", () => {
     },
   } as unknown as NotificationService;
 
+  const bridgeStateTrackerMock = {
+    handleStatusChange: (userId: string, status: string) => {
+      trackerCalls.push({ userId, status });
+    },
+    dispose: () => {},
+  } as unknown as BridgeStateTracker;
+
   before(async () => {
-    ctx = await createTestApp({ notificationService: notificationServiceMock });
+    ctx = await createTestApp({
+      notificationService: notificationServiceMock,
+      bridgeStateTracker: bridgeStateTrackerMock,
+    });
     deviceTokenRepo = new DeviceTokenRepository(ctx.dbAccessor);
   });
 
   beforeEach(() => {
     sendCalls.length = 0;
+    trackerCalls.length = 0;
   });
 
   after(async () => {
@@ -181,14 +199,33 @@ describe("Notification routes", () => {
 
     assert.equal(res.statusCode, 200);
     assert.deepEqual(res.json(), { ok: true });
-    assert.equal(sendCalls.length, 1);
-    assert.equal(sendCalls[0]?.userId, user.userId);
-    assert.deepEqual(sendCalls[0]?.payload, {
-      category: "connection_status",
-      title: "Bridge Offline",
-      body: "Your bridge has disconnected. AI sessions are paused.",
-      collapseKey: "connection_status",
+    assert.equal(trackerCalls.length, 1);
+    assert.equal(trackerCalls[0]?.userId, user.userId);
+    assert.equal(trackerCalls[0]?.status, "disconnected");
+  });
+
+  it("POST /internal/bridge-status (connected) delegates to bridgeStateTracker", async () => {
+    const user = await ctx.createUser();
+
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/internal/bridge-status",
+      headers: {
+        "x-relay-secret": "test-relay-secret",
+        "content-type": "application/json",
+      },
+      payload: JSON.stringify({
+        userId: user.userId,
+        status: "connected",
+        timestamp: new Date().toISOString(),
+      }),
     });
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.json(), { ok: true });
+    assert.equal(trackerCalls.length, 1);
+    assert.equal(trackerCalls[0]?.userId, user.userId);
+    assert.equal(trackerCalls[0]?.status, "connected");
   });
 
   it("POST /internal/bridge-status returns 401 with missing or wrong secret", async () => {


### PR DESCRIPTION
## Summary

- Add `BridgeStateTracker` service with per-user in-memory debounce (60s stabilization window) to prevent push notification spam from brief bridge connectivity flickers (e.g., macOS sleep/wake cycles)
- Replace immediate notification dispatch in `/internal/bridge-status` endpoint with fire-and-forget delegation to the tracker
- Wire tracker into DI composition root with graceful shutdown cleanup (`dispose()` on SIGINT/SIGTERM)

## Problem

When a laptop goes to sleep and briefly wakes, the bridge rapidly connects/disconnects, causing a burst of "Bridge Online" → "Bridge Offline" push notifications. Every `POST /internal/bridge-status` from the relay immediately triggered an FCM notification with zero debounce.

## Solution

New `BridgeStateTracker` service sits between the route handler and `NotificationService`:

- **Per-user state tracking**: `Map<userId, {pendingStatus, lastNotifiedStatus, timer, generation}>`
- **60s debounce window**: Notification only fires after state is stable for 60 seconds
- **Flicker absorption**: Rapid state changes cancel pending timers; only final stable state notifies
- **Redundancy suppression**: Same-status-as-last-notified = skip (no duplicate notifications)
- **Generation counter**: Prevents stale async `sendToUser()` completions from corrupting state
- **Error resilience**: `try/catch/finally` in timer callback prevents unhandled rejections (Node 22)
- **Configurable**: Debounce duration is a constructor parameter (default 60000ms) for testability

## Changes

| File | Change |
|------|--------|
| `src/services/bridge-state-tracker.ts` | New debounce service (105 lines) |
| `tests/notifications/bridge-state-tracker.test.ts` | TDD test suite — 13 tests covering debounce, flicker, multi-user, error handling, stale async, dispose |
| `src/routes/notifications.ts` | Replace inline notification logic with `bridgeStateTracker.handleStatusChange()` |
| `src/server.ts` | Add `bridgeStateTracker` to `AppServices` type |
| `src/index.ts` | Wire DI + shutdown cleanup |
| `tests/helpers/setup.ts` | Add tracker override support |
| `tests/notifications/routes.test.ts` | Adapt bridge-status tests to verify delegation |

## Testing

- 13 unit tests (TDD, `node:test` + `mock.timers`) covering:
  - Stable state notification after debounce
  - Flicker absorption (rapid connect/disconnect → zero spam)
  - Same-status deduplication
  - Multi-user isolation
  - `sendToUser` rejection handling
  - Stale async completion protection (generation counter)
  - `dispose()` cleanup and idempotency
- Build: `npm run build` ✅
- Lint: `npm run lint` ✅

## Known Limitations

- **Single-instance only**: In-memory state, no cross-process coordination
- **Unbounded map**: Entries not evicted after last state change (fine for small user base)
- **Unused `timestamp`**: `BridgeStatusBody.timestamp` not used for ordering (relay delivers in order)