### PR TITLE
fix: extend bridge status notification debounce to two minutes

### DIFF
--- a/src/services/bridge-state-tracker.ts
+++ b/src/services/bridge-state-tracker.ts
@@ -3,6 +3,8 @@ import type { NotificationPayload, NotificationService } from "./notification-se
 
 type BridgeStatus = BridgeStatusBody["status"];
 
+const DEFAULT_BRIDGE_NOTIFICATION_DEBOUNCE_MS = 120_000;
+
 type BridgeStateEntry = {
   pendingStatus: BridgeStatus | null;
   lastNotifiedStatus: BridgeStatus | null;
@@ -15,7 +17,7 @@ export class BridgeStateTracker {
   readonly #debounceMs: number;
   readonly #state = new Map<string, BridgeStateEntry>();
 
-  constructor(notificationService: NotificationService, debounceMs: number = 60_000) {
+  constructor(notificationService: NotificationService, debounceMs: number = DEFAULT_BRIDGE_NOTIFICATION_DEBOUNCE_MS) {
     this.#notificationService = notificationService;
     this.#debounceMs = debounceMs;
   }

--- a/tests/notifications/bridge-state-tracker.test.ts
+++ b/tests/notifications/bridge-state-tracker.test.ts
@@ -14,7 +14,8 @@ type Deferred<T> = {
   reject: (reason?: unknown) => void;
 };
 
-const DEBOUNCE_MS = 60_000;
+const DEBOUNCE_MS = 120_000;
+const HALF_DEBOUNCE_MS = DEBOUNCE_MS / 2;
 
 function flushMicrotasks(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
@@ -58,6 +59,29 @@ describe("BridgeStateTracker", () => {
     mock.timers.reset();
   });
 
+  it("default debounce waits two minutes before notifying", async () => {
+    const sendCalls: SendCall[] = [];
+    const notificationServiceMock = {
+      sendToUser: async (userId: string, payload: NotificationPayload) => {
+        sendCalls.push({ userId, payload });
+        return { devicesNotified: 1 };
+      },
+    } as unknown as NotificationService;
+    const tracker = new BridgeStateTracker(notificationServiceMock);
+
+    tracker.handleStatusChange("user-1", "connected");
+
+    mock.timers.tick(HALF_DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    assert.equal(sendCalls.length, 0);
+
+    mock.timers.tick(HALF_DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    assert.deepEqual(sendCalls, [{ userId: "user-1", payload: connectedPayload() }]);
+  });
+
   it("stable connected notifies after debounce", async () => {
     const sendCalls: SendCall[] = [];
     const notificationServiceMock = {
@@ -70,7 +94,12 @@ describe("BridgeStateTracker", () => {
 
     tracker.handleStatusChange("user-1", "connected");
 
-    mock.timers.tick(DEBOUNCE_MS);
+    mock.timers.tick(HALF_DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    assert.equal(sendCalls.length, 0);
+
+    mock.timers.tick(HALF_DEBOUNCE_MS);
     await flushMicrotasks();
 
     assert.deepEqual(sendCalls, [{ userId: "user-1", payload: connectedPayload() }]);
@@ -88,7 +117,12 @@ describe("BridgeStateTracker", () => {
 
     tracker.handleStatusChange("user-1", "disconnected");
 
-    mock.timers.tick(DEBOUNCE_MS);
+    mock.timers.tick(HALF_DEBOUNCE_MS);
+    await flushMicrotasks();
+
+    assert.equal(sendCalls.length, 0);
+
+    mock.timers.tick(HALF_DEBOUNCE_MS);
     await flushMicrotasks();
 
     assert.deepEqual(sendCalls, [{ userId: "user-1", payload: disconnectedPayload() }]);
@@ -105,9 +139,9 @@ describe("BridgeStateTracker", () => {
     const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
 
     tracker.handleStatusChange("user-1", "connected");
-    mock.timers.tick(30_000);
+    mock.timers.tick(HALF_DEBOUNCE_MS);
     tracker.handleStatusChange("user-1", "disconnected");
-    mock.timers.tick(30_000);
+    mock.timers.tick(HALF_DEBOUNCE_MS);
     tracker.handleStatusChange("user-1", "connected");
 
     mock.timers.tick(DEBOUNCE_MS);
@@ -152,9 +186,9 @@ describe("BridgeStateTracker", () => {
     const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
 
     tracker.handleStatusChange("user-1", "connected");
-    mock.timers.tick(30_000);
+    mock.timers.tick(HALF_DEBOUNCE_MS);
     tracker.handleStatusChange("user-1", "connected");
-    mock.timers.tick(30_000);
+    mock.timers.tick(HALF_DEBOUNCE_MS);
     await flushMicrotasks();
 
     assert.deepEqual(sendCalls, [{ userId: "user-1", payload: connectedPayload() }]);
@@ -218,7 +252,7 @@ describe("BridgeStateTracker", () => {
     await flushMicrotasks();
 
     tracker.handleStatusChange("user-1", "disconnected");
-    mock.timers.tick(30_000);
+    mock.timers.tick(HALF_DEBOUNCE_MS);
     tracker.handleStatusChange("user-1", "connected");
     mock.timers.tick(DEBOUNCE_MS);
     await flushMicrotasks();


### PR DESCRIPTION
## Summary
- increase the shared bridge connected/disconnected notification debounce from 1 minute to 2 minutes
- add test coverage for the default constructor path used by production wiring and assert no notification fires halfway through the debounce window
- validate the tracker-specific test suite and TypeScript build locally; full `npm test` is blocked in this environment because MongoDB is unavailable on `localhost:27017`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extended the debounce for bridge connected/disconnected notifications from 1 to 2 minutes to reduce noisy alerts from brief flaps. The `BridgeStateTracker` default is now 120,000 ms; tests verify no notification at half the window and a send after the full delay.

- **Bug Fixes**
  - Set `DEFAULT_BRIDGE_NOTIFICATION_DEBOUNCE_MS` to 120,000 and use it as the constructor default.
  - Added tests for the default constructor path and half-window no-op for both connected/disconnected cases.

<sup>Written for commit 66e142915b866d4aba949f6e68b7b945f3e50fda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

