### PR TITLE
fix: ACK OAuth completion before consuming pending session

### DIFF
--- a/src/routes/auth/session-status.ts
+++ b/src/routes/auth/session-status.ts
@@ -6,20 +6,23 @@
  *
  * Responses:
  *   200 { status: "pending" }                                  — long-poll timed out, still pending
- *   200 { status: "complete", accessToken, refreshToken, user } — tokens delivered & consumed; subsequent polls return 404
+ *   200 { status: "complete", accessToken, refreshToken, user } — tokens ready; repeated polls return the same payload until ACK
  *   200 { status: "denied" }
  *   200 { status: "error", message }
  *   400 { error: "bad_request" }                                — missing/invalid session-token header
  *   404 { error: "not_found" }                                  — unknown OR already-consumed (deliberately conflated, see CQ-11)
  *   410 { status: "expired" }
  *
- * CQ-11 (404 conflation): once `complete` has been consumed by a previous
- * poll, the session entry is deleted. A subsequent poll with the same token
- * cannot distinguish "session never existed" from "session was just
- * consumed". Both return 404 — this is intentional. The tokens have already
- * been delivered exactly once; revealing that a session "existed" would
- * leak no useful information to a legitimate client and could aid token
- * enumeration. Clients should treat 404 as terminal and reset their flow.
+ * ACK endpoint:
+ *   POST /auth/session/status/ack                         — consumes a complete session after the client persists tokens
+ *
+ * CQ-11 (404 conflation): once `complete` has been ACKed, the session entry
+ * is deleted. A subsequent poll with the same token cannot distinguish
+ * "session never existed" from "session was just consumed". Both return 404 —
+ * this is intentional. The tokens were already acknowledged by the legitimate
+ * client; revealing that a session "existed" would leak no useful information
+ * and could aid token enumeration. Clients should treat 404 as terminal and
+ * reset their flow.
  */
 
 import { FastifyPluginAsync, type FastifyReply, type FastifyRequest } from "fastify";
@@ -31,6 +34,7 @@ import type {
   AuthSessionStatusExpiredReply,
   AuthSessionStatusPendingReply,
   AuthSessionStatusReply,
+  SuccessReply,
 } from "../../models/api.js";
 import { PendingAuthStatus, PendingAuthStore, type PendingAuthSession } from "../../services/pending-auth-store.js";
 import { parseSessionTokenHeader } from "./init.js";
@@ -75,12 +79,9 @@ export const sessionStatusRoutes: FastifyPluginAsync<SessionStatusRouteOptions> 
       case PendingAuthStatus.AwaitingConfirmation:
         return createPendingReply();
       case PendingAuthStatus.Complete:
-        // Consume only when a live connection is still available for delivery.
-        // This avoids deleting tokens for Android clients whose OS aborted the
-        // in-flight long-poll while the server-side waiter was still resolving.
-        // A tiny race remains if the socket dies after this check but before the
-        // kernel flushes the response; closing that would require an explicit
-        // client ack, which would create a broader replay/read window.
+        // Only return a completed payload when a live connection is still
+        // available. Delivery itself is acknowledged by POST /ack so a socket
+        // death after this check no longer burns the completion.
         if (!isClientConnectionOpen({ request, reply })) {
           return reply.hijack();
         }
@@ -92,11 +93,23 @@ export const sessionStatusRoutes: FastifyPluginAsync<SessionStatusRouteOptions> 
       case PendingAuthStatus.Error:
         return createErrorReply({ message: nextSession.errorMessage ?? "authentication_failed" });
       case PendingAuthStatus.Consumed:
-        // CQ-11: tokens were already delivered to a prior poll. We deliberately
+        // CQ-11: tokens were already ACKed by a prior poller. We deliberately
         // return the same 404 used for "unknown session" to avoid leaking
         // session existence after consumption.
         throw new NotFoundError({ debugMessage: "Pending auth session already consumed" });
     }
+  });
+
+  fastify.post<{ Reply: SuccessReply }>("/auth/session/status/ack", async (request) => {
+    const sessionToken = parseSessionTokenHeader(request.headers["x-sesori-session-token"]);
+    const tokenHash = PendingAuthStore.hashToken(sessionToken);
+
+    const completion = pendingAuthStore.consumeCompletion(tokenHash);
+    if (!completion) {
+      throw new NotFoundError({ debugMessage: "Pending auth session completion not found" });
+    }
+
+    return { success: true };
   });
 };
 
