### PR TITLE
fix(session-status): deterministic disconnect test + hijack observability + docs

### DIFF
--- a/src/routes/auth/session-status.ts
+++ b/src/routes/auth/session-status.ts
@@ -12,6 +12,8 @@
  *   400 { error: "bad_request" }                                — missing/invalid session-token header
  *   404 { error: "not_found" }                                  — unknown OR already-consumed (deliberately conflated, see CQ-11)
  *   410 { status: "expired" }
+ *   (no response, `reply.hijack()`) — connection was already dead at delivery time;
+ *                                     the session is left readable for a retry, see CLIENT-LIVENESS DELIVERY
  *
  * CQ-11 (404 conflation): once `complete` has been consumed by a previous
  * poll, the session entry is deleted. A subsequent poll with the same token
@@ -20,6 +22,16 @@
  * been delivered exactly once; revealing that a session "existed" would
  * leak no useful information to a legitimate client and could aid token
  * enumeration. Clients should treat 404 as terminal and reset their flow.
+ *
+ * CLIENT-LIVENESS DELIVERY (Android backgrounding): before consuming a
+ * `complete` session we re-check that the client connection is still
+ * writable (`request.raw.destroyed`, `request.socket.destroyed`,
+ * `reply.raw.writableEnded`). If not, we hijack the reply (no response
+ * sent) and leave the completion readable so the client's retry consumes
+ * it exactly once. A tiny race remains where the socket dies between the
+ * liveness check and the kernel flush; closing it would require an explicit
+ * client ack, which would either delay deletion or create a re-readable
+ * replay window — the very thing CQ-11 avoids.
  */
 
 import { FastifyPluginAsync, type FastifyReply, type FastifyRequest } from "fastify";
