### PR TITLE
feat(oauth): store email address from OAuth providers

### DIFF
--- a/src/clients/auth/apple-client.ts
+++ b/src/clients/auth/apple-client.ts
@@ -71,6 +71,7 @@ export class AppleClient extends OAuthClient {
     return {
       providerUserId: result.data.sub,
       providerUsername: result.data.email ?? null,
+      email: result.data.email ?? null,
     };
   }
 

--- a/src/clients/auth/github-client.ts
+++ b/src/clients/auth/github-client.ts
@@ -10,6 +10,7 @@ const tokenResponseSchema = z.object({
 const userResponseSchema = z.object({
   id: z.number(),
   login: z.string().nullable().optional(),
+  email: z.string().email().nullable().optional(),
 });
 
 export class GithubClient extends OAuthClient {
@@ -34,10 +35,11 @@ export class GithubClient extends OAuthClient {
     return {
       providerUserId: user.id,
       providerUsername: user.login,
+      email: user.email,
     };
   }
 
-  async #fetchUser(accessToken: string): Promise<{ id: string; login: string | null }> {
+  async #fetchUser(accessToken: string): Promise<{ id: string; login: string | null; email: string | null }> {
     const response = await fetch("https://api.github.com/user", {
       headers: { Authorization: `token ${accessToken}`, Accept: "application/json" },
     });
@@ -55,6 +57,7 @@ export class GithubClient extends OAuthClient {
     return {
       id: String(result.data.id),
       login: result.data.login ?? null,
+      email: result.data.email ?? null,
     };
   }
 }

--- a/src/clients/auth/google-client.ts
+++ b/src/clients/auth/google-client.ts
@@ -14,6 +14,7 @@ const idTokenPayloadSchema = z.object({
   sub: z.string().min(1),
   name: z.string().optional(),
   given_name: z.string().optional(),
+  email: z.string().email().optional(),
 });
 
 const GOOGLE_JWKS_URI = "https://www.googleapis.com/oauth2/v3/certs";
@@ -41,10 +42,11 @@ export class GoogleClient extends OAuthClient {
     return {
       providerUserId: user.sub,
       providerUsername: user.name ?? null,
+      email: user.email ?? null,
     };
   }
 
-  async #verifyIdToken(idToken: string, clientId: string): Promise<{ sub: string; name?: string }> {
+  async #verifyIdToken(idToken: string, clientId: string): Promise<{ sub: string; name?: string; email?: string }> {
     const { payload } = await jwtVerify(idToken, this.#jwks, {
       issuer: ["accounts.google.com", "https://accounts.google.com"],
       audience: clientId,
@@ -58,6 +60,7 @@ export class GoogleClient extends OAuthClient {
     return {
       sub: result.data.sub,
       name: result.data.name ?? result.data.given_name,
+      email: result.data.email,
     };
   }
 }

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -16,6 +16,7 @@ export const oauthAccountSchema = z.object({
   provider: z.string(),
   providerUserId: z.string(),
   providerUsername: z.string().nullable(),
+  email: z.string().nullable().optional(),
   createdAt: z.date(),
   updatedAt: z.date(),
 });

--- a/src/repositories/oauth-account-repo.ts
+++ b/src/repositories/oauth-account-repo.ts
@@ -23,6 +23,7 @@ export class OAuthAccountRepository {
     provider: string;
     providerUserId: string;
     providerUsername: string | null;
+    email: string | null;
   }): Promise<{ account: OAuthAccount; potentialUserId: string }> {
     const now = new Date();
     const potentialUserId = new ObjectId();
@@ -32,6 +33,10 @@ export class OAuthAccountRepository {
     // $set would null out a previously stored username. Only update when present.
     if (params.providerUsername !== null) {
       $set.providerUsername = params.providerUsername;
+    }
+    // Same for email — only update when present to avoid nulling out on subsequent sign-ins.
+    if (params.email !== null) {
+      $set.email = params.email;
     }
 
     const $setOnInsert: Record<string, unknown> = {
@@ -43,6 +48,9 @@ export class OAuthAccountRepository {
     };
     if (params.providerUsername === null) {
       $setOnInsert.providerUsername = null;
+    }
+    if (params.email === null) {
+      $setOnInsert.email = null;
     }
 
     const result = await this.#collection.findOneAndUpdate(

--- a/src/routes/google.ts
+++ b/src/routes/google.ts
@@ -48,7 +48,7 @@ export const googleRoutes: FastifyPluginAsync<GoogleRouteOptions> = async (fasti
     authUrl.searchParams.set("client_id", config.GOOGLE_CLIENT_ID);
     authUrl.searchParams.set("redirect_uri", redirect_uri);
     authUrl.searchParams.set("response_type", "code");
-    authUrl.searchParams.set("scope", "openid profile");
+    authUrl.searchParams.set("scope", "openid profile email");
     authUrl.searchParams.set("state", state);
     authUrl.searchParams.set("code_challenge", code_challenge);
     authUrl.searchParams.set("code_challenge_method", code_challenge_method);

--- a/src/services/apple-native-verifier.ts
+++ b/src/services/apple-native-verifier.ts
@@ -76,6 +76,7 @@ export class AppleNativeVerifier {
     return {
       providerUserId: result.data.sub,
       providerUsername: result.data.email ?? null,
+      email: result.data.email ?? null,
     };
   }
 }

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -57,6 +57,7 @@ export class AuthService {
         provider: providerName,
         providerUserId: identity.providerUserId,
         providerUsername: identity.providerUsername,
+        email: identity.email,
       });
     } catch (error) {
       if (error instanceof BadGatewayError) throw error;
@@ -74,6 +75,7 @@ export class AuthService {
       provider: OAuthProviderName.Apple,
       providerUserId: identity.providerUserId,
       providerUsername: identity.providerUsername,
+      email: identity.email,
     });
   }
 
@@ -122,11 +124,13 @@ export class AuthService {
     provider: string;
     providerUserId: string;
     providerUsername: string | null;
+    email: string | null;
   }): Promise<AuthResult> {
     const { account, potentialUserId } = await this.#oauthAccountRepo.upsert({
       provider: params.provider,
       providerUserId: params.providerUserId,
       providerUsername: params.providerUsername,
+      email: params.email,
     });
 
     const accountUserId = account.userId.toHexString();

