### PR TITLE
feat(install): UTF-8 charset + X-Sesori-Install-Version header on install routes

### DIFF
--- a/src/routes/install.ts
+++ b/src/routes/install.ts
@@ -9,12 +9,14 @@ export const installRoutes: FastifyPluginAsync<InstallRouteOptions> = async (fas
   const { installScriptService } = opts;
 
   fastify.get<{ Reply: string }>("/install.sh", async (_request, reply) => {
-    const scriptBody = await installScriptService.getInstallSh();
-    reply.type("text/plain").send(scriptBody);
+    const script = await installScriptService.getInstallSh();
+    // charset=utf-8 is required: the scripts contain UTF-8 box-drawing characters; without it
+    // clients (PowerShell, terminals) default to a single-byte codepage and render mojibake.
+    reply.header("x-sesori-install-version", script.version).type("text/plain; charset=utf-8").send(script.body);
   });
 
   fastify.get<{ Reply: string }>("/install.ps1", async (_request, reply) => {
-    const scriptBody = await installScriptService.getInstallPs1();
-    reply.type("text/plain").send(scriptBody);
+    const script = await installScriptService.getInstallPs1();
+    reply.header("x-sesori-install-version", script.version).type("text/plain; charset=utf-8").send(script.body);
   });
 };

--- a/src/services/install-script-service.ts
+++ b/src/services/install-script-service.ts
@@ -52,6 +52,12 @@ export type InstallScriptRelease = {
   installPowerShellPath: string;
 };
 