@@ -64,7 +76,16 @@ export const sessionStatusRoutes: FastifyPluginAsync<SessionStatusRouteOptions> 
     });
 
     if (!nextSession) {
+      // The waiter resolved null either because the abort signal fired
+      // (client disconnected) or because the session was evicted/expired
+      // mid-wait. If the socket is dead, hijack: a 404 to a dead socket is
+      // wasted I/O, and the legitimate retry hits the synchronous
+      // getSessionByTokenHash check at the top of this handler.
       if (!isClientConnectionOpen({ request, reply })) {
+        request.log.warn(
+          { tokenHashPrefix: tokenHash.slice(0, 8) },
+          "session-status: client disconnected before delivery; hijacking reply",
+        );
         return reply.hijack();
       }
       throw new NotFoundError({ debugMessage: "Pending auth session no longer exists" });
@@ -82,6 +103,10 @@ export const sessionStatusRoutes: FastifyPluginAsync<SessionStatusRouteOptions> 
         // kernel flushes the response; closing that would require an explicit
         // client ack, which would create a broader replay/read window.
         if (!isClientConnectionOpen({ request, reply })) {
+          request.log.warn(
+            { tokenHashPrefix: tokenHash.slice(0, 8) },
+            "session-status: client disconnected before complete delivery; preserving session for retry",
+          );
           return reply.hijack();
         }
         return createCompleteReply({ pendingAuthStore, tokenHash });

--- a/src/services/pending-auth-store.ts
+++ b/src/services/pending-auth-store.ts
@@ -402,6 +402,15 @@ export class PendingAuthStore {
    *
    * Race-safe: a status change happening between `getSessionByTokenHash` and
    * waiter registration triggers an immediate resolve via the re-check below.
+   *
+   * @param options.abortSignal Optional cancellation signal. When the signal
+   *   aborts, the waiter resolves to `null` (NOT to a session snapshot) —
+   *   callers should treat `null` as "do not deliver, the requester is gone
+   *   or no longer cares". If the signal is already aborted at call time,
+   *   the returned promise resolves to `null` synchronously without
+   *   registering a waiter. The abort listener is registered with
+   *   `{ once: true }` and removed on every other resolution path (status
+   *   change, timeout, removeWaiter), so callers do not need to clean up.
    */
   waitForStatusChange(
     tokenHash: string,

--- a/tests/auth/session-status.test.ts
+++ b/tests/auth/session-status.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
+import type { Socket } from "node:net";
 import Fastify, { type FastifyInstance, type InjectOptions, type LightMyRequestResponse } from "fastify";
 import { ApiError } from "../../src/lib/errors.js";
 import { sessionStatusRoutes } from "../../src/routes/auth/session-status.js";
@@ -105,14 +106,31 @@ describe("GET /auth/session/status", () => {
   it("keeps a completed session readable once when the waiting client disconnects before delivery", async () => {
     const tokenHash = createPendingSession({ sessionToken: VALID_SESSION_TOKEN });
     const origin = await app.listen({ host: "127.0.0.1", port: 0 });
-    const pendingRequest = openStatusRequest({ origin, sessionToken: VALID_SESSION_TOKEN });
 
-    await delay(10);
+    // Sync on the server-side socket 'close' event — the exact edge that
+    // fires the route's abort listener. Anything coarser (e.g. setTimeout)
+    // races the residual window documented in session-status.ts.
+    const serverConnection = new Promise<Socket>((resolve) => {
+      app.server.once("connection", (socket) => resolve(socket));
+    });
+    const requestReceived = new Promise<void>((resolve) => {
+      app.server.once("request", () => resolve());
+    });
+
+    const pendingRequest = openStatusRequest({ origin, sessionToken: VALID_SESSION_TOKEN });
+    const serverSocket = await serverConnection;
+    await requestReceived;
+    await flushHookChain();
+
+    // Registered after the route's own 'close' listener so Node fires them
+    // in order: the route's abort dispatch + waiter teardown run first.
+    const serverSocketClosed = new Promise<void>((resolve) => {
+      serverSocket.once("close", () => resolve());
+    });
     pendingRequest.destroy();
-    await pendingRequest.closed;
+    await Promise.all([pendingRequest.closed, serverSocketClosed]);
 
     pendingAuthStore.completeSession({ tokenHash, tokens: TEST_TOKENS, user: TEST_USER });
-    await delay(10);
 
     assert.equal(pendingAuthStore.getSessionByTokenHash(tokenHash)?.status, "complete");
 
@@ -318,7 +336,11 @@ describe("GET /auth/session/status", () => {
     };
   }
 
-  async function delay(ms: number): Promise<void> {
-    await new Promise((resolve) => setTimeout(resolve, ms));
+  async function flushHookChain(): Promise<void> {
+    // Two setImmediate yields drain Fastify's onRequest → preHandler → route
+    // dispatch so the handler reaches its first await (where the abort
+    // listener has been registered on the socket).
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
   }
 });


### PR DESCRIPTION
## Summary

Follow-up to #32. Three small, independent improvements to the long-poll disconnect fix:

1. **Fix a flaky integration test** (was failing ~80% of runs in the full suite, passes 10/10 now).
2. **Add observability** on both `reply.hijack()` branches via `request.log.warn` — without this we cannot tell whether the new race-mitigation arm fires 0.1% or 30% of the time in production.
3. **Document the new client-liveness contract** at the API boundaries (file-header docstring + `waitForStatusChange` JSDoc + the missing inline comment on the `!nextSession` hijack branch).

## Why now

The PR #32 fix landed on master, but the [integration test for its acceptance criterion A1](https://github.com/sesori-ai/sesori_auth_server/blob/master/tests/auth/session-status.test.ts#L105-L138) (`keeps a completed session readable once when the waiting client disconnects before delivery`) is flaky:

```
$ for i in 1..5; do npx tsx --test tests/auth/session-status.test.ts; done
Run 1: 10/11 pass (disconnect test FAIL)
Run 2: 11/11 pass
Run 3: 10/11 pass (disconnect test FAIL)
Run 4: 10/11 pass (disconnect test FAIL)
Run 5: 10/11 pass (disconnect test FAIL)
```

That means PR #32's Android-disconnect fix has no working CI guard. A regression in `createRequestCloseSignal` or `isClientConnectionOpen` would not fail CI.

## Root cause of the flake

The test uses `await pendingRequest.closed` (resolves on the **client's** request `'close'`) followed by `await delay(10)` before calling `completeSession()`. But:

- The client-side `'close'` event fires when the client socket is destroyed — locally, before the FIN reaches the server.
- The server-side socket `'close'` event (the one that fires the route's abort listener inside `createRequestCloseSignal`) happens **after** the FIN propagates and Node delivers it.
- `delay(10)` is **not synchronized** with the server-side observation. On a loaded test runner the server-side close listener has not yet fired when `completeSession()` runs.

Result: `completeSession()` notifies the waiter with the Complete session before the abort has had a chance to tear it down, the route resumes, `isClientConnectionOpen()` still returns `true` (the server has not yet observed the FIN), and `consumeCompletion()` deletes the session — which is exactly the documented residual race that the production code's own comment at [`session-status.ts:78-83`](https://github.com/sesori-ai/sesori_auth_server/blob/master/src/routes/auth/session-status.ts#L78-L83) acknowledges.

## Fix

Synchronize on the **server-side** socket `'close'` event instead:

```ts
const serverConnection = new Promise<Socket>((resolve) => {
  app.server.once("connection", (socket) => resolve(socket));
});
const requestReceived = new Promise<void>((resolve) => {
  app.server.once("request", () => resolve());
});

const pendingRequest = openStatusRequest({ origin, sessionToken: VALID_SESSION_TOKEN });
const serverSocket = await serverConnection;
await requestReceived;
await flushHookChain(); // 2x setImmediate — drains Fastify onRequest/preHandler

const serverSocketClosed = new Promise<void>((resolve) => {
  serverSocket.once("close", () => resolve());
});
pendingRequest.destroy();
await Promise.all([pendingRequest.closed, serverSocketClosed]);

pendingAuthStore.completeSession({ ... });
```

Two synchronization edges:

1. **Pre-destroy**: wait for the server's `'connection'` + `'request'` events plus a `flushHookChain()` so Fastify dispatches to the route handler before we destroy. The handler registers its socket-close listener synchronously before its first await.
2. **Post-destroy**: register `serverSocketClosed` **after** the route's listener so Node fires them in order (route's first, mine second). By the time mine fires, the abort dispatch and waiter teardown have already run synchronously inside the route's listener. Microtasks drain between the close event and my next test line, so the route handler's continuation (which calls `reply.hijack()`) runs before `completeSession()`.

Result: deterministic, no `delay()` anywhere in the test, 10/10 passes.

## Hijack observability

Both `reply.hijack()` branches now emit `request.log.warn`. The warn lines carry only the first 8 chars of the token hash to keep secrets out of logs. This lets operators quantify how often the new race-mitigation path fires:

```ts
if (!isClientConnectionOpen({ request, reply })) {
  request.log.warn(
    { tokenHashPrefix: tokenHash.slice(0, 8) },
    "session-status: client disconnected before complete delivery; preserving session for retry",
  );
  return reply.hijack();
}
```

## Documentation

- **File header of `session-status.ts`**: added the third terminal outcome (`(no response, reply.hijack())`) to the response matrix, plus a `CLIENT-LIVENESS DELIVERY` section mirroring the `CQ-11` block.
- **`PendingAuthStore.waitForStatusChange` JSDoc**: documented the new `options.abortSignal` parameter contract — resolves to `null` on abort, listener auto-cleanup, no caller responsibility.
- **`!nextSession` hijack branch**: added the missing inline "why" comment so both `reply.hijack()` call sites read symmetrically (the other branch already had a five-line "why" block).

## Verification

- `npm run build` → clean
- `npm run lint` → clean
- `npm run format:check` → clean
- `tests/auth/session-status.test.ts` → **10/10 runs pass** (was 1-2/5)
- `tests/services/pending-auth-store.test.ts` → 11/11 pass

## Scope of change

| File | +/- |
|---|---|
| `src/routes/auth/session-status.ts` | +25 / -0 |
| `src/services/pending-auth-store.ts` | +9 / -0 |
| `tests/auth/session-status.test.ts` | +28 / -6 |

No production logic changes — only observability log lines, docstring/comment additions, and the test fix. The route's behavior on the happy path and on the disconnect race is bit-identical to the merged PR #32.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the session-status disconnect test deterministic and add observability for hijacked responses. Also document the client‑liveness contract and waiter abort semantics; no runtime behavior change.

- **Bug Fixes**
  - Remove timeouts from the disconnect test and sync on the server-side socket close: wait for `connection` and `request`, flush Fastify hooks, destroy the client, then await the server socket `close`. Test is now reliable.

- **New Features**
  - Log `request.log.warn` on both `reply.hijack()` branches with a `tokenHashPrefix` (first 8 chars) to measure how often the race‑mitigation path triggers.

<sup>Written for commit c9c741f1d06e5b4f2ca9b192c5cf28001aeb47a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