--- a/src/types/oauth.ts
+++ b/src/types/oauth.ts
@@ -17,6 +17,7 @@ export type OAuthExchangeParams = {
 export type OAuthIdentity = {
   providerUserId: string;
   providerUsername: string | null;
+  email: string | null;
 };
 
 export type OAuthTokens = {

--- a/tests/auth/apple-native.test.ts
+++ b/tests/auth/apple-native.test.ts
@@ -7,12 +7,13 @@ import { BadGatewayError } from "../../src/lib/errors.js";
 const FAKE_IDENTITY = {
   providerUserId: "apple-user-123",
   providerUsername: "fake-apple-user@example.com",
+  email: "fake-apple-user@example.com",
 };
 
 class FakeAppleNativeVerifier {
-  private identity: { providerUserId: string; providerUsername: string | null };
+  private identity: { providerUserId: string; providerUsername: string | null; email: string | null };
 
-  constructor(identity: { providerUserId: string; providerUsername: string | null }) {
+  constructor(identity: { providerUserId: string; providerUsername: string | null; email: string | null }) {
     this.identity = identity;
   }
 
@@ -20,7 +21,7 @@ class FakeAppleNativeVerifier {
     _idToken: string,
     _clientId: string,
     _nonce?: string,
-  ): Promise<{ providerUserId: string; providerUsername: string | null }> {
+  ): Promise<{ providerUserId: string; providerUsername: string | null; email: string | null }> {
     return this.identity;
   }
 }
@@ -30,7 +31,7 @@ class FakeFailingAppleNativeVerifier {
     _idToken: string,
     _clientId: string,
     _nonce?: string,
-  ): Promise<{ providerUserId: string; providerUsername: string | null }> {
+  ): Promise<{ providerUserId: string; providerUsername: string | null; email: string | null }> {
     throw new BadGatewayError({ debugMessage: "Invalid Apple ID token" });
   }
 }

--- a/tests/auth/apple.test.ts
+++ b/tests/auth/apple.test.ts
@@ -8,6 +8,7 @@ const VALID_REDIRECT_URI = "https://app.example.com/oauth/callback";
 const FAKE_IDENTITY = {
   providerUserId: "apple-user-123",
   providerUsername: "fake-apple-user",
+  email: "fake-apple-user@example.com",
 };
 
 describe("Apple OAuth routes", () => {

--- a/tests/auth/github.test.ts
+++ b/tests/auth/github.test.ts
@@ -9,6 +9,7 @@ const VALID_REDIRECT_URI = "myapp://oauth/callback";
 const FAKE_IDENTITY = {
   providerUserId: "github-user-123",
   providerUsername: "fake-github-user",
+  email: "fake-github-user@example.com",
 };
 
 describe("GitHub OAuth routes", () => {

--- a/tests/repositories/oauth-account-repo.test.ts
+++ b/tests/repositories/oauth-account-repo.test.ts
@@ -37,6 +37,7 @@ describe("OAuthAccountRepository.upsert", () => {
       provider: "apple",
       providerUserId: "apple-user-123",
       providerUsername: null,
+      email: null,
     });
     assert.equal(afterNullUpsert.account.providerUsername, "alice@example.com");
 
@@ -44,6 +45,7 @@ describe("OAuthAccountRepository.upsert", () => {
       provider: "apple",
       providerUserId: "apple-user-123",
       providerUsername: "alice2@example.com",
+      email: "alice2@example.com",
     });
     assert.equal(afterNewEmailUpsert.account.providerUsername, "alice2@example.com");
   });


### PR DESCRIPTION
This PR adds support for storing user email addresses from OAuth providers in the database.

## Changes

### Data Model
- Added `email: string | null` to `OAuthIdentity` type
- Added `email` field to `OAuthAccount` schema (nullable, optional)

### Provider Updates
- **GitHub**: Extracts email from the `/user` API response (available with `read:user` scope)
- **Google**: Added `email` scope and extracts email from the `id_token` JWT
- **Apple**: Returns email from the `id_token` in both web OAuth and native flows

### Storage Logic
- `OAuthAccountRepository.upsert()` now accepts and stores email
- Uses conditional `$set` to avoid nulling out email on subsequent sign-ins (matches existing pattern for `providerUsername`)
- Email is stored in `$setOnInsert` on first sign-in

### Security Note
Email addresses are stored in the database but are intentionally NOT included in JWT tokens, following the existing security pattern of not putting PII in tokens.

## Testing
- All 206 existing tests pass
- Build compiles without errors

## Provider Email Availability
| Provider | Email Source | Scope Required |
|----------|--------------|----------------|
| GitHub | `/user` API | `read:user` |
| Google | `id_token` claims | `email` |
| Apple | `id_token` claims | `email` (default) |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stores user email addresses from OAuth providers and persists them on the OAuth account, enabling future email-based features while keeping PII out of JWTs. Adds email extraction for GitHub, Google, and Apple and threads it through the upsert flow.

- **New Features**
  - Added `email: string | null` to `OAuthIdentity` and `OAuthAccount` schema.
  - GitHub: reads `email` from `/user` API using `read:user` scope.
  - Google: requests `openid profile email` and reads `email` from the `id_token`.
  - Apple (web/native): reads `email` from the `id_token`.
  - Repository: `OAuthAccountRepository.upsert()` stores `email` with conditional `$set` and `$setOnInsert` to avoid nulling on later sign-ins.
  - JWTs unchanged; no PII added to tokens.

<sup>Written for commit c23405336718315a6944657f36d9ea954267a419. Summary will update on new commits. <a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/26?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

