### PR TITLE
fix: preserve projectId in push notification data

### DIFF
--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -82,6 +82,7 @@ export const notificationDataSchema = z.object({
   category: z.string(),
   eventType: z.string().nullable().optional(),
   sessionId: z.string().nullable().optional(),
+  projectId: z.string().nullable().optional(),
 });
 
 export const sendNotificationBodySchema = z.object({

--- a/src/services/notification-service.ts
+++ b/src/services/notification-service.ts
@@ -5,6 +5,7 @@ export interface NotificationData {
   category: string;
   eventType?: string | null;
   sessionId?: string | null;
+  projectId?: string | null;
 }
 
 export interface NotificationPayload {
@@ -40,6 +41,7 @@ export class NotificationService {
       if (payload.data.category) flatData["category"] = payload.data.category;
       if (payload.data.eventType) flatData["eventType"] = payload.data.eventType;
       if (payload.data.sessionId) flatData["sessionId"] = payload.data.sessionId;
+      if (payload.data.projectId) flatData["projectId"] = payload.data.projectId;
     }
 
     const messages: Array<BaseMessage & { token: string }> = tokens.map((t) => ({

--- a/tests/notifications/notification-service.test.ts
+++ b/tests/notifications/notification-service.test.ts
@@ -48,7 +48,12 @@ const payload: NotificationPayload = {
   title: "New update",
   body: "You have a new message",
   collapseKey: "updates-collapse",
-  data: { screen: "inbox" },
+  data: {
+    category: "session_message",
+    eventType: "agent_turn_completed",
+    sessionId: "session-123",
+    projectId: "/Users/alexandrudochioiu/sesori-ai/sesori_apps_monorepo",
+  },
 };
 
 describe("NotificationService", () => {
@@ -70,6 +75,22 @@ describe("NotificationService", () => {
     const secondMessage = messaging.calls[0]?.[1] as { token?: string };
     assert.equal(firstMessage.token, "token-a");
     assert.equal(secondMessage.token, "token-b");
+  });
+
+  it("flattens projectId into FCM data payload", async () => {
+    const tokenRepo = createMockDeviceTokenRepo([{ userId: "user-1", token: "token-a", platform: "ios" }]);
+    const messaging = createMockMessaging([{ success: true }]);
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging);
+
+    await service.sendToUser("user-1", payload);
+
+    const firstMessage = messaging.calls[0]?.[0] as { data?: Record<string, string> };
+    assert.deepEqual(firstMessage.data, {
+      category: "session_message",
+      eventType: "agent_turn_completed",
+      sessionId: "session-123",
+      projectId: "/Users/alexandrudochioiu/sesori-ai/sesori_apps_monorepo",
+    });
   });
 
   it("returns 0 and does not call messaging when user has no tokens", async () => {

--- a/tests/notifications/routes.test.ts
+++ b/tests/notifications/routes.test.ts
@@ -135,7 +135,12 @@ describe("Notification routes", () => {
         title: "Need your input",
         body: "The assistant is waiting for confirmation.",
         collapseKey: "ai_interaction",
-        data: { category: "ai_interaction", eventType: "question_asked", sessionId: "abc123" },
+        data: {
+          category: "ai_interaction",
+          eventType: "question_asked",
+          sessionId: "abc123",
+          projectId: "/Users/alexandrudochioiu/sesori-ai/sesori_apps_monorepo",
+        },
       }),
     });
 
@@ -143,6 +148,7 @@ describe("Notification routes", () => {
     assert.deepEqual(res.json(), { ok: true, devicesNotified: 2 });
     assert.equal(sendCalls.length, 1);
     assert.equal(sendCalls[0]?.userId, user.userId);
+    assert.equal(sendCalls[0]?.payload.data?.projectId, "/Users/alexandrudochioiu/sesori-ai/sesori_apps_monorepo");
   });
 
   it("POST /notifications/send returns 400 with invalid category", async () => {


### PR DESCRIPTION
## Summary

- preserve `projectId` in the auth server `/notifications/send` request validation and FCM data flattening
- fix the bridge→auth→mobile push contract so notification taps receive `projectId` alongside `sessionId`
- add route and notification-service coverage for the new field

## Root cause

The bridge was posting `projectId` inside nested `data`, but the auth server dropped it in two places:

1. `src/models/api.ts` — `notificationDataSchema` did not allow `projectId`, so Zod stripped it during `safeParse`
2. `src/services/notification-service.ts` — FCM `flatData` only forwarded `category`, `eventType`, and `sessionId`

As a result, the mobile app received push `message.data` without `projectId`, parsed `projectId=null`, and correctly fell back to the projects list.

## Changes

- add `projectId` to `notificationDataSchema`
- add `projectId` to `NotificationData`
- include `projectId` in the flattened FCM `data` payload
- update route test to verify `projectId` survives request parsing
- add notification service test to verify `projectId` reaches final FCM `data`

## Verification

- `npm run build` ✅
- `npm run lint` ✅
- `node --import tsx --test --test-concurrency=1 tests/notifications/notification-service.test.ts` ✅
- `tests/notifications/routes.test.ts` is environment-blocked locally because MongoDB is not running on `localhost:27017`