### PR TITLE
fix: deliver OAuth completion only to a live connection (Android retry safety)

### DIFF
--- a/src/routes/auth/session-status.ts
+++ b/src/routes/auth/session-status.ts
@@ -22,7 +22,7 @@
  * enumeration. Clients should treat 404 as terminal and reset their flow.
  */
 
-import { FastifyPluginAsync } from "fastify";
+import { FastifyPluginAsync, type FastifyReply, type FastifyRequest } from "fastify";
 import { NotFoundError } from "../../lib/errors.js";
 import type {
   AuthSessionStatusCompleteReply,
@@ -60,9 +60,13 @@ export const sessionStatusRoutes: FastifyPluginAsync<SessionStatusRouteOptions> 
       tokenHash,
       session,
       statusPollTimeoutMs,
+      abortSignal: createRequestCloseSignal({ request, reply }),
     });
 
     if (!nextSession) {
+      if (!isClientConnectionOpen({ request, reply })) {
+        return reply;
+      }
       throw new NotFoundError({ debugMessage: "Pending auth session no longer exists" });
     }
 
@@ -71,6 +75,15 @@ export const sessionStatusRoutes: FastifyPluginAsync<SessionStatusRouteOptions> 
       case PendingAuthStatus.AwaitingConfirmation:
         return createPendingReply();
       case PendingAuthStatus.Complete:
+        // Consume only when a live connection is still available for delivery.
+        // This avoids deleting tokens for Android clients whose OS aborted the
+        // in-flight long-poll while the server-side waiter was still resolving.
+        // A tiny race remains if the socket dies after this check but before the
+        // kernel flushes the response; closing that would require an explicit
+        // client ack, which would create a broader replay/read window.
+        if (!isClientConnectionOpen({ request, reply })) {
+          return reply;
+        }
         return createCompleteReply({ pendingAuthStore, tokenHash });
       case PendingAuthStatus.Denied:
         return createDeniedReply();
