### PR TITLE
feat: session-scoped Android notification tag for push collapse + dismiss

### DIFF
--- a/src/services/notification-service.ts
+++ b/src/services/notification-service.ts
@@ -52,7 +52,7 @@ export class NotificationService {
         collapseKey: payload.collapseKey ?? undefined,
         // Android ignores collapseKey for already-displayed notification messages;
         // the tag is what replaces/dismisses the visible notification per session.
-        notification: { channelId: payload.category, tag: payload.collapseKey ?? undefined },
+        notification: { channelId: payload.category, tag: payload.collapseKey || undefined },
       },
       apns: {
         headers: payload.collapseKey ? { "apns-collapse-id": payload.collapseKey } : undefined,

--- a/src/services/notification-service.ts
+++ b/src/services/notification-service.ts
@@ -50,7 +50,9 @@ export class NotificationService {
       data: flatData,
       android: {
         collapseKey: payload.collapseKey ?? undefined,
-        notification: { channelId: payload.category },
+        // Android ignores collapseKey for already-displayed notification messages;
+        // the tag is what replaces/dismisses the visible notification per session.
+        notification: { channelId: payload.category, tag: payload.collapseKey ?? undefined },
       },
       apns: {
         headers: payload.collapseKey ? { "apns-collapse-id": payload.collapseKey } : undefined,

--- a/tests/notifications/notification-service.test.ts
+++ b/tests/notifications/notification-service.test.ts
@@ -109,6 +109,21 @@ describe("NotificationService", () => {
     assert.equal(firstMessage.apns?.headers?.["apns-collapse-id"], payload.collapseKey);
   });
 
+  it("omits the Android tag and apns-collapse-id when the collapse key is empty", async () => {
+    const tokenRepo = createMockDeviceTokenRepo([{ userId: "user-1", token: "token-a", platform: "android" }]);
+    const messaging = createMockMessaging([{ success: true }]);
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging);
+
+    await service.sendToUser("user-1", { ...payload, collapseKey: "" });
+
+    const firstMessage = messaging.calls[0]?.[0] as {
+      android?: { notification?: { tag?: string } };
+      apns?: { headers?: Record<string, string> };
+    };
+    assert.equal(firstMessage.android?.notification?.tag, undefined);
+    assert.equal(firstMessage.apns?.headers, undefined);
+  });
+
   it("returns 0 and does not call messaging when user has no tokens", async () => {
     const tokenRepo = createMockDeviceTokenRepo([{ userId: "another-user", token: "token-x", platform: "ios" }]);
     const messaging = createMockMessaging([{ success: true }]);

--- a/tests/notifications/notification-service.test.ts
+++ b/tests/notifications/notification-service.test.ts
@@ -93,6 +93,22 @@ describe("NotificationService", () => {
     });
   });
 
+  it("sets a session-scoped Android tag and iOS apns-collapse-id from the collapse key", async () => {
+    const tokenRepo = createMockDeviceTokenRepo([{ userId: "user-1", token: "token-a", platform: "android" }]);
+    const messaging = createMockMessaging([{ success: true }]);
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging);
+
+    await service.sendToUser("user-1", payload);
+
+    const firstMessage = messaging.calls[0]?.[0] as {
+      android?: { notification?: { tag?: string; channelId?: string } };
+      apns?: { headers?: Record<string, string> };
+    };
+    assert.equal(firstMessage.android?.notification?.tag, payload.collapseKey);
+    assert.equal(firstMessage.android?.notification?.channelId, payload.category);
+    assert.equal(firstMessage.apns?.headers?.["apns-collapse-id"], payload.collapseKey);
+  });
+
   it("returns 0 and does not call messaging when user has no tokens", async () => {
     const tokenRepo = createMockDeviceTokenRepo([{ userId: "another-user", token: "token-x", platform: "ios" }]);
     const messaging = createMockMessaging([{ success: true }]);


### PR DESCRIPTION
## What

Sets `android.notification.tag` (from `collapseKey`) on outbound FCM messages, and keeps `apns-collapse-id = collapseKey`.

## Why

Companion to the mobile/bridge change that makes the push `collapseKey` **session-scoped**. For background notifications rendered by the OS:

- **Android** *ignores* `collapseKey` for already-displayed notification messages — the `notification.tag` is what makes a new notification **replace** the displayed one and lets the app **dismiss** it via `NotificationManager.cancel(tag, 0)`. This PR adds that tag.
- **iOS** already replaces/dismisses via `apns-collapse-id` (unchanged here, now session-scoped because `collapseKey` is).

With this, opening a session on the phone dismisses its background notifications and new notifications for a session replace older ones, on both platforms.

## Testing

- `npm run build` (tsc) clean, `eslint` clean, `prettier --check` clean.
- `notification-service` tests pass (8), including a new assertion that `android.notification.tag` and `apns-collapse-id` are both set from `collapseKey`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets `android.notification.tag` from the session-scoped `collapseKey` so Android background notifications replace older ones and can be dismissed per session. Omits both the Android tag and iOS `apns-collapse-id` when `collapseKey` is empty; iOS behavior is otherwise unchanged.

- **New Features**
  - Set `android.notification.tag` to `collapseKey` for FCM (omitted when empty) to enable replace/dismiss via `NotificationManager.cancel(tag, 0)` on Android.
  - Added tests covering both platforms: tag/`apns-collapse-id` set from `collapseKey`, and both omitted when empty.

<sup>Written for commit 0301f9b98bb67147ee3c97ad08b1295b636b48fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

