### PR TITLE
fix(install): resolve installer from stable v tags, not dropped bridge-v tags

### DIFF
--- a/src/services/install-script-service.ts
+++ b/src/services/install-script-service.ts
@@ -3,7 +3,13 @@ import { BadGatewayError } from "../lib/errors.js";
 
 const INSTALL_SCRIPT_REPO_OWNER = "sesori-ai";
 const INSTALL_SCRIPT_REPO_NAME = "sesori_apps_monorepo";
-const INSTALL_SCRIPT_TAG_PREFIX = "bridge-v";
+// Stable releases are tagged `vX.Y.Z`. The repo previously also published `bridge-vX.Y.Z`
+// tags; those were dropped, so matching `bridge-v` froze this resolver on the last legacy
+// tag (bridge-v1.0.7) and served stale install scripts. Match the `v` prefix and require a
+// clean three-part version so prerelease/internal tags (e.g. v1.1.1-internal.124) and any
+// other v-prefixed tag are ignored even if GitHub's prerelease flag is unset.
+const INSTALL_SCRIPT_TAG_PREFIX = "v";
+const STABLE_VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
 const INSTALL_SCRIPT_PATH_SH = "install.sh";
 const INSTALL_SCRIPT_PATH_PS1 = "install.ps1";
 const INSTALL_SCRIPT_CACHE_TTL_MS = 5 * 60 * 1000;
@@ -47,7 +53,8 @@ export type InstallScriptRelease = {
 };
 
 /**
- * Resolves the newest published bridge installer release and caches both script bodies together.
+ * Resolves the newest published stable bridge installer release (a `vX.Y.Z` tag) and caches both
+ * script bodies together.
  * GitHub transport details stay local to this service for now, while callers only consume install.sh/install.ps1 content.
  */
 export class InstallScriptService {
@@ -101,7 +108,11 @@ export class InstallScriptService {
   }
 
   #toEligibleRelease(release: GithubRelease): EligibleGithubRelease | null {
-    if (!release.tag_name.startsWith(INSTALL_SCRIPT_TAG_PREFIX) || release.draft || release.prerelease) {
+    if (release.draft || release.prerelease) {
+      return null;
+    }
+
+    if (!this.#isStableVersionTag(release.tag_name)) {
       return null;
     }
 
@@ -114,6 +125,15 @@ export class InstallScriptService {
       tagName: release.tag_name,
       publishedAt,
     };
+  }
+
+  #isStableVersionTag(tagName: string): boolean {
+    if (!tagName.startsWith(INSTALL_SCRIPT_TAG_PREFIX)) {
+      return false;
+    }
+
+    const versionText = tagName.slice(INSTALL_SCRIPT_TAG_PREFIX.length);
+    return STABLE_VERSION_PATTERN.test(versionText);
   }
 
   #compareEligibleReleases(left: EligibleGithubRelease, right: EligibleGithubRelease): number {