@@ -99,6 +112,7 @@ async function waitForTerminalOrTimeout(params: {
   tokenHash: string;
   session: PendingAuthSession;
   statusPollTimeoutMs: number;
+  abortSignal?: AbortSignal;
 }): Promise<PendingAuthSession | null> {
   let session = params.session;
   if (session.status !== PendingAuthStatus.Pending && session.status !== PendingAuthStatus.AwaitingConfirmation) {
@@ -113,7 +127,9 @@ async function waitForTerminalOrTimeout(params: {
       return session;
     }
 
-    const nextSession = await params.pendingAuthStore.waitForStatusChange(params.tokenHash, remainingMs);
+    const nextSession = await params.pendingAuthStore.waitForStatusChange(params.tokenHash, remainingMs, {
+      abortSignal: params.abortSignal,
+    });
     if (!nextSession) {
       return null;
     }
@@ -125,6 +141,28 @@ async function waitForTerminalOrTimeout(params: {
   }
 
   return session;
+}
+
+function createRequestCloseSignal(params: { request: FastifyRequest; reply: FastifyReply }): AbortSignal {
+  const controller = new AbortController();
+  const abortIfUndelivered = () => {
+    if (!params.reply.raw.writableEnded) {
+      controller.abort();
+    }
+  };
+  const removeAbortListener = () => {
+    params.request.raw.off("close", abortIfUndelivered);
+  };
+
+  params.request.raw.once("close", abortIfUndelivered);
+  params.reply.raw.once("finish", removeAbortListener);
+  params.reply.raw.once("close", removeAbortListener);
+
+  return controller.signal;
+}
+
+function isClientConnectionOpen(params: { request: FastifyRequest; reply: FastifyReply }): boolean {
+  return !params.request.raw.aborted && !params.request.socket.destroyed && !params.reply.raw.writableEnded;
 }
 
 function createPendingReply(): AuthSessionStatusPendingReply {

--- a/src/routes/auth/session-status.ts
+++ b/src/routes/auth/session-status.ts
@@ -65,7 +65,7 @@ export const sessionStatusRoutes: FastifyPluginAsync<SessionStatusRouteOptions> 
 
     if (!nextSession) {
       if (!isClientConnectionOpen({ request, reply })) {
-        return reply;
+        return reply.hijack();
       }
       throw new NotFoundError({ debugMessage: "Pending auth session no longer exists" });
     }
@@ -82,7 +82,7 @@ export const sessionStatusRoutes: FastifyPluginAsync<SessionStatusRouteOptions> 
         // kernel flushes the response; closing that would require an explicit
         // client ack, which would create a broader replay/read window.
         if (!isClientConnectionOpen({ request, reply })) {
-          return reply;
+          return reply.hijack();
         }
         return createCompleteReply({ pendingAuthStore, tokenHash });
       case PendingAuthStatus.Denied:
@@ -145,16 +145,31 @@ async function waitForTerminalOrTimeout(params: {
 
 function createRequestCloseSignal(params: { request: FastifyRequest; reply: FastifyReply }): AbortSignal {
   const controller = new AbortController();
+
+  // If the connection is already gone, abort immediately without registering
+  // listeners that will never fire.
+  if (params.request.raw.destroyed || params.request.socket.destroyed || params.reply.raw.writableEnded) {
+    controller.abort();
+    return controller.signal;
+  }
+
   const abortIfUndelivered = () => {
     if (!params.reply.raw.writableEnded) {
       controller.abort();
     }
   };
   const removeAbortListener = () => {
-    params.request.raw.off("close", abortIfUndelivered);
+    params.request.socket.off("close", abortIfUndelivered);
+    params.reply.raw.off("close", abortIfUndelivered);
+    params.reply.raw.off("finish", removeAbortListener);
+    params.reply.raw.off("close", removeAbortListener);
   };
 
-  params.request.raw.once("close", abortIfUndelivered);
+  // Use the underlying socket close and response close events rather than
+  // request.raw 'close', which can also fire when the request stream ends on a
+  // healthy keep-alive connection.
+  params.request.socket.once("close", abortIfUndelivered);
+  params.reply.raw.once("close", abortIfUndelivered);
   params.reply.raw.once("finish", removeAbortListener);
   params.reply.raw.once("close", removeAbortListener);
 
@@ -162,7 +177,7 @@ function createRequestCloseSignal(params: { request: FastifyRequest; reply: Fast
 }
 
 function isClientConnectionOpen(params: { request: FastifyRequest; reply: FastifyReply }): boolean {
-  return !params.request.raw.aborted && !params.request.socket.destroyed && !params.reply.raw.writableEnded;
+  return !params.request.raw.destroyed && !params.request.socket.destroyed && !params.reply.raw.writableEnded;
 }
 
 function createPendingReply(): AuthSessionStatusPendingReply {

--- a/src/services/pending-auth-store.ts
+++ b/src/services/pending-auth-store.ts
@@ -455,6 +455,13 @@ export class PendingAuthStore {
       };
 
       if (options?.abortSignal) {
+        // Recheck inside the promise executor: the signal may have aborted in
+        // the gap between the initial check above and listener registration.
+        if (options.abortSignal.aborted) {
+          clearTimeout(timeout);
+          resolve(null);
+          return;
+        }
         waiter.abortListener = () => {
           this.#removeWaiter(tokenHash, waiter);
           clearTimeout(timeout);

--- a/src/services/pending-auth-store.ts
+++ b/src/services/pending-auth-store.ts
@@ -86,6 +86,8 @@ type StatusWaiter = {
   initialStatus: PendingAuthStatus;
   resolve: (session: PendingAuthSession | null) => void;
   timeout: ReturnType<typeof setTimeout>;
+  abortSignal?: AbortSignal;
+  abortListener?: () => void;
 };
 
 export class PendingAuthStore {
@@ -401,9 +403,17 @@ export class PendingAuthStore {
    * Race-safe: a status change happening between `getSessionByTokenHash` and
    * waiter registration triggers an immediate resolve via the re-check below.
    */
-  waitForStatusChange(tokenHash: string, timeoutMs: number): Promise<PendingAuthSession | null> {
+  waitForStatusChange(
+    tokenHash: string,
+    timeoutMs: number,
+    options?: { abortSignal?: AbortSignal },
+  ): Promise<PendingAuthSession | null> {
     const session = this.getSessionByTokenHash(tokenHash);
     if (!session) {
+      return Promise.resolve(null);
+    }
+
+    if (options?.abortSignal?.aborted) {
       return Promise.resolve(null);
     }
 
@@ -435,10 +445,23 @@ export class PendingAuthStore {
         initialStatus: session.status,
         resolve: (nextSession) => {
           clearTimeout(timeout);
+          if (waiter.abortSignal && waiter.abortListener) {
+            waiter.abortSignal.removeEventListener("abort", waiter.abortListener);
+          }
           resolve(nextSession);
         },
         timeout,
+        abortSignal: options?.abortSignal,
       };
+
+      if (options?.abortSignal) {
+        waiter.abortListener = () => {
+          this.#removeWaiter(tokenHash, waiter);
+          clearTimeout(timeout);
+          resolve(null);
+        };
+        options.abortSignal.addEventListener("abort", waiter.abortListener, { once: true });
+      }
 
       const waiters = this.#waitersByTokenHash.get(tokenHash) ?? new Set<StatusWaiter>();
       waiters.add(waiter);
@@ -575,6 +598,9 @@ export class PendingAuthStore {
     }
 
     waiters.delete(waiter);
+    if (waiter.abortSignal && waiter.abortListener) {
+      waiter.abortSignal.removeEventListener("abort", waiter.abortListener);
+    }
     if (waiters.size === 0) {
       this.#waitersByTokenHash.delete(tokenHash);
     }

--- a/tests/auth/session-status.test.ts
+++ b/tests/auth/session-status.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
+import http from "node:http";
 import Fastify, { type FastifyInstance, type InjectOptions, type LightMyRequestResponse } from "fastify";
 import { ApiError } from "../../src/lib/errors.js";
 import { sessionStatusRoutes } from "../../src/routes/auth/session-status.js";
@@ -99,6 +100,42 @@ describe("GET /auth/session/status", () => {
     assert.equal(firstResponse.statusCode, 200);
     assert.equal(secondResponse.statusCode, 404);
     assert.equal(secondResponse.json<{ error: string }>().error, "not_found");
+  });
+
+  it("keeps a completed session readable once when the waiting client disconnects before delivery", async () => {
+    const tokenHash = createPendingSession({ sessionToken: VALID_SESSION_TOKEN });
+    const origin = await app.listen({ host: "127.0.0.1", port: 0 });
+    const pendingRequest = openStatusRequest({ origin, sessionToken: VALID_SESSION_TOKEN });
+
+    await delay(10);
+    pendingRequest.destroy();
+    await pendingRequest.closed;
+
+    pendingAuthStore.completeSession({ tokenHash, tokens: TEST_TOKENS, user: TEST_USER });
+    await delay(10);
+
+    assert.equal(pendingAuthStore.getSessionByTokenHash(tokenHash)?.status, "complete");
+
+    const retryResponse = await injectWithKeepAlive({
+      method: "GET",
+      url: "/auth/session/status",
+      headers: { "x-sesori-session-token": VALID_SESSION_TOKEN },
+    });
+    const replayResponse = await injectWithKeepAlive({
+      method: "GET",
+      url: "/auth/session/status",
+      headers: { "x-sesori-session-token": VALID_SESSION_TOKEN },
+    });
+
+    assert.equal(retryResponse.statusCode, 200);
+    assert.deepEqual(retryResponse.json(), {
+      status: "complete",
+      accessToken: TEST_TOKENS.accessToken,
+      refreshToken: TEST_TOKENS.refreshToken,
+      user: TEST_USER,
+    });
+    assert.equal(replayResponse.statusCode, 404);
+    assert.equal(replayResponse.json<{ error: string }>().error, "not_found");
   });
 
   it("returns denied when the pending session is denied during long-polling", async () => {
@@ -259,5 +296,29 @@ describe("GET /auth/session/status", () => {
     } finally {
       clearInterval(keepAlive);
     }
+  }
+
+  function openStatusRequest(params: { origin: string; sessionToken: string }): {
+    destroy: () => void;
+    closed: Promise<void>;
+  } {
+    const request = http.request(new URL("/auth/session/status", params.origin), {
+      method: "GET",
+      headers: { "x-sesori-session-token": params.sessionToken },
+    });
+    const closed = new Promise<void>((resolve) => {
+      request.once("close", resolve);
+      request.once("error", () => resolve());
+    });
+    request.end();
+
+    return {
+      destroy: () => request.destroy(),
+      closed,
+    };
+  }
+
+  async function delay(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
   }
 });

--- a/tests/services/pending-auth-store.test.ts
+++ b/tests/services/pending-auth-store.test.ts
@@ -104,6 +104,40 @@ describe("PendingAuthStore", () => {
     }
   });
 
+  it("releases aborted long-poll waiters without observing a later completion", async () => {
+    const store = createStore();
+    const tokenHash = createSessionTokenHash();
+    store.createSession({
+      tokenHash,
+      provider: OAuthProviderName.Google,
+      pkceVerifier: "pkce-verifier",
+      state: "oauth-state",
+    });
+
+    const controller = new AbortController();
+    const waitPromise = store.waitForStatusChange(tokenHash, 5_000, { abortSignal: controller.signal });
+
+    controller.abort();
+    const waited = await waitPromise;
+    const completed = store.completeSession({
+      tokenHash,
+      tokens: {
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+      },
+      user: {
+        id: "user-1",
+        provider: "google",
+        providerUserId: "provider-user-1",
+        providerUsername: "octocat",
+      },
+    });
+
+    assert.equal(waited, null);
+    assert.equal(completed?.status, "complete");
+    assert.equal(store.getSessionByTokenHash(tokenHash)?.status, "complete");
+  });
+
   it("expires sessions and releases waiters", async () => {
     let currentTime = new Date("2026-05-14T12:00:00.000Z");
     const store = createStore({

--- a/tests/services/pending-auth-store.test.ts
+++ b/tests/services/pending-auth-store.test.ts
@@ -7,6 +7,16 @@ function createSessionTokenHash(token = "session-token"): string {
   return PendingAuthStore.hashToken(token);
 }
 
+function uniqueUserCodeGenerator(): () => string {
+  let counter = 0;
+  return () => {
+    const n = counter++;
+    const first = String.fromCharCode(0x41 + (n % 26));
+    const second = String.fromCharCode(0x41 + ((n + 1) % 26));
+    return `${first}${second}${(n % 9) + 1}${((n + 1) % 9) + 1}`;
+  };
+}
+
 function createStore(overrides?: ConstructorParameters<typeof PendingAuthStore>[0]): PendingAuthStore {
   return new PendingAuthStore({
     sessionTtlMs: 5 * 60 * 1000,
@@ -136,6 +146,45 @@ describe("PendingAuthStore", () => {
     assert.equal(waited, null);
     assert.equal(completed?.status, "complete");
     assert.equal(store.getSessionByTokenHash(tokenHash)?.status, "complete");
+  });
+
+  it("aborting one waiter does not affect waiters for other sessions", async () => {
+    const store = createStore({ userCodeGenerator: uniqueUserCodeGenerator() });
+    const tokenHashA = createSessionTokenHash("token-a");
+    const tokenHashB = createSessionTokenHash("token-b");
+    store.createSession({
+      tokenHash: tokenHashA,
+      provider: OAuthProviderName.Github,
+      pkceVerifier: "pkce-a",
+      state: "state-a",
+    });
+    store.createSession({
+      tokenHash: tokenHashB,
+      provider: OAuthProviderName.Google,
+      pkceVerifier: "pkce-b",
+      state: "state-b",
+    });
+
+    const controllerA = new AbortController();
+    const waitA = store.waitForStatusChange(tokenHashA, 5_000, { abortSignal: controllerA.signal });
+    const waitB = store.waitForStatusChange(tokenHashB, 5_000);
+
+    controllerA.abort();
+    const waitedA = await waitA;
+    store.completeSession({
+      tokenHash: tokenHashB,
+      tokens: { accessToken: "b-access", refreshToken: "b-refresh" },
+      user: {
+        id: "user-b",
+        provider: "google",
+        providerUserId: "provider-b",
+        providerUsername: "user-b",
+      },
+    });
+    const waitedB = await waitB;
+
+    assert.equal(waitedA, null);
+    assert.equal(waitedB?.status, "complete");
   });
 
   it("expires sessions and releases waiters", async () => {


### PR DESCRIPTION
## Summary
- Fixes GET /auth/session/status so completed OAuth sessions are consumed only when the polling client connection is still live.
- Wires the long-poll waiter to abort on request close, preventing stale waiters from reaching the consume step after Android backgrounds and aborts the socket.
- Keeps post-delivery semantics unchanged: one successful complete delivery consumes the session; later polls return 404.

## Bug
Android can background the app while the mobile client has an in-flight OAuth long-poll. The OS aborts that socket, but the server-side waiter can still resolve to complete. Previously the status route immediately called consumeCompletion(tokenHash), deleting the tokens while Fastify/Node was writing to a dead socket. The client retry then saw 404, so login failed even though provider auth succeeded.

## Replay-safe design
This uses consume-on-confirmed-live-delivery, not idempotent-until-TTL. The completion is not re-readable for the TTL, which avoids giving any holder of the session token a repeated token-read window. Instead, the route checks request.raw.aborted, request.socket.destroyed, and reply.raw.writableEnded before consumeCompletion. If the connection is already gone, it returns without consuming, leaving the legitimate retry poll to read the completion exactly once.

## Residual race
There is still a tiny race where the socket is alive at the liveness check but dies before the response is fully flushed. Closing that completely would require an explicit client ack protocol. That ack would either delay deletion or make the completion re-readable while waiting for the ack, creating the replay/token-theft window this fix intentionally avoids.

## Companion mobile work
Companion mobile client work lives in the Sesori apps monorepo on branch mobile-google-login-issue and makes LoginCubit lifecycle-aware so Android resumes retry the status poll after backgrounding.

## Verification
- npm run build
- npm run lint
- npm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GET /auth/session/status to consume OAuth completion only when the connection is still open, so Android background retries succeed. Adds abortable long-poll waiters and stronger liveness checks to preserve one-time delivery (later polls return 404).

- **Bug Fixes**
  - Abort long-poll waiters on request close via a robust `AbortSignal` (socket/response close events, immediate abort if already closed, listener cleanup).
  - Check client connection liveness before consuming completion (and before returning 404); if closed, skip consume so the next poll reads it once.
  - Added tests for disconnect-before-delivery retry, aborted waiter release, and isolation between waiters.

<sup>Written for commit 039ec5bc9cbab1cda23dd7d58bdfee8953c72452. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