+export type ResolvedInstallScript = {
+  /** Stable release version the script body was resolved from, e.g. "1.1.0" (no `v` prefix). */
+  version: string;
+  body: string;
+};
+
 /**
  * Resolves the newest published stable bridge installer release (a `vX.Y.Z` tag) and caches both
  * script bodies together.
@@ -67,14 +73,18 @@ export class InstallScriptService {
   #cacheEntry: InstallScriptCacheEntry | null = null;
   #refreshPromise: Promise<InstallScriptCacheEntry> | null = null;
 
-  async getInstallSh(): Promise<string> {
+  async getInstallSh(): Promise<ResolvedInstallScript> {
     const cacheEntry = await this.#getCacheEntry();
-    return cacheEntry.installSh;
+    return { version: this.#toVersion(cacheEntry.tag), body: cacheEntry.installSh };
   }
 
-  async getInstallPs1(): Promise<string> {
+  async getInstallPs1(): Promise<ResolvedInstallScript> {
     const cacheEntry = await this.#getCacheEntry();
-    return cacheEntry.installPs1;
+    return { version: this.#toVersion(cacheEntry.tag), body: cacheEntry.installPs1 };
+  }
+
+  #toVersion(tag: string): string {
+    return tag.startsWith(INSTALL_SCRIPT_TAG_PREFIX) ? tag.slice(INSTALL_SCRIPT_TAG_PREFIX.length) : tag;
   }
 
   selectLatestRelease(releasesPayload: unknown): InstallScriptRelease {

--- a/tests/install/install-script-service.test.ts
+++ b/tests/install/install-script-service.test.ts
@@ -224,8 +224,10 @@ describe("InstallScriptService", () => {
     const installSh = await service.getInstallSh();
     const installPs1 = await service.getInstallPs1();
 
-    assert.equal(installSh, "#!/bin/sh\necho bridge\n");
-    assert.equal(installPs1, "Write-Output bridge\n");
+    assert.equal(installSh.body, "#!/bin/sh\necho bridge\n");
+    assert.equal(installPs1.body, "Write-Output bridge\n");
+    assert.equal(installSh.version, "1.4.0");
+    assert.equal(installPs1.version, "1.4.0");
     assert.deepEqual(
       fetchMock.calls.map((call) => call.url),
       [releasesUrl(1), releasesUrl(2), contentsUrl("install.sh", tag), contentsUrl("install.ps1", tag)],
@@ -264,8 +266,9 @@ describe("InstallScriptService", () => {
     const installSh = await service.getInstallSh();
     const installPs1 = await service.getInstallPs1();
 
-    assert.equal(installSh, "#!/bin/sh\necho newer\n");
-    assert.equal(installPs1, "Write-Output newer\n");
+    assert.equal(installSh.body, "#!/bin/sh\necho newer\n");
+    assert.equal(installPs1.body, "Write-Output newer\n");
+    assert.equal(installSh.version, "1.5.0");
     assert.deepEqual(
       fetchMock.calls.map((call) => call.url),
       [releasesUrl(1), releasesUrl(2), contentsUrl("install.sh", newerTag), contentsUrl("install.ps1", newerTag)],
@@ -290,8 +293,9 @@ describe("InstallScriptService", () => {
     now += service.cacheTtlMs - 1;
     const installPs1 = await service.getInstallPs1();
 
-    assert.equal(installSh, "curl -fsSL https://example.test/install.sh | sh");
-    assert.equal(installPs1, "irm https://example.test/install.ps1 | iex");
+    assert.equal(installSh.body, "curl -fsSL https://example.test/install.sh | sh");
+    assert.equal(installPs1.body, "irm https://example.test/install.ps1 | iex");
+    assert.equal(installSh.version, "1.4.0");
     assert.equal(fetchMock.calls.length, 3);
     assertGithubRequestMetadata(fetchMock.calls);
     assertOnlyAllowedGithubUrls(fetchMock.calls);
@@ -332,8 +336,9 @@ describe("InstallScriptService", () => {
 
     const [installSh, installPs1] = await Promise.all([installShPromise, installPs1Promise]);
 
-    assert.equal(installSh, "refreshed-sh");
-    assert.equal(installPs1, "refreshed-ps1");
+    assert.equal(installSh.body, "refreshed-sh");
+    assert.equal(installPs1.body, "refreshed-ps1");
+    assert.equal(installSh.version, "1.1.0");
     assert.equal(fetchMock.calls.filter((call) => call.url === contentsUrl("install.sh", refreshedTag)).length, 1);
     assert.equal(fetchMock.calls.filter((call) => call.url === contentsUrl("install.ps1", refreshedTag)).length, 1);
     assertGithubRequestMetadata(fetchMock.calls);
@@ -361,7 +366,7 @@ describe("InstallScriptService", () => {
     now += service.cacheTtlMs;
     const installPs1 = await service.getInstallPs1();
 
-    assert.equal(installPs1, "stable-ps1");
+    assert.equal(installPs1.body, "stable-ps1");
     assert.deepEqual(
       fetchMock.calls.map((call) => call.url),
       [releasesUrl(1), contentsUrl("install.sh", tag), contentsUrl("install.ps1", tag), releasesUrl(1)],
@@ -370,7 +375,7 @@ describe("InstallScriptService", () => {
     now += service.cacheTtlMs - 1;
     const installSh = await service.getInstallSh();
 
-    assert.equal(installSh, "stable-sh");
+    assert.equal(installSh.body, "stable-sh");
     assert.equal(fetchMock.calls.length, 4);
     assertGithubRequestMetadata(fetchMock.calls);
     assertOnlyAllowedGithubUrls(fetchMock.calls);
@@ -401,8 +406,8 @@ describe("InstallScriptService", () => {
     const refreshedInstallPs1 = await service.getInstallPs1();
     const refreshedInstallSh = await service.getInstallSh();
 
-    assert.equal(refreshedInstallPs1, "updated-ps1");
-    assert.equal(refreshedInstallSh, "updated-sh");
+    assert.equal(refreshedInstallPs1.body, "updated-ps1");
+    assert.equal(refreshedInstallSh.body, "updated-sh");
     assert.deepEqual(
       fetchMock.calls.map((call) => call.url),
       [
@@ -463,12 +468,12 @@ describe("InstallScriptService", () => {
     now += service.cacheTtlMs;
     const staleInstallPs1 = await service.getInstallPs1();
 
-    assert.equal(staleInstallPs1, "stale-ps1");
+    assert.equal(staleInstallPs1.body, "stale-ps1");
 
     now += service.cacheTtlMs - 1;
     const staleInstallSh = await service.getInstallSh();
 
-    assert.equal(staleInstallSh, "stale-sh");
+    assert.equal(staleInstallSh.body, "stale-sh");
     assertGithubRequestMetadata(fetchMock.calls);
     assertOnlyAllowedGithubUrls(fetchMock.calls);
     fetchMock.assertExhausted();

--- a/tests/install/routes.test.ts
+++ b/tests/install/routes.test.ts
@@ -104,8 +104,8 @@ describe("Install routes", () => {
   }
 
   const installScriptService: Pick<InstallScriptService, "getInstallSh" | "getInstallPs1"> = {
-    getInstallSh: async () => "#!/bin/sh\necho install\n",
-    getInstallPs1: async () => "Write-Output 'install'\n",
+    getInstallSh: async () => ({ version: "1.2.3", body: "#!/bin/sh\necho install\n" }),
+    getInstallPs1: async () => ({ version: "1.2.3", body: "Write-Output 'install'\n" }),
   };
 
   async function createRouteTestApp(t: NodeTestContext): Promise<TestContext> {
@@ -127,7 +127,8 @@ describe("Install routes", () => {
       });
 
       assert.equal(res.statusCode, 200);
-      assert.match(res.headers["content-type"] ?? "", /text\/plain/);
+      assert.match(res.headers["content-type"] ?? "", /text\/plain;\s*charset=utf-8/);
+      assert.equal(res.headers["x-sesori-install-version"], "1.2.3");
       assert.equal(res.body, "#!/bin/sh\necho install\n");
     } finally {
       await ctx.cleanup();
@@ -143,7 +144,8 @@ describe("Install routes", () => {
       });
 
       assert.equal(res.statusCode, 200);
-      assert.match(res.headers["content-type"] ?? "", /text\/plain/);
+      assert.match(res.headers["content-type"] ?? "", /text\/plain;\s*charset=utf-8/);
+      assert.equal(res.headers["x-sesori-install-version"], "1.2.3");
       assert.equal(res.body, "Write-Output 'install'\n");
     } finally {
       await ctx.cleanup();
@@ -189,6 +191,7 @@ describe("Install routes", () => {
 
       assert.equal(firstSh.statusCode, 200);
       assert.equal(firstSh.body, "first-sh");
+      assert.equal(firstSh.headers["x-sesori-install-version"], "1.4.0");
       assert.equal(firstPs1.statusCode, 200);
       assert.equal(firstPs1.body, "first-ps1");
 
@@ -199,6 +202,7 @@ describe("Install routes", () => {
 
       assert.equal(secondSh.statusCode, 200);
       assert.equal(secondSh.body, "second-sh");
+      assert.equal(secondSh.headers["x-sesori-install-version"], "1.5.0");
       assert.equal(secondPs1.statusCode, 200);
       assert.equal(secondPs1.body, "second-ps1");
       assert.deepEqual(

--- a/tests/install/wiring.test.ts
+++ b/tests/install/wiring.test.ts
@@ -27,8 +27,8 @@ describe("Install script service wiring", () => {
     mockMongoHarness(t);
 
     const installScriptService = {
-      getInstallSh: async () => "#!/bin/sh\necho stub\n",
-      getInstallPs1: async () => "Write-Output stub\n",
+      getInstallSh: async () => ({ version: "9.9.9", body: "#!/bin/sh\necho stub\n" }),
+      getInstallPs1: async () => ({ version: "9.9.9", body: "Write-Output stub\n" }),
     } as InstallScriptService;
 
     const ctx = await createTestApp({ installScriptService });


### PR DESCRIPTION
Follow-up to #35 (which fixed *which* release the installer is served from). This PR fixes how the install responses are returned.

## 1. Fix mojibake (missing UTF-8 charset)

The served scripts contain UTF-8 box-drawing characters (`─`, U+2500). The responses were `content-type: text/plain` with **no charset**, so clients that don't default to UTF-8 (PowerShell `irm`, some terminals/editors) decoded the bytes as a single-byte codepage (Windows-1252) and rendered mojibake:

```
# â”€â”€ Verify binary â”€â”€â”€â”€â”€â”€â”€...   # what the user saw
# ── Verify binary ───────...   # what the file actually contains
```

Verified against `https://api.sesori.com/install.ps1`: the bytes on the wire are **valid UTF-8** (`iconv -f UTF-8` passes; hexdump shows `e2 94 80`). The corruption is purely client-side decoding due to the missing charset. Fix: serve `text/plain; charset=utf-8`.

## 2. Surface the resolved version (`X-Sesori-Install-Version`)

Add a response header exposing the stable release version the script body was resolved from (e.g. `1.1.0`), so it's possible to see which release the served installer came from without diffing the body. Header prefix matches the existing `X-Sesori-*` convention.

`InstallScriptService.getInstallSh()/getInstallPs1()` now return `{ version, body }` — the version is derived from the resolved `vX.Y.Z` tag and read atomically from the same cache entry as the body (no second cache read / no tag/body skew).

## Tests

- Updated install unit/route/wiring tests to the new `{ version, body }` shape.
- Added coverage: version derivation from tag, `charset=utf-8` on the content-type, and the `X-Sesori-Install-Version` header value (stubbed + live-service route paths).

Local: `tests/install/*` (21) pass, `tsc --noEmit`, `eslint`, `prettier --check` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve install scripts correctly across clients and surface the resolved release version. Adds UTF-8 charset to responses and a version header on `/install.sh` and `/install.ps1`.

- **Bug Fixes**
  - Send `text/plain; charset=utf-8` to prevent mojibake in PowerShell and some terminals.

- **New Features**
  - Add `X-Sesori-Install-Version` header with the stable version (e.g. `1.1.0`).
  - `InstallScriptService.getInstallSh/getInstallPs1` now return `{ version, body }` derived atomically from the cached `vX.Y.Z` tag.

<sup>Written for commit 8579610c52ed29576ca4d8e7975b7932d358a2e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