--- a/tests/install/install-script-service.test.ts
+++ b/tests/install/install-script-service.test.ts
@@ -127,38 +127,52 @@ describe("InstallScriptService", () => {
 
     const release = service.selectLatestRelease([
       createRelease("server-v9.0.0", "2026-03-02T10:00:00.000Z"),
-      createRelease("bridge-v1.2.0", "2026-03-03T10:00:00.000Z", { draft: true }),
-      createRelease("bridge-v1.3.0-rc.1", "2026-03-04T10:00:00.000Z", { prerelease: true }),
-      createRelease("bridge-v0.9.0", "not-a-date"),
-      createRelease("bridge-v1.1.0", "2026-03-01T10:00:00.000Z"),
+      createRelease("v1.2.0", "2026-03-03T10:00:00.000Z", { draft: true }),
+      createRelease("v1.3.0-rc.1", "2026-03-04T10:00:00.000Z", { prerelease: true }),
+      createRelease("v0.9.0", "not-a-date"),
+      createRelease("v1.1.0", "2026-03-01T10:00:00.000Z"),
     ]);
 
-    assert.equal(release.tagName, "bridge-v1.1.0");
+    assert.equal(release.tagName, "v1.1.0");
     assert.equal(release.publishedAt, "2026-03-01T10:00:00.000Z");
+  });
+
+  it("excludes prerelease/internal version tags even when not flagged as prerelease", () => {
+    const service = new InstallScriptService();
+
+    // Internal builds (e.g. v1.1.1-internal.124) are newer by date but must never be served as the
+    // installer. Guard on the tag shape too, not just GitHub's prerelease flag.
+    const release = service.selectLatestRelease([
+      createRelease("v1.1.1-internal.124", "2026-03-20T10:00:00.000Z"),
+      createRelease("voice-v9.9.9", "2026-03-19T10:00:00.000Z"),
+      createRelease("v1.1.0", "2026-03-01T10:00:00.000Z"),
+    ]);
+
+    assert.equal(release.tagName, "v1.1.0");
   });
 
   it("selects the newest eligible release by published_at", () => {
     const service = new InstallScriptService();
 
     const release = service.selectLatestRelease([
-      createRelease("bridge-v1.2.0", "2026-02-12T08:30:00.000Z"),
-      createRelease("bridge-v1.4.0", "2026-02-14T08:30:00.000Z"),
-      createRelease("bridge-v1.3.0", "2026-02-13T08:30:00.000Z"),
+      createRelease("v1.2.0", "2026-02-12T08:30:00.000Z"),
+      createRelease("v1.4.0", "2026-02-14T08:30:00.000Z"),
+      createRelease("v1.3.0", "2026-02-13T08:30:00.000Z"),
     ]);
 
-    assert.equal(release.tagName, "bridge-v1.4.0");
+    assert.equal(release.tagName, "v1.4.0");
   });
 
   it("uses descending tag_name as the deterministic numeric tie-breaker", () => {
     const service = new InstallScriptService();
 
     const release = service.selectLatestRelease([
-      createRelease("bridge-v1.9.0", "2026-02-14T08:30:00.000Z"),
-      createRelease("bridge-v1.10.0", "2026-02-14T08:30:00.000Z"),
-      createRelease("bridge-v1.8.9", "2026-02-14T08:30:00.000Z"),
+      createRelease("v1.9.0", "2026-02-14T08:30:00.000Z"),
+      createRelease("v1.10.0", "2026-02-14T08:30:00.000Z"),
+      createRelease("v1.8.9", "2026-02-14T08:30:00.000Z"),
     ]);
 
-    assert.equal(release.tagName, "bridge-v1.10.0");
+    assert.equal(release.tagName, "v1.10.0");
   });
 
   it("throws BadGatewayError when no eligible release exists", () => {
@@ -167,7 +181,7 @@ describe("InstallScriptService", () => {
     assert.throws(
       () =>
         service.selectLatestRelease([
-          createRelease("bridge-v1.0.0", "2026-02-14T08:30:00.000Z", { draft: true }),
+          createRelease("v1.0.0", "2026-02-14T08:30:00.000Z", { draft: true }),
           createRelease("web-v1.0.0", "2026-02-14T08:30:00.000Z"),
         ]),
       (error: unknown) => {
@@ -180,7 +194,7 @@ describe("InstallScriptService", () => {
 
   it("continues fetching release pages until it finds an eligible release and then downloads both scripts", async (t) => {
     const service = new InstallScriptService();
-    const tag = "bridge-v1.4.0";
+    const tag = "v1.4.0";
     const timeoutCalls: number[] = [];
     t.mock.method(AbortSignal, "timeout", (delay: number) => {
       timeoutCalls.push(delay);
@@ -193,7 +207,7 @@ describe("InstallScriptService", () => {
           createJsonResponse(
             [
               createRelease("server-v1.2.0", "2026-02-10T08:30:00.000Z"),
-              createRelease("bridge-v1.2.0", "2026-02-10T08:30:00.000Z", { prerelease: true }),
+              createRelease("v1.2.0", "2026-02-10T08:30:00.000Z", { prerelease: true }),
             ],
             {
               headers: {
@@ -225,8 +239,8 @@ describe("InstallScriptService", () => {
 
   it("keeps comparing eligible releases across pages by published_at", async (t) => {
     const service = new InstallScriptService();
-    const olderTag = "bridge-v1.4.0";
-    const newerTag = "bridge-v1.5.0";
+    const olderTag = "v1.4.0";
+    const newerTag = "v1.5.0";
     const fetchMock = createFetchMock(t, {
       [releasesUrl(1)]: [
         () =>
@@ -262,7 +276,7 @@ describe("InstallScriptService", () => {
 
   it("reuses one atomic cache entry for cache hits across both script getters", async (t) => {
     const service = new InstallScriptService();
-    const tag = "bridge-v1.4.0";
+    const tag = "v1.4.0";
     let now = 1_000;
     t.mock.method(Date, "now", () => now);
 
@@ -286,8 +300,8 @@ describe("InstallScriptService", () => {
 
   it("single-flights concurrent expired-cache refreshes through one shared promise", async (t) => {
     const service = new InstallScriptService();
-    const initialTag = "bridge-v1.0.0";
-    const refreshedTag = "bridge-v1.1.0";
+    const initialTag = "v1.0.0";
+    const refreshedTag = "v1.1.0";
     let now = 10_000;
     let releasePageTwoResolve!: (value: Response) => void;
     const releasePageTwoPromise = new Promise<Response>((resolve) => {
@@ -329,7 +343,7 @@ describe("InstallScriptService", () => {
 
   it("extends the ttl without refetching script bodies when the selected tag is unchanged", async (t) => {
     const service = new InstallScriptService();
-    const tag = "bridge-v1.4.0";
+    const tag = "v1.4.0";
     let now = 50_000;
     t.mock.method(Date, "now", () => now);
 
@@ -365,8 +379,8 @@ describe("InstallScriptService", () => {
 
   it("atomically replaces the cached scripts when the selected tag changes", async (t) => {
     const service = new InstallScriptService();
-    const initialTag = "bridge-v1.0.0";
-    const updatedTag = "bridge-v1.1.0";
+    const initialTag = "v1.0.0";
+    const updatedTag = "v1.1.0";
     let now = 75_000;
     t.mock.method(Date, "now", () => now);
 
@@ -408,7 +422,7 @@ describe("InstallScriptService", () => {
 
   it("throws BadGatewayError when script content is missing during a cold refresh", async (t) => {
     const service = new InstallScriptService();
-    const tag = "bridge-v1.4.0";
+    const tag = "v1.4.0";
     const fetchMock = createFetchMock(t, {
       [releasesUrl(1)]: [() => createJsonResponse([createRelease(tag, "2026-02-14T08:30:00.000Z")])],
       [contentsUrl("install.sh", tag)]: [() => createTextResponse("")],
@@ -428,8 +442,8 @@ describe("InstallScriptService", () => {
 
   it("keeps stale cached scripts and extends expiry after a warm refresh failure", async (t) => {
     const service = new InstallScriptService();
-    const initialTag = "bridge-v2.0.0";
-    const updatedTag = "bridge-v2.1.0";
+    const initialTag = "v2.0.0";
+    const updatedTag = "v2.1.0";
     let now = 100_000;
     t.mock.method(Date, "now", () => now);
 

--- a/tests/install/routes.test.ts
+++ b/tests/install/routes.test.ts
@@ -166,8 +166,8 @@ describe("Install routes", () => {
 
   it("GET /install.sh and /install.ps1 stay paired across a refresh when the release tag changes", async (t) => {
     const ctx = await createLiveServiceRouteTestApp(t);
-    const tagOne = "bridge-v1.4.0";
-    const tagTwo = "bridge-v1.5.0";
+    const tagOne = "v1.4.0";
+    const tagTwo = "v1.5.0";
     let now = 1_000;
     t.mock.method(Date, "now", () => now);
 

--- a/tests/install/wiring.test.ts
+++ b/tests/install/wiring.test.ts
@@ -54,7 +54,7 @@ describe("Install script service wiring", () => {
         return new Response(
           JSON.stringify([
             {
-              tag_name: "bridge-v1.2.0",
+              tag_name: "v1.2.0",
               draft: false,
               prerelease: false,
               published_at: "2026-04-16T08:00:00.000Z",
@@ -64,11 +64,11 @@ describe("Install script service wiring", () => {
         );
       }
 
-      if (url.includes("/contents/install.sh?ref=bridge-v1.2.0")) {
+      if (url.includes("/contents/install.sh?ref=v1.2.0")) {
         return new Response("#!/bin/sh\necho real\n", { status: 200 });
       }
 
-      if (url.includes("/contents/install.ps1?ref=bridge-v1.2.0")) {
+      if (url.includes("/contents/install.ps1?ref=v1.2.0")) {
         return new Response("Write-Output real\n", { status: 200 });
       }
 


### PR DESCRIPTION
## Problem

A Windows user running the installer hit:

```
Invoke-RestMethod : Invalid URI: The hostname could not be parsed.
```

Root cause is **here in the auth server**, not the install script. `InstallScriptService` resolves which GitHub release to serve `install.sh` / `install.ps1` from by filtering release tags with a `bridge-v` prefix:

```ts
const INSTALL_SCRIPT_TAG_PREFIX = "bridge-v";
```

The monorepo **dropped `bridge-v` tags** and now ships stable releases as `vX.Y.Z`. The newest tag still matching `bridge-v*` is `bridge-v1.0.7`, so this service froze on that ancient ref and kept serving its install scripts — which predate:

- the PowerShell `${ReleasesApiUrl}` brace fix (the actual URI crash)
- Windows ARM64 support
- the `bridge-v` tag removal itself

So `sesori.com/install.ps1` (and `install.sh`) have been stale for every release since `bridge-v1.0.7`.

## Fix

- Match the `v` prefix instead of `bridge-v`.
- Require a clean three-part version (`^\d+\.\d+\.\d+$`) so prerelease/internal tags (e.g. `v1.1.1-internal.124`) and any stray `v`-prefixed tag are rejected **even if GitHub's `prerelease` flag is unset** — defense against the same tag-convention drift that caused this incident.

This resolves to the latest stable release (currently `v1.1.0`, which contains the PowerShell fix).

## Tests

- Renamed all install test fixtures from `bridge-v*` to `v*`.
- Added a regression test: an internal tag (`v1.1.1-internal.124`) that is **not** flagged `prerelease`, plus a non-version `v`-prefixed tag (`voice-v9.9.9`), are both excluded; the stable `v1.1.0` wins.

Local: `tests/install/*` (21 tests) pass, `tsc`, `eslint`, and `prettier --check` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes installer release selection to use stable `vX.Y.Z` tags instead of the dropped `bridge-v` tags. This updates the served `install.sh`/`install.ps1` and prevents the Windows PowerShell URI error.

- **Bug Fixes**
  - Resolve releases from `v` tags and require a strict `X.Y.Z` version, rejecting internal/prerelease-like tags even if `prerelease` is false.
  - Updated tests: renamed fixtures to `v*` and added a regression case to ensure unflagged internal tags are ignored and the latest stable wins.

<sup>Written for commit de8db040bca52297c0daa4b97e4cc34e09525fe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