@@ -188,9 +201,9 @@ function createCompleteReply(params: {
   pendingAuthStore: PendingAuthStore;
   tokenHash: string;
 }): AuthSessionStatusCompleteReply {
-  const completion = params.pendingAuthStore.consumeCompletion(params.tokenHash);
+  const completion = params.pendingAuthStore.getCompletion(params.tokenHash);
   if (!completion) {
-    throw new NotFoundError({ debugMessage: "Pending auth session completion already consumed" });
+    throw new NotFoundError({ debugMessage: "Pending auth session completion not found" });
   }
 
   return {

--- a/src/services/pending-auth-store.ts
+++ b/src/services/pending-auth-store.ts
@@ -361,21 +361,31 @@ export class PendingAuthStore {
     });
   }
 
-  /**
-   * Atomically consume a completed session — returns tokens/user once, then
-   * deletes the entry. Subsequent calls return null (the LRU entry is gone,
-   * `getSessionByTokenHash` returns null too).
-   */
-  consumeCompletion(tokenHash: string): { tokens: PendingAuthTokens; user: UserProfile } | null {
+  /** Read a completed session without consuming it. The client must ACK before deletion. */
+  getCompletion(tokenHash: string): { tokens: PendingAuthTokens; user: UserProfile } | null {
     const entry = this.#getActiveEntry(tokenHash);
     if (!entry || entry.session.status !== PendingAuthStatus.Complete || !entry.session.tokens || !entry.session.user) {
       return null;
     }
 
-    const completion = {
+    return {
       tokens: { ...entry.session.tokens },
       user: { ...entry.session.user },
     };
+  }
+
+  /**
+   * Atomically consume a completed session after the client has acknowledged
+   * durable receipt — returns tokens/user once, then deletes the entry.
+   * Subsequent calls return null (the LRU entry is gone,
+   * `getSessionByTokenHash` returns null too).
+   */
+  consumeCompletion(tokenHash: string): { tokens: PendingAuthTokens; user: UserProfile } | null {
+    const completion = this.getCompletion(tokenHash);
+    const entry = this.#getActiveEntry(tokenHash);
+    if (!completion || !entry) {
+      return null;
+    }
 
     // Notify any pollers with a "consumed" status, then delete the entry.
     // The LRU dispose callback also notifies (with null), but the waiters set

--- a/src/services/pending-auth-store.ts
+++ b/src/services/pending-auth-store.ts
@@ -381,11 +381,15 @@ export class PendingAuthStore {
    * `getSessionByTokenHash` returns null too).
    */
   consumeCompletion(tokenHash: string): { tokens: PendingAuthTokens; user: UserProfile } | null {
-    const completion = this.getCompletion(tokenHash);
     const entry = this.#getActiveEntry(tokenHash);
-    if (!completion || !entry) {
+    if (!entry || entry.session.status !== PendingAuthStatus.Complete || !entry.session.tokens || !entry.session.user) {
       return null;
     }
+
+    const completion = {
+      tokens: { ...entry.session.tokens },
+      user: { ...entry.session.user },
+    };
 
     // Notify any pollers with a "consumed" status, then delete the entry.
     // The LRU dispose callback also notifies (with null), but the waiters set

--- a/tests/auth/session-status.test.ts
+++ b/tests/auth/session-status.test.ts
@@ -62,7 +62,7 @@ describe("GET /auth/session/status", () => {
     assert.ok(Date.now() - startedAt >= 20);
   });
 
-  it("returns a completed auth payload immediately and consumes it", async () => {
+  it("returns a completed auth payload immediately without consuming before ACK", async () => {
     const tokenHash = createPendingSession({ sessionToken: VALID_SESSION_TOKEN });
     pendingAuthStore.completeSession({ tokenHash, tokens: TEST_TOKENS, user: TEST_USER });
 
@@ -79,10 +79,10 @@ describe("GET /auth/session/status", () => {
       refreshToken: TEST_TOKENS.refreshToken,
       user: TEST_USER,
     });
-    assert.equal(pendingAuthStore.getSessionByTokenHash(tokenHash), null);
+    assert.equal(pendingAuthStore.getSessionByTokenHash(tokenHash)?.status, "complete");
   });
 
-  it("returns 404 after a completion has already been consumed", async () => {
+  it("returns the same completion until ACK, then returns 404", async () => {
     const tokenHash = createPendingSession({ sessionToken: VALID_SESSION_TOKEN });
     pendingAuthStore.completeSession({ tokenHash, tokens: TEST_TOKENS, user: TEST_USER });
 
@@ -96,13 +96,27 @@ describe("GET /auth/session/status", () => {
       url: "/auth/session/status",
       headers: { "x-sesori-session-token": VALID_SESSION_TOKEN },
     });
+    const ackResponse = await injectWithKeepAlive({
+      method: "POST",
+      url: "/auth/session/status/ack",
+      headers: { "x-sesori-session-token": VALID_SESSION_TOKEN },
+    });
+    const afterAckResponse = await injectWithKeepAlive({
+      method: "GET",
+      url: "/auth/session/status",
+      headers: { "x-sesori-session-token": VALID_SESSION_TOKEN },
+    });
 
     assert.equal(firstResponse.statusCode, 200);
-    assert.equal(secondResponse.statusCode, 404);
-    assert.equal(secondResponse.json<{ error: string }>().error, "not_found");
+    assert.deepEqual(secondResponse.json(), firstResponse.json());
+    assert.equal(ackResponse.statusCode, 200);
+    assert.deepEqual(ackResponse.json(), { success: true });
+    assert.equal(pendingAuthStore.getSessionByTokenHash(tokenHash), null);
+    assert.equal(afterAckResponse.statusCode, 404);
+    assert.equal(afterAckResponse.json<{ error: string }>().error, "not_found");
   });
 
-  it("keeps a completed session readable once when the waiting client disconnects before delivery", async () => {
+  it("keeps a completed session readable until ACK when the waiting client disconnects before delivery", async () => {
     const tokenHash = createPendingSession({ sessionToken: VALID_SESSION_TOKEN });
     const origin = await app.listen({ host: "127.0.0.1", port: 0 });
     const pendingRequest = openStatusRequest({ origin, sessionToken: VALID_SESSION_TOKEN });
@@ -134,8 +148,8 @@ describe("GET /auth/session/status", () => {
       refreshToken: TEST_TOKENS.refreshToken,
       user: TEST_USER,
     });
-    assert.equal(replayResponse.statusCode, 404);
-    assert.equal(replayResponse.json<{ error: string }>().error, "not_found");
+    assert.equal(replayResponse.statusCode, 200);
+    assert.deepEqual(replayResponse.json(), retryResponse.json());
   });
 
   it("returns denied when the pending session is denied during long-polling", async () => {
@@ -249,7 +263,7 @@ describe("GET /auth/session/status", () => {
     assert.equal(res.json<{ error: string }>().error, "not_found");
   });
 
-  it("only one of two concurrent pollers receives the tokens (QA-3)", async () => {
+  it("lets concurrent completed pollers receive the same payload before ACK", async () => {
     const tokenHash = createPendingSession({ sessionToken: VALID_SESSION_TOKEN });
     pendingAuthStore.completeSession({ tokenHash, tokens: TEST_TOKENS, user: TEST_USER });
 
@@ -267,9 +281,9 @@ describe("GET /auth/session/status", () => {
     ]);
 
     const completed = [a, b].filter((r) => r.statusCode === 200 && r.json().status === "complete");
-    assert.equal(completed.length, 1, "exactly one poller must consume the tokens");
-    const failed = [a, b].filter((r) => r.statusCode === 404);
-    assert.equal(failed.length, 1, "the losing poller must see 404 (CQ-11 conflation)");
+    assert.equal(completed.length, 2, "both pollers must see the same completion until ACK");
+    assert.deepEqual(a.json(), b.json());
+    assert.equal(pendingAuthStore.getSessionByTokenHash(tokenHash)?.status, "complete");
   });
 
   function createPendingSession(params: { sessionToken: string }): string {


### PR DESCRIPTION
## Summary\n- keep completed OAuth pending-session payloads readable to the same session token until the client acknowledges durable receipt\n- add POST /auth/session/status/ack to consume/delete completed sessions after mobile persists tokens\n- update session-status tests for repeated delivery, ACK consumption, disconnected waiter retry, and concurrent pollers\n\n## Verification\n- npm run build\n- npm run lint\n- node --import tsx --test --test-concurrency=1 tests/auth/session-status.test.ts\n- npm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require client ACK before consuming completed OAuth sessions to prevent token loss on disconnects and allow safe retries. Adds `POST /auth/session/status/ack`; completed payloads are repeatable until ACK, then future polls return 404.

- **New Features**
  - Added `POST /auth/session/status/ack` to consume a completed session after the client persists tokens.

- **Bug Fixes**
  - GET `/auth/session/status` now returns the same complete payload until ACK. Delivery only happens on a live connection. Disconnects and concurrent pollers can retry safely. After ACK, polls return 404.

<sup>Written for commit 8da199aadd00a4f323c0ecc226ff90124db56d50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

