### PR TITLE
Add password account creation script and fix ensureIndexes idempotency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1280,6 +1280,19 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -3231,9 +3244,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -3247,9 +3260,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "funding": [
         {
           "type": "github",
@@ -3259,18 +3272,19 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fastify": {
-      "version": "5.8.4",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.4.tgz",
-      "integrity": "sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==",
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
+      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
       "funding": [
         {
           "type": "github",
@@ -3477,9 +3491,9 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.7.0.tgz",
-      "integrity": "sha512-o3qS8zCJbApe7aKzkO2Pa380t9cHISqeSd3blqYTtOuUUUua3qZTLwNWgGUOss3td6wbzrZhiHIj3c8+fC046Q==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.8.0.tgz",
+      "integrity": "sha512-iawoQkmZbsA+2DY5UEuB8f6jSlskzzySoye0D2F6e3zlDZX9DUcXf0HhZqLUn/P6WhLGvTf6ZtCmshZvhAgTYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
@@ -3490,7 +3504,7 @@
         "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^3.1.0",
-        "node-forge": "^1.3.1",
+        "node-forge": "^1.4.0",
         "uuid": "^11.0.2"
       },
       "engines": {
@@ -5137,9 +5151,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -5236,9 +5250,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -5407,9 +5421,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "optional": true,
@@ -5934,9 +5948,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.1.tgz",
-      "integrity": "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "env:decrypt": "sh -c 'sops decrypt env/app/${ENV:-local}.env > .env && echo \"Decrypted env/app/${ENV:-local}.env → .env\"'",
     "env:edit": "sh -c 'sops edit env/app/${ENV:-local}.env'",
     "env:update-keys": "sh -c 'for f in env/app/*.env; do [ -f \"$f\" ] && sops updatekeys -y \"$f\"; done'",
+    "create-password-account": "tsx scripts/create-password-account.ts",
     "circular-dependencies": "madge --circular --ts-config ./tsconfig.json ./src/index.ts"
   },
   "dependencies": {

--- a/scripts/create-password-account.ts
+++ b/scripts/create-password-account.ts
@@ -22,27 +22,23 @@ async function prompt(question: string): Promise<string> {
 
 async function promptPassword(question: string): Promise<string> {
   const { default: readline } = await import("readline");
+
+  const mutedOutput = new (await import("node:stream")).Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+
   const rl = readline.createInterface({
     input: process.stdin,
-    output: process.stdout,
+    output: mutedOutput,
+    terminal: true,
   });
-  return new Promise((resolve) => {
-    const stdin = process.stdin;
-    stdin.on("data", (char: Buffer) => {
-      const s = char.toString();
-      switch (s) {
-        case "\n":
-        case "\r":
-        case "\u0004":
-          stdin.pause();
-          break;
-        default:
-          process.stdout.write("*");
-          break;
-      }
-    });
 
-    rl.question(question, (answer) => {
+  process.stdout.write(question);
+
+  return new Promise((resolve) => {
+    rl.on("line", (answer) => {
       rl.close();
       process.stdout.write("\n");
       resolve(answer.trim());

--- a/scripts/create-password-account.ts
+++ b/scripts/create-password-account.ts
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+import { ObjectId } from "mongodb";
+import argon2 from "argon2";
+import { MongoDbConnector } from "../src/db/mongo-db-connector.js";
+import { MongoDbAccessor } from "../src/db/mongo-db-accessor.js";
+import { MongoDbDatabase, AuthDbCollection } from "../src/types/mongo.js";
+import type { User, PasswordAccount } from "../src/models/documents.js";
+
+async function prompt(question: string): Promise<string> {
+  const { default: readline } = await import("readline");
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+async function promptPassword(question: string): Promise<string> {
+  const { default: readline } = await import("readline");
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    const stdin = process.stdin;
+    stdin.on("data", (char: Buffer) => {
+      const s = char.toString();
+      switch (s) {
+        case "\n":
+        case "\r":
+        case "\u0004":
+          stdin.pause();
+          break;
+        default:
+          process.stdout.write("*");
+          break;
+      }
+    });
+
+    rl.question(question, (answer) => {
+      rl.close();
+      process.stdout.write("\n");
+      resolve(answer.trim());
+    });
+  });
+}
+
+function printUsage(): void {
+  console.log("Usage:");
+  console.log("  npx tsx scripts/create-password-account.ts <email> <password>");
+  console.log("  npx tsx scripts/create-password-account.ts <email>         # prompts for password");
+  console.log("  npx tsx scripts/create-password-account.ts                 # prompts for both");
+  console.log();
+  console.log("Requires MONGODB_URI environment variable.");
+  console.log("Example with SOPS env:");
+  console.log("  sops exec-env env/app/local.env 'npx tsx scripts/create-password-account.ts reviewer@example.com mypassword'");
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    printUsage();
+  }
+
+  const mongodbUri = process.env.MONGODB_URI;
+  if (!mongodbUri) {
+    console.error("Error: MONGODB_URI environment variable is required.");
+    console.error();
+    console.error("You can provide it via a .env file or SOPS:");
+    console.error("  sops exec-env env/app/local.env 'npx tsx scripts/create-password-account.ts ...'");
+    process.exit(1);
+  }
+
+  let email = args[0];
+  let password = args[1];
+
+  if (!email) {
+    email = await prompt("Email: ");
+    if (!email) {
+      console.error("Error: Email is required.");
+      process.exit(1);
+    }
+  }
+
+  if (!password) {
+    password = await promptPassword("Password: ");
+    if (!password) {
+      console.error("Error: Password is required.");
+      process.exit(1);
+    }
+  }
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    console.error("Error: Invalid email format.");
+    process.exit(1);
+  }
+
+  if (password.length < 6) {
+    console.error("Error: Password must be at least 6 characters.");
+    process.exit(1);
+  }
+
+  const connector = new MongoDbConnector({
+    connectionString: mongodbUri,
+  });
+
+  const accessor = new MongoDbAccessor(connector);
+
+  try {
+    await accessor.ensureIndexes();
+
+    const userCollection = accessor.getCollection<User>(MongoDbDatabase.Auth, AuthDbCollection.Users);
+    const passwordCollection = accessor.getCollection<PasswordAccount>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.PasswordAccounts,
+    );
+
+    const existing = await passwordCollection.findOne({ email: email.toLowerCase() });
+    if (existing) {
+      console.error(`Error: An account with email '${email}' already exists (userId: ${existing.userId.toHexString()}).`);
+      process.exit(1);
+    }
+
+    const userId = new ObjectId();
+    const now = new Date();
+
+    const user: User = {
+      _id: userId,
+      tokenVersion: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await userCollection.insertOne(user);
+
+    const hash = await argon2.hash(password, { type: argon2.argon2id });
+    const passwordAccount: PasswordAccount = {
+      _id: new ObjectId(),
+      userId,
+      email: email.toLowerCase(),
+      passwordHash: hash,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await passwordCollection.insertOne(passwordAccount);
+
+    console.log("✅ Password account created successfully");
+    console.log(`   User ID:  ${userId.toHexString()}`);
+    console.log(`   Email:    ${passwordAccount.email}`);
+    console.log(`   Database: ${MongoDbDatabase.Auth} / ${AuthDbCollection.PasswordAccounts}`);
+  } catch (error) {
+    console.error("Error creating account:", error);
+    process.exit(1);
+  } finally {
+    await connector.close();
+  }
+}
+
+main();

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -2,7 +2,7 @@ import { Collection, Db, MongoServerError, type Document, type IndexSpecificatio
 import { MongoDbDatabase, AuthDbCollection } from "../types/mongo.js";
 import { MongoDbConnector } from "./mongo-db-connector.js";
 
-type IndexDefinition = {
+export type IndexDefinition = {
   spec: IndexSpecification;
   options?: CreateIndexesOptions;
 };
@@ -30,16 +30,16 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
   } satisfies DatabaseConfig<AuthDbCollection>,
 };
 
-function indexKeyMatches(a: IndexSpecification, b: IndexSpecification): boolean {
+export function indexKeyMatches(a: IndexSpecification, b: IndexSpecification): boolean {
   const aRec = a as Record<string, unknown>;
   const bRec = b as Record<string, unknown>;
-  const keysA = Object.keys(aRec).sort();
-  const keysB = Object.keys(bRec).sort();
+  const keysA = Object.keys(aRec);
+  const keysB = Object.keys(bRec);
   if (keysA.length !== keysB.length) return false;
   return keysA.every((k, i) => k === keysB[i] && aRec[k] === bRec[k]);
 }
 
-function indexMatchesDesired(existing: Record<string, unknown>, desired: IndexDefinition): boolean {
+export function indexMatchesDesired(existing: Record<string, unknown>, desired: IndexDefinition): boolean {
   if (!indexKeyMatches(existing.key as IndexSpecification, desired.spec)) return false;
   const desiredUnique = desired.options?.unique ?? false;
   const existingUnique = existing.unique === true;

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -1,4 +1,11 @@
-import { Collection, Db, MongoServerError, type Document, type IndexSpecification, type CreateIndexesOptions } from "mongodb";
+import {
+  Collection,
+  Db,
+  MongoServerError,
+  type Document,
+  type IndexSpecification,
+  type CreateIndexesOptions,
+} from "mongodb";
 import { MongoDbDatabase, AuthDbCollection } from "../types/mongo.js";
 import { MongoDbConnector } from "./mongo-db-connector.js";
 
@@ -41,9 +48,17 @@ export function indexKeyMatches(a: IndexSpecification, b: IndexSpecification): b
 
 export function indexMatchesDesired(existing: Record<string, unknown>, desired: IndexDefinition): boolean {
   if (!indexKeyMatches(existing.key as IndexSpecification, desired.spec)) return false;
-  const desiredUnique = desired.options?.unique ?? false;
-  const existingUnique = existing.unique === true;
-  return desiredUnique === existingUnique;
+
+  const desiredOpts = desired.options ?? {};
+  const relevantKeys = new Set(["unique", ...Object.keys(desiredOpts)]);
+
+  for (const key of relevantKeys) {
+    const desiredValue = desiredOpts[key as keyof CreateIndexesOptions] ?? false;
+    const existingValue = existing[key] ?? false;
+    if (desiredValue !== existingValue) return false;
+  }
+
+  return true;
 }
 
 export class MongoDbAccessor {
@@ -86,7 +101,7 @@ export class MongoDbAccessor {
             if (error instanceof MongoServerError && error.code === 86) {
               const specKeys = Object.keys(desired.spec).join(",");
               console.warn(
-                `Index conflict on ${collectionName} (${specKeys}): existing index differs from desired config. Manual cleanup may be required.`
+                `Index conflict on ${collectionName} (${specKeys}): existing index differs from desired config. Manual cleanup may be required.`,
               );
               continue;
             }

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -1,4 +1,4 @@
-import { Collection, Db, type Document, type IndexSpecification, type CreateIndexesOptions } from "mongodb";
+import { Collection, Db, MongoServerError, type Document, type IndexSpecification, type CreateIndexesOptions } from "mongodb";
 import { MongoDbDatabase, AuthDbCollection } from "../types/mongo.js";
 import { MongoDbConnector } from "./mongo-db-connector.js";
 
@@ -30,6 +30,22 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
   } satisfies DatabaseConfig<AuthDbCollection>,
 };
 
+function indexKeyMatches(a: IndexSpecification, b: IndexSpecification): boolean {
+  const aRec = a as Record<string, unknown>;
+  const bRec = b as Record<string, unknown>;
+  const keysA = Object.keys(aRec).sort();
+  const keysB = Object.keys(bRec).sort();
+  if (keysA.length !== keysB.length) return false;
+  return keysA.every((k, i) => k === keysB[i] && aRec[k] === bRec[k]);
+}
+
+function indexMatchesDesired(existing: Record<string, unknown>, desired: IndexDefinition): boolean {
+  if (!indexKeyMatches(existing.key as IndexSpecification, desired.spec)) return false;
+  const desiredUnique = desired.options?.unique ?? false;
+  const existingUnique = existing.unique === true;
+  return desiredUnique === existingUnique;
+}
+
 export class MongoDbAccessor {
   readonly #connector: MongoDbConnector;
 
@@ -50,16 +66,32 @@ export class MongoDbAccessor {
       const dbConfig = DATABASE_CONFIG[dbName];
       const db = this.getDb(dbName);
 
-      const existing = new Set((await db.listCollections().toArray()).map((c) => c.name));
+      const existingCollections = new Set((await db.listCollections().toArray()).map((c) => c.name));
 
       for (const [collectionName, indexes] of Object.entries(dbConfig.collections)) {
-        if (!existing.has(collectionName)) {
+        if (!existingCollections.has(collectionName)) {
           await db.createCollection(collectionName);
         }
 
         const collection = db.collection(collectionName);
-        for (const index of indexes) {
-          await collection.createIndex(index.spec, index.options ?? {});
+        const existingIndexes = await collection.indexes();
+
+        for (const desired of indexes) {
+          const alreadyExists = existingIndexes.some((idx) => indexMatchesDesired(idx, desired));
+          if (alreadyExists) continue;
+
+          try {
+            await collection.createIndex(desired.spec, desired.options ?? {});
+          } catch (error) {
+            if (error instanceof MongoServerError && error.code === 86) {
+              const specKeys = Object.keys(desired.spec).join(",");
+              console.warn(
+                `Index conflict on ${collectionName} (${specKeys}): existing index differs from desired config. Manual cleanup may be required.`
+              );
+              continue;
+            }
+            throw error;
+          }
         }
       }
     }

--- a/tests/db/mongo-db-accessor.test.ts
+++ b/tests/db/mongo-db-accessor.test.ts
@@ -1,0 +1,61 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { indexKeyMatches, indexMatchesDesired, type IndexDefinition } from "../../src/db/mongo-db-accessor.js";
+
+describe("indexKeyMatches", () => {
+  it("returns true for identical single-field specs", () => {
+    assert.equal(indexKeyMatches({ email: 1 }, { email: 1 }), true);
+  });
+
+  it("returns true for identical compound specs", () => {
+    assert.equal(indexKeyMatches({ userId: 1, word: 1 }, { userId: 1, word: 1 }), true);
+  });
+
+  it("returns false when field order differs", () => {
+    assert.equal(indexKeyMatches({ a: 1, b: 1 }, { b: 1, a: 1 }), false);
+  });
+
+  it("returns false when field names differ", () => {
+    assert.equal(indexKeyMatches({ email: 1 }, { userId: 1 }), false);
+  });
+
+  it("returns false when key directions differ", () => {
+    assert.equal(indexKeyMatches({ email: 1 }, { email: -1 }), false);
+  });
+
+  it("returns false when key count differs", () => {
+    assert.equal(indexKeyMatches({ email: 1 }, { email: 1, userId: 1 }), false);
+  });
+});
+
+describe("indexMatchesDesired", () => {
+  it("returns true when key and unique option match", () => {
+    const existing = { key: { email: 1 }, unique: true, name: "email_1", v: 2 };
+    const desired: IndexDefinition = { spec: { email: 1 }, options: { unique: true } };
+    assert.equal(indexMatchesDesired(existing, desired), true);
+  });
+
+  it("returns true when key matches and both are non-unique", () => {
+    const existing = { key: { userId: 1 }, name: "userId_1", v: 2 };
+    const desired: IndexDefinition = { spec: { userId: 1 } };
+    assert.equal(indexMatchesDesired(existing, desired), true);
+  });
+
+  it("returns false when key differs", () => {
+    const existing = { key: { email: 1 }, unique: true, name: "email_1", v: 2 };
+    const desired: IndexDefinition = { spec: { userId: 1 }, options: { unique: true } };
+    assert.equal(indexMatchesDesired(existing, desired), false);
+  });
+
+  it("returns false when unique option differs", () => {
+    const existing = { key: { userId: 1 }, name: "userId_1", v: 2 };
+    const desired: IndexDefinition = { spec: { userId: 1 }, options: { unique: true } };
+    assert.equal(indexMatchesDesired(existing, desired), false);
+  });
+
+  it("returns false when existing is unique but desired is not", () => {
+    const existing = { key: { userId: 1 }, unique: true, name: "userId_1", v: 2 };
+    const desired: IndexDefinition = { spec: { userId: 1 } };
+    assert.equal(indexMatchesDesired(existing, desired), false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a CLI script to manually seed password accounts (useful for mobile app review/testing) and fixes a bug where `ensureIndexes()` crashes on existing indexes that differ from the desired config.

## Changes

### New script: `scripts/create-password-account.ts`

Interactive or arg-based CLI to create a `User` + `PasswordAccount` in MongoDB:
- Accepts email + password as args or prompts interactively (password hidden)
- Validates email format and minimum password length
- Checks for duplicate emails before inserting
- Uses the same `argon2id` hashing as `AuthService`
- Reuses existing `MongoDbConnector` / `MongoDbAccessor`

**Usage:**
```bash
# Interactive (recommended)
sops exec-env env/app/local.env 'npx tsx scripts/create-password-account.ts'

# With args
sops exec-env env/app/local.env 'npx tsx scripts/create-password-account.ts reviewer@example.com mypassword'
```

Also adds a convenience npm script:
```bash
npm run create-password-account
```

### Fix: `src/db/mongo-db-accessor.ts`

`ensureIndexes()` was blindly calling `createIndex()`, which throws a hard `IndexKeySpecsConflict` (code 86) when an index exists with the same keys but different options (e.g., non-unique vs `unique: true`).

**Before:**
```typescript
for (const index of indexes) {
  await collection.createIndex(index.spec, index.options ?? {});
}
```

**After:**
1. Fetches existing indexes via `collection.indexes()`
2. Compares key specs + `unique` option with `indexMatchesDesired()`
3. Skips creation if matching index already exists
4. Falls back to graceful warning on actual conflicts (code 86) instead of crashing

This makes `ensureIndexes()` idempotent and safe to call at any time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CLI to create password accounts and makes Mongo index setup idempotent. The CLI now masks password input; index creation compares keys and relevant options and skips duplicates.

- **New Features**
  - Added `scripts/create-password-account.ts` to create a `User` + `PasswordAccount` interactively or via args; validates email/password, masks password input, and hashes with `argon2id` (via `argon2`).
  - Added npm script `create-password-account` to run with `tsx`.

- **Bug Fixes**
  - `ensureIndexes()` now compares existing indexes (key order + relevant options like `unique`) and only creates missing ones.
  - On conflicts (`code 86`), logs a warning and continues, making the operation idempotent.
  - Added unit tests for `indexKeyMatches` and `indexMatchesDesired`.

<sup>Written for commit 4d2150ccd1db51dd051bc574dbda579bb362a3f6. Summary will update on new commits. <a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/25?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

