### PR TITLE
fix: report email/password accounts with provider "email" instead of "password"

### DIFF
--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,6 +1,6 @@
 import type { OAuthClient } from "../clients/auth/oauth-client.js";
 import {
-  AUTH_PROVIDER_PASSWORD,
+  AUTH_PROVIDER_EMAIL,
   OAuthProviderName,
   type OAuthExchangeParams,
   type OAuthIdentity,
@@ -117,7 +117,7 @@ export class AuthService {
 
     return this.#signTokensForUser({
       userId: account.userId.toHexString(),
-      provider: AUTH_PROVIDER_PASSWORD,
+      provider: AUTH_PROVIDER_EMAIL,
       providerUserId: account.userId.toHexString(),
       providerUsername: account.email,
       tokenVersion: user.tokenVersion ?? 0,
@@ -231,7 +231,7 @@ export class AuthService {
     if (passwordAccount) {
       return this.#signTokensForUser({
         userId,
-        provider: AUTH_PROVIDER_PASSWORD,
+        provider: AUTH_PROVIDER_EMAIL,
         providerUserId: userId,
         providerUsername: passwordAccount.email,
         tokenVersion: user.tokenVersion,
@@ -286,7 +286,7 @@ export class AuthService {
     if (passwordAccount) {
       return {
         id: userId,
-        provider: AUTH_PROVIDER_PASSWORD,
+        provider: AUTH_PROVIDER_EMAIL,
         providerUserId: userId,
         providerUsername: passwordAccount.email,
       };

--- a/src/services/token-service.ts
+++ b/src/services/token-service.ts
@@ -21,7 +21,7 @@ export class TokenService {
     this.#publicKey = publicKeyPem.replace(/\\n/g, "\n");
   }
 
-  // Password users sign access tokens with provider="password" and providerUserId=user._id.toString().
+  // Password users sign access tokens with provider="email" and providerUserId=user._id.toString().
   // providerUserId stays as the 24-char hex ObjectId string so we avoid putting email into the JWT.
   signAccessToken(payload: { userId: string; provider: string; providerUserId: string }): string {
     const now = Math.floor(Date.now() / 1000);

--- a/src/types/oauth.ts
+++ b/src/types/oauth.ts
@@ -4,7 +4,10 @@ export enum OAuthProviderName {
   Apple = "apple",
 }
 
-export const AUTH_PROVIDER_PASSWORD = "password";
+// Provider key for email/password accounts. Must stay "email": it is part of
+// the public API contract — clients (mobile app, bridge) parse it into a strict
+// AuthProvider enum that only knows github/google/apple/email.
+export const AUTH_PROVIDER_EMAIL = "email";
 
 export type OAuthExchangeParams = {
   code: string;

--- a/tests/auth/password.test.ts
+++ b/tests/auth/password.test.ts
@@ -64,7 +64,7 @@ describe("Password authentication", () => {
       assert.ok(body.accessToken, "Should return access token");
       assert.ok(body.refreshToken, "Should return refresh token");
       assert.ok(body.user.id, "Should return user id");
-      assert.equal(body.user.provider, "password");
+      assert.equal(body.user.provider, "email");
     });
 
     it("returns 401 for wrong password", async () => {
@@ -184,7 +184,7 @@ describe("Password authentication", () => {
       }>();
       assert.ok(body.accessToken);
       assert.ok(body.refreshToken);
-      assert.equal(body.user.provider, "password");
+      assert.equal(body.user.provider, "email");
     });
   });
 
@@ -211,7 +211,7 @@ describe("Password authentication", () => {
 
       assert.equal(meRes.statusCode, 200);
       const body = meRes.json<{ user: { id: string; provider: string; providerUsername: string } }>();
-      assert.equal(body.user.provider, "password");
+      assert.equal(body.user.provider, "email");
       assert.equal(body.user.providerUsername, email.toLowerCase());
     });
   });
@@ -329,7 +329,7 @@ describe("Password authentication", () => {
         headers: { authorization: `Bearer ${passwordTokens.accessToken}` },
       });
       assert.equal(passwordMeRes.statusCode, 200);
-      assert.equal(passwordMeRes.json<{ user: { provider: string } }>().user.provider, "password");
+      assert.equal(passwordMeRes.json<{ user: { provider: string } }>().user.provider, "email");
 
       const oauthLogoutRes = await ctx.app.inject({
         method: "POST",


### PR DESCRIPTION
## Problem

Email login is broken in **all shipped clients** (mobile app + bridge). `POST /auth/email` accepts the credentials but returns `"provider": "password"` in the response. The clients parse that field into a strict `AuthProvider` enum that only knows `github` / `google` / `apple` / `email`, so they throw:

```
Email login failed: Exception: Failed to parse auth response: FormatException: Unknown AuthProvider key: password
```

The same wrong key was returned by `/auth/refresh` and `/auth/me` for password accounts.

## Fix

Renamed `AUTH_PROVIDER_PASSWORD = "password"` → `AUTH_PROVIDER_EMAIL = "email"` in `src/types/oauth.ts` and updated its three usages in `auth-service.ts` (`authenticatePassword`, `refreshAuthTokens`, `findUserAuthProfile`). Added a comment pinning the value to the client contract so it doesn't regress.

## Why server-side (vs. client-side)

- The value is **never persisted**: password accounts live in `PasswordAccountRepository` with no `provider` field — the string is synthesized at response/token-signing time only. Zero data migration.
- Fixing here repairs **already-shipped** mobile apps and bridges on their next request — no app-store release needed. (A client-side tolerance fix was drafted as sesori_apps_monorepo#220 but is being closed in favor of this.)
- `"email"` is the semantically correct public key: the endpoint is `/auth/email` and the documented client enum value is `email`.

## Compatibility notes

- **In-flight access tokens** issued before deploy carry `provider: "password"` as a JWT claim until they expire. The claim is validated as `z.string()` and nothing switches on it server-side or in the relay, so this is benign.
- OAuth providers are unaffected — their stored provider keys (`github`/`google`/`apple`) already match the clients.

## Verification

- `npm run build` ✓
- `npm run lint` ✓
- `npm test` ✓ — 310 pass, 0 fail (assertions in `tests/auth/password.test.ts` updated to expect `"email"`, including the mixed OAuth/password `/auth/me` case)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix email login by reporting provider "email" instead of "password" for email/password accounts, so shipped clients parse auth responses correctly. Aligns API responses and signed tokens with the documented `AuthProvider` enum to unblock login and /auth/me.

- **Bug Fixes**
  - Return provider "email" for password accounts in /auth/email, /auth/refresh, and /auth/me.
  - Rename `AUTH_PROVIDER_PASSWORD` to `AUTH_PROVIDER_EMAIL` and use it in token signing and profile lookups.
  - Update tests to expect "email"; existing tokens with "password" remain valid until they expire.

<sup>Written for commit c7bfb94becbf0d0fe160622071418de5a3501c08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

