### PR TITLE
feat(auth): describe requesting device on OAuth confirmation instead of match code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Generated code — collapse diffs on GitHub and exclude from language stats
+*.test.ts linguist-generated=true
+*.test.js linguist-generated=true
+*.test.tsx linguist-generated=true
+*.test.jsx linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ keys/
 .sisyphus/
 
 *.worktrees/
+.DS_Store

--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: address-pr-comments
+description: Address unresolved inline PR review comments on a GitHub pull request. Fetches unresolved comments, assesses validity (with extra scrutiny for AI/bot reviewers), implements fixes, leaves a reply on every comment thread, and commits changes. Use when the user asks to address PR comments, resolve review feedback, implement requested changes, or handle PR review threads.
+---
+
+# address-pr-comments
+
+Addresses unresolved inline PR review comments by assessing their validity, implementing fixes, and leaving a reply on each comment thread. Every thread gets a response — either confirming the fix or explaining why the comment was not addressed.
+
+## Core Rules
+
+1. **Unresolved comments only**: Unless explicitly told otherwise, only fetch and address comments where `is_resolved == false`. Use the `--unresolved` flag.
+2. **Every thread gets a reply**: After assessing and acting on a comment, you MUST post a reply to that comment thread. No thread should be left without a response.
+3. **Do not reply twice**: Before posting a reply, inspect the comments after the most recent `[Sesori reply]`. If the last comment is already a `[Sesori reply]` and there are no later reviewer comments, skip the thread. If the only later comments are acknowledgment-only bot comments (for example "Acknowledged", "Thanks", "Looks good", or "Accepted") with no new request, objection, question, or requested change, skip the thread. Do not skip if a later comment raises a follow-up, pushback, asks for clarification, or requests additional changes; handle that as a new actionable comment.
+4. **Reply prefix**: Every reply must start with `[Sesori reply]` so it is clear the response comes from the agent, not the human user.
+5. **All comments are assessed**: Every comment must be evaluated for validity. Do not automatically assume any comment is correct.
+6. **Extra scrutiny for AI/bot comments**: Comments from AI reviewers or bots require more careful assessment. They are more likely to be incorrect, irrelevant, or based on stale context.
+7. **Human comments are trusted by default**: Comments from actual humans should be assumed valid unless you have a strong reason to believe they are wrong, detrimental, or cause likely unintended side effects.
+8. **Single commit**: All fixes can be committed together in a single commit. The user squash-merges at the end.
+9. **Never amend**: Always create new commits when addressing feedback. Do not use `git commit --amend`, `git rebase` to rewrite published history, or any other history-rewriting operation. If you make a mistake in a commit, fix it with a follow-up commit rather than rewriting.
+10. **Never force push**: Do not use force push under any circumstances. If the remote branch has moved ahead of your local branch, pull/merge and continue with normal commits. History rewriting on a shared branch is forbidden.
+11. **Outdated comments**: If `is_outdated == true`, assess whether the comment is still relevant. If the issue still exists in the current code, address it. If not, reply explaining why it is no longer applicable.
+
+## Workflow
+
+### Step 1: Fetch Unresolved Comments
+
+Use the `pr-inline-comments` skill to fetch ONLY unresolved comments:
+
+```bash
+../pr-inline-comments/scripts/fetch.sh <pr-number> --unresolved [--repo OWNER/REPO]
+```
+
+If the user specifies a time window (e.g., "since yesterday"), also pass `--since <ISO_8601>`.
+
+**Important:** The JSON output can be large and may get truncated in the terminal. Always save it to a file first:
+
+```bash
+../pr-inline-comments/scripts/fetch.sh <pr-number> --unresolved > /tmp/pr_comments.json
+```
+
+Then parse the file with `jq` or similar tools. You will receive an array of thread objects. Each thread contains:
+- `thread_id`: The root comment ID (use this for posting replies)
+- `path`: File path
+- `line`: Line number
+- `is_resolved`, `is_outdated`: Resolution status
+- `comments[]`: Array of comments in the thread, each with `user`, `body`, `created_at`
+
+### Step 2: Assess Each Comment
+
+For each comment thread, read the relevant code and assess the comment's validity.
+
+#### Validity Assessment
+
+A comment is **valid** if:
+- It correctly identifies a real issue (bug, style violation, architecture problem, missing test, etc.)
+- The suggested change is appropriate and correct
+- It is actionable and clear
+
+A comment is **invalid** if:
+- It is based on a misunderstanding of the code
+- The suggestion would introduce a bug or worsen the code
+- It is stylistically opinionated without project convention backing
+- It suggests that the syntax is invalid but the analyzer accepts it
+- It is outdated and no longer applies
+- It is from an AI/bot and contains obvious hallucinations or generic advice
+
+#### AI/Bot Identification
+
+Apply extra scrutiny when the comment author (`user` field) matches any of these patterns:
+- Username indicates author is a bot — commonly name contains: `bot`, `[bot]`, `github-actions`, `codex`, `gemini`, `copilot`, `claude`, `gpt`, `ai-`
+- The comment uses very formal, mechanical, or templated language
+- The suggestion is generic and lacks specific context about this codebase
+
+For AI/bot comments:
+- Verify the claim by reading the actual code
+- Check if the suggestion aligns with existing codebase patterns
+- Do not implement blindly — apply the same critical thinking you would use on your own code
+
+#### Acknowledgment-only bot follow-ups
+
+Some bots post a short acknowledgment after the `[Sesori reply]` instead of resolving the thread. Treat the thread as already addressed when every comment after the most recent `[Sesori reply]` is acknowledgment-only, such as "Acknowledged", "Thanks", "Looks good", "Accepted", or equivalent non-actionable wording.
+
+Do not treat a bot follow-up as acknowledgment-only if it contains any of the following:
+- a new requested change or clarification
+- a question about the fix
+- a pushback or objection
+- a statement that the previous reply did not address the original concern
+- a new link, suggestion, or actionable review note
+
+For human follow-ups, assume the follow-up is actionable unless it is explicitly just an acknowledgment.
+
+For human comments:
+- Assume the comment is correct unless you have strong evidence otherwise
+- If you disagree, still explain your reasoning in the reply
+- If you disagreed with a given reason, but the human replied to still go ahead and do it, you must proceed with the requested task
+
+### Step 3: Implement Fixes
+
+For each valid comment:
+
+1. Read the file(s) referenced in the comment
+2. Understand the context around the commented line
+3. Make the minimal, correct fix
+4. Verify the fix does not break existing functionality
+5. If multiple comments affect the same file, batch the changes
+
+Fix guidelines:
+- Fix minimally. Do not refactor unrelated code.
+- A small, safe hardening or cleanup a reviewer flags **inside a file or class your PR already modifies** is in scope — implement it rather than declining it as "pre-existing" or "out of scope." Reserve those reasons for genuinely unrelated files or large/risky refactors.
+- Follow existing codebase conventions (style, naming, patterns)
+- If a comment requests a specific approach and you disagree, use your judgment but explain in the reply
+- If you are changing logic or fixing logic bugs/edge case omissions/etc, use TDD (write a failing test first)
+- Do not suppress type errors with `as any`, `@ts-ignore`, or `@ts-expect-error`
+
+### Step 4: Commit and Push Changes
+
+After all fixes have been implemented, check the worktree status first. If there are pre-existing modifications or untracked files unrelated to the PR comments, warn the user and ask whether to proceed before committing.
+
+```bash
+git status
+```
+
+If the worktree is clean except for the files you modified for the PR comments, stage and commit only those files:
+
+```bash
+git add <file1> <file2> ...
+git commit -m "fix: address PR review comments"
+```
+
+**Never** stage unrelated work in a PR feedback commit. Do not use `git add -A`.
+
+Or use a more specific message if the changes are purely stylistic or architectural:
+
+```bash
+git commit -m "refactor: address PR review feedback"
+```
+
+Then push the commit so the fixes are visible on the remote branch:
+
+```bash
+git push origin <branch-name>
+```
+
+**Important:** Always commit and push BEFORE posting replies. If you post "Addressed" before pushing, the fixes won't be visible to reviewers, making the replies misleading.
+
+**Important:** Never rewrite history when addressing PR feedback. Do not amend commits and do not force push. If the remote branch has diverged, pull/merge normally and add new commits on top. The user squash-merges at the end, so a linear chain of fix commits is expected.
+
+**No changes to commit:** If all fetched comments were invalid, outdated, or questions requiring no code change, skip the commit and push steps. Proceed directly to posting replies.
+
+### Step 5: Leave Replies
+
+After the commit has been successfully pushed, post a reply to each comment thread explaining what was done.
+
+**Reply format for Addressed and Partially addressed:**
+```
+[Sesori reply] <status> (in commit <commit_hash>)
+
+<detailed explanation>
+```
+
+The explanation must describe **what** was changed and **why**, not just restate the status. A reply that only says "Addressed" or "Fixed" is insufficient.
+
+**Be concise.** Say only what is meaningful. If you did exactly what was requested with no side effects or additional context needed, a single sentence like "Renamed `foo` to `bar` as requested" is enough. Only add more detail when there is genuinely something worth communicating — e.g., the fix caused a related change elsewhere, you rejected part of the suggestion for a specific reason, or the change has implications the reviewer should know about. Do not add pointless fluff.
+
+**Reply format for Not addressed and Question:**
+```
+[Sesori reply] <status>
+
+<explanation>
+```
+
+Where `<status>` is one of:
+- `Addressed` — The fix has been implemented and pushed
+- `Not addressed` — The comment was assessed as invalid or not applicable
+- `Partially addressed` — Part of the request was implemented, part was not
+- `Question` — The comment is unclear and needs clarification from the reviewer
+
+**Examples:**
+
+Addressed (simple fix):
+```
+[Sesori reply] Addressed (in commit a1b2c3d)
+
+Changed the loop boundary from `i <= n` to `i < n` in `src/utils.ts` to fix the off-by-one error.
+```
+
+Addressed (complex fix requiring more context):
+```
+[Sesori reply] Addressed (in commit a1b2c3d)
+
+Extracted the retry logic into a separate `RetryService` in `src/services/retry_service.dart`. This centralizes the backoff strategy and makes it reusable across the HTTP client and the WebSocket reconnect flow.
+```
+
+Not addressed (AI comment found invalid):
+```
+[Sesori reply] Not addressed
+
+This suggestion would introduce a race condition. The current implementation already handles synchronization correctly via the existing mutex.
+```
+
+Not addressed (outdated):
+```
+[Sesori reply] Not addressed
+
+This comment refers to code that has been refactored in a subsequent commit. The variable in question no longer exists.
+```
+
+Partially addressed:
+```
+[Sesori reply] Partially addressed (in commit a1b2c3d)
+
+Renamed the function as requested. Did not remove the platform abstraction because it would break Windows support and duplicate OS detection logic.
+```
+
+Question:
+```
+[Sesori reply] Question
+
+Could you clarify what you mean by "optimize this"? Are you looking for time complexity improvements or reduced memory usage?
+```
+
+**Posting replies via helper script:**
+
+Use the included `reply.sh` helper script:
+
+```bash
+./scripts/reply.sh <pr-number> <thread_id> "Addressed: Fixed the null check."
+```
+
+The script automatically prefixes the body with `[Sesori reply]` if not already present.
+
+## Edge Cases
+
+### Comment on a file not in the working tree
+
+If the comment references a file that does not exist in your working tree (e.g., the PR added it and you are on a different branch), ask the user whether they want you to change the current branch or worktree before proceeding. There is a chance the user asked in the wrong session to review a PR.
+
+### Multiple comments on the same line
+
+If multiple threads reference the same line, address each independently. They may be about different issues.
+
+### Comments requesting architectural changes
+
+If a human reviewer requests a significant architectural change, implement it without complaining — even if it requires refactoring multiple files. Do not push back or suggest creating a follow-up issue unless you have a strong technical reason to believe the change is wrong.
+
+For AI/bot comments requesting large architectural changes, apply normal validity assessment. If the suggestion is genuinely reasonable, implement it. If it is misguided, reply explaining why it is not viable.
+
+### Comments with no clear action
+
+Some comments are questions or discussions without a clear requested change. Reply to these with `[Sesori reply] Question:` or `[Sesori reply] Not addressed:` and explain why no code change is needed.
+
+### Resolved comments that the user wants revisited
+
+If the user explicitly asks you to look at resolved comments, omit the `--unresolved` flag when fetching. Apply the same assessment and reply process.
+
+## Dependencies
+
+- `gh` (authenticated via `gh auth login`)
+- `pr-inline-comments` skill (for fetching comments)
+- Access to the repository working tree (to read and edit files)
+
+## Determining the PR Number
+
+If the user invokes this skill without an explicit PR number (e.g. "address the PR comments" or "review feedback"), assume they are referring to the most recently raised PR in the current session. Look at the recent conversation for the latest PR URL or number; if in doubt, ask the user to confirm before fetching comments.
+
+## Example Session
+
+User: "Address the comments on PR 42"
+
+1. Fetch unresolved comments using the `pr-inline-comments` skill
+2. Receive 3 threads:
+   - Thread 1 (human): "This loop has an off-by-one error"
+   - Thread 2 (bot): "Consider using a more functional approach"
+   - Thread 3 (human): "Missing null check here"
+3. Assess:
+   - Thread 1: Valid. Fix the loop boundary.
+   - Thread 2: AI suggestion. Current imperative approach is clearer here. Do not implement.
+   - Thread 3: Valid. Add null check.
+4. Implement fixes for threads 1 and 3.
+5. Make a single commit and push
+6. Post replies:
+   - Thread 1: `[Sesori reply] Addressed (in commit a1b2c3d)\n\nChanged the loop boundary from i <= n to i < n in src/utils.ts to fix the off-by-one error.]`
+   - Thread 2: `[Sesori reply] Not addressed\n\nThe current imperative approach is intentional and more readable here.]`
+   - Thread 3: `[Sesori reply] Addressed (in commit a1b2c3d)\n\nAdded null check in src/services/user_service.dart before accessing user.email.`

--- a/.opencode/skills/address-pr-comments/scripts/reply.sh
+++ b/.opencode/skills/address-pr-comments/scripts/reply.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: reply.sh <pr-number> <comment-id> <body> [--repo OWNER/REPO]
+
+Posts a reply to a PR review comment thread via the GitHub API.
+
+Arguments:
+  pr-number    The pull request number
+  comment-id   The comment ID (thread_id from fetch.sh output)
+  body         The reply body text. Will be prefixed with [Sesori reply] if not already.
+
+Flags:
+  --repo OWNER/REPO  Override the current repo. Defaults to gh repo view.
+
+Examples:
+  reply.sh 42 12345 "Addressed: Fixed the null check."
+  reply.sh 42 12345 "Not addressed: This would break existing tests." --repo owner/repo
+EOF
+}
+
+PR_NUMBER=""
+COMMENT_ID=""
+BODY=""
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) [[ $# -lt 2 ]] && { echo "Error: --repo requires a value" >&2; usage; exit 2; }; REPO="$2"; shift 2 ;;
+    -h|--help)    usage; exit 0 ;;
+    --)           shift; break ;;
+    -*)           echo "Unknown flag: $1" >&2; usage; exit 2 ;;
+    *)
+      if [[ -z "$PR_NUMBER" ]]; then
+        PR_NUMBER="$1"
+      elif [[ -z "$COMMENT_ID" ]]; then
+        COMMENT_ID="$1"
+      elif [[ -z "$BODY" ]]; then
+        BODY="$1"
+      else
+        echo "Unexpected positional argument: $1" >&2
+        usage; exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+# Collect any remaining arguments after -- as part of the body
+if [[ $# -gt 0 ]]; then
+  if [[ -z "$BODY" ]]; then
+    BODY="$*"
+  else
+    BODY="$BODY $*"
+  fi
+fi
+
+if [[ -z "$PR_NUMBER" || -z "$COMMENT_ID" || -z "$BODY" ]]; then
+  echo "Error: Missing required arguments" >&2
+  usage; exit 2
+fi
+
+if [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+  :
+else
+  echo "Error: PR number must be a positive integer, got: $PR_NUMBER" >&2
+  exit 2
+fi
+
+if [[ "$COMMENT_ID" =~ ^[1-9][0-9]*$ ]]; then
+  :
+else
+  echo "Error: Comment ID must be a positive integer, got: $COMMENT_ID" >&2
+  exit 2
+fi
+
+if [[ -z "$REPO" ]]; then
+  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+fi
+
+if [[ "$BODY" != "[Sesori reply]"* ]]; then
+  BODY="[Sesori reply] $BODY"
+fi
+
+if ! gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments/${COMMENT_ID}/replies" \
+  -f body="$BODY" > /dev/null; then
+  echo "Error: failed to post reply to comment ${COMMENT_ID} on PR #${PR_NUMBER} in ${REPO}" >&2
+  exit 1
+fi
+
+echo "Reply posted to comment ${COMMENT_ID} on PR #${PR_NUMBER}"

--- a/.opencode/skills/monitor-pr/SKILL.md
+++ b/.opencode/skills/monitor-pr/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: monitor-pr
+description: Monitor GitHub PRs with the pr_monitor tool and handle incoming "[PR Monitor]" reports. Use immediately after raising a PR, or when the user asks to monitor/watch a PR. Address automatically everything it flags. For PR comments, rely on the address-pr-comments skill to address them.
+---
+
+# monitor-pr
+
+Watch a GitHub PR in the background via the `pr_monitor` tool and act on the
+factual reports it delivers to this session.
+
+## Starting a monitor
+
+**Proactively start a monitor right after raising a PR** (e.g. after `gh pr create`):
+
+```
+pr_monitor(action: "start", pr: "owner/repo#123")
+```
+
+- The `pr` argument is always explicit — `owner/repo#123` or a full PR URL. Never a bare number.
+- One monitor per PR; start several monitors for several PRs.
+- Monitors belong to this session and **do not survive an opencode restart**. When
+  resuming PR work in a fresh opencode instance, check `pr_monitor(action: "status")`
+  and re-start monitors as needed.
+- Tuning (debounce, poll interval, CI wait, ignored comment tag) lives in
+  `.opencode/pr-monitor.json` — not in tool arguments.
+
+## Handling a `[PR Monitor]` report
+
+Reports state facts only (CI status, mergeability, reviews, comment counts). Decide and
+act as follows, addressing everything in the report in one batch:
+
+| Report says | Do this |
+| --- | --- |
+| `CI: failing (…)` | Inspect the failures (`gh pr checks <pr> --repo owner/repo`, `gh run view <run-id> --log-failed --repo owner/repo`), fix the root cause, commit and push. Never delete or weaken tests to go green. |
+| `Mergeable: CONFLICTING` | Merge the latest base branch INTO the PR branch. First resolve the PR's actual base ref: `gh pr view <number> --repo owner/repo --json baseRefName -q .baseRefName`, then `git fetch origin && git merge origin/<baseRefName>`. **NEVER rebase.** Resolve conflicts conservatively so functionality from both sides is preserved — when unsure, read the full context of both changes before choosing. Run the relevant tests, then push the merge commit. |
+| New inline comments / `changes_requested` | Follow the `address-pr-comments` skill: fetch unresolved threads, assess validity, implement fixes, reply to every thread. |
+| New issue comments | Read them (`gh pr view <number> --repo owner/repo --comments`) and act only if they request something. |
+| Approved + CI passing + 0 unresolved threads | Nothing to fix — summarize the PR state to the user. |
+| `— MERGED` / `— CLOSED` | The monitor already stopped itself. Nothing to do. |
+
+> **Owner-account comments are NOT your own replies.** The agent pushes commits
+> and posts review replies using the **same GitHub account as the human owner**,
+> so a report that lists new comments from that account (e.g. "1 new: 1
+> &lt;owner&gt;") may be the **human giving you an instruction**, not an echo of
+> your own reply. Agent replies always start with `[Sesori reply]` (see the
+> `address-pr-comments` skill). Treat any owner-account comment **without** that
+> prefix as a human instruction — fetch it and act on it (including when it
+> overrides a decision you already made). Never skip a reported owner-account
+> comment by assuming you wrote it.
+
+## After handling a report — no manual flush needed
+
+A delivered `[PR Monitor]` report has **already advanced** the "new since last flush"
+baseline, so the activity it reported is not echoed back at you. The report itself acts as
+the flush. Just handle everything in the report in one batch, then wait for the next report
+(or for merge/close). Do **not** flush as a routine step after handling a report.
+
+## Other actions
+
+- `pr_monitor(action: "status")` — list this session's monitors (also useful before ending a work session).
+- `pr_monitor(action: "flush", pr: "owner/repo#123")` or `pr_monitor(action: "flush", pr: "all")` — force an immediate full status report on demand (this also advances the baseline). Use it only when you want the current state right now instead of waiting for the next scheduled report — never as a routine step after handling a report.
+- `pr_monitor(action: "stop", pr: "owner/repo#123")` or `pr_monitor(action: "stop", pr: "all")` — stop watching without waiting for merge.

--- a/.opencode/skills/pr-inline-comments/SKILL.md
+++ b/.opencode/skills/pr-inline-comments/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: pr-inline-comments
+description: Fetch inline (code) review comments on a GitHub pull request, grouped into threads, with optional filtering by datetime. Use when the user asks to read or address PR comments, code review feedback, reviewer notes, or wants to see only recent review activity on a PR. Resolves natural-language time windows like "last 30 minutes", "since yesterday 5 PM", or "since commit abc123" into ISO 8601 before invoking the script. Requires gh and jq.
+---
+
+# pr-inline-comments
+
+Returns inline code review comments on a PR, grouped into threads, optionally filtered by datetime and/or resolution status. Issue-level PR comments (those not anchored to a line of code) are not included.
+
+Backed by the GitHub GraphQL API, which exposes review threads natively (with `isResolved` and `isOutdated`). The REST `/pulls/{n}/comments` endpoint does not expose resolution status.
+
+## Output schema
+
+A single JSON array of thread objects. Thread-level fields appear once per thread. Per-comment fields live only inside `comments[]`.
+
+```json
+[
+  {
+    "thread_id": 100,
+    "path": "src/foo.ts",
+    "line": 42,
+    "side": "RIGHT",
+    "start_line": null,
+    "is_resolved": false,
+    "is_outdated": false,
+    "commit_id": "abc123",
+    "diff_hunk": "@@ -40,3 +40,3 @@",
+    "url": "https://github.com/o/r/pull/1#discussion_r100",
+    "latest_at": "2026-04-29T13:30:00Z",
+    "comments": [
+      { "id": 100, "user": "alice", "body": "...", "created_at": "...", "updated_at": "...", "html_url": "..." },
+      { "id": 101, "user": "bob",   "body": "...", "created_at": "...", "updated_at": "...", "html_url": "..." }
+    ]
+  }
+]
+```
+
+Thread-level fields (`thread_id`, `path`, `line`, `side`, `start_line`, `is_resolved`, `is_outdated`, `commit_id`, `diff_hunk`, `url`, `latest_at`) come from the thread itself or its root comment. Replies do not repeat them. Per-comment fields are limited to `id`, `user`, `body`, `created_at`, `updated_at`, `html_url`.
+
+`thread_id` is the GraphQL `databaseId` of the root comment, equivalent to the REST comment id (a stable integer).
+
+`latest_at` is the maximum `createdAt` across all comments in the thread.
+
+Threads are sorted by `path`, then `line`, then `thread_id`.
+
+## Invocation
+
+```bash
+./scripts/fetch.sh <pr-number> [--since ISO_DATETIME] [--unresolved] [--repo OWNER/REPO]
+```
+
+**Avoiding output truncation:** The JSON output can be large. To prevent truncation by the shell or terminal, redirect stdout to a uniquely-named file and read from there:
+
+```bash
+PR_NUMBER="<pr-number>"
+OUTFILE="/tmp/pr_${PR_NUMBER}_comments_$(date +%Y%m%d_%H%M%S).json"
+./scripts/fetch.sh "$PR_NUMBER" --unresolved > "$OUTFILE"
+# Then read "$OUTFILE"
+```
+
+The timestamp in the filename prevents conflicts with stale files from previous runs or other PRs.
+
+Flags:
+
+- `--since ISO_DATETIME`: keep only threads whose **latest comment** is at or after the given datetime. Inclusive. The whole thread is returned (including older replies) when it qualifies.
+- `--unresolved`: keep only threads where `is_resolved == false`.
+- `--repo OWNER/REPO`: override the current repo. Defaults to `gh repo view --json nameWithOwner`.
+
+`--since` and `--unresolved` compose: a thread must satisfy both to be kept.
+
+## `--since` accepted formats
+
+The script validates input strictly and normalizes to UTC `Z` form internally. Any of these are accepted:
+
+```
+2026-04-29T14:30:00Z
+2026-04-29T17:00:00+03:00
+2026-04-29T17:00:00+0300
+2026-04-29T14:30:00.123Z          # fractional seconds are accepted and stripped
+```
+
+Invalid inputs (no timezone, date only, wrong shape) cause the script to exit with a clear error before any API calls.
+
+If the input is not already in canonical UTC `Z` form, the script prints a normalization line to stderr, e.g.:
+
+```
+Normalized --since: 2026-04-28T17:00:00+03:00 -> 2026-04-28T14:00:00Z
+```
+
+This is informational only and does not affect stdout.
+
+## Resolving `--since` from natural language
+
+Convert the user's expression to **any** valid ISO 8601 datetime with a timezone, then pass it to the script. The script handles UTC normalization regardless of platform. There is no need to use `date -d` (GNU) or `date -j -f` (BSD) directly.
+
+### Relative durations
+
+Examples: "last 30 minutes", "past 2 hours", "in the last day", "last week".
+
+Use Python (always available on macOS and Linux, stdlib only):
+
+```bash
+# 30 minutes ago, in UTC Z form
+python3 -c "from datetime import datetime, timedelta, timezone; print((datetime.now(timezone.utc) - timedelta(minutes=30)).strftime('%Y-%m-%dT%H:%M:%SZ'))"
+
+# 2 hours ago
+python3 -c "from datetime import datetime, timedelta, timezone; print((datetime.now(timezone.utc) - timedelta(hours=2)).strftime('%Y-%m-%dT%H:%M:%SZ'))"
+
+# 1 day ago
+python3 -c "from datetime import datetime, timedelta, timezone; print((datetime.now(timezone.utc) - timedelta(days=1)).strftime('%Y-%m-%dT%H:%M:%SZ'))"
+```
+
+For "current UTC now" without a library, POSIX `date` works on both platforms:
+
+```bash
+date -u +"%Y-%m-%dT%H:%M:%SZ"
+```
+
+### Clock-time references
+
+Examples: "since yesterday 5 PM", "since Monday 9 AM", "since this morning".
+
+Resolve in the user's local timezone (assume system local unless they explicitly state otherwise). Produce an ISO 8601 datetime with the local offset; the script will convert to UTC.
+
+```bash
+# Yesterday 17:00 local
+python3 -c "
+from datetime import datetime, timedelta
+local_now = datetime.now().astimezone()
+target = (local_now - timedelta(days=1)).replace(hour=17, minute=0, second=0, microsecond=0)
+print(target.strftime('%Y-%m-%dT%H:%M:%S%z'))
+"
+# e.g. 2026-04-28T17:00:00+0300
+```
+
+The script accepts `+0300` and `+03:00` equivalently. For "Monday 9 AM" or other named days, compute the target date in Python with `weekday()` arithmetic.
+
+For ambiguous expressions like "this morning", pick a sensible boundary (e.g., 06:00 local) and state it back to the user.
+
+### Commit references
+
+Examples: "since commit abc123", "since the latest commit on main", "since I pushed".
+
+```bash
+SHA=abc123
+gh api "/repos/${REPO}/commits/${SHA}" --jq '.commit.committer.date'
+# -> 2026-04-29T12:34:56Z
+```
+
+Use `.commit.committer.date` for "when this commit landed on the branch", which is the usual interpretation. Use `.commit.author.date` only if the user explicitly means when the commit was originally written (different on rebased history).
+
+For "since the head of the PR":
+
+```bash
+gh pr view <pr-number> --json commits --jq '.commits[-1].committedDate'
+```
+
+For "since the last commit on the current branch":
+
+```bash
+SHA=$(git rev-parse HEAD)
+gh api "/repos/${REPO}/commits/${SHA}" --jq '.commit.committer.date'
+```
+
+### Confirming back to the user
+
+Before running the script, print one line confirming the resolved value:
+
+```
+Resolved "yesterday 5 PM" to 2026-04-28T17:00:00+03:00 (your local 17:00 EEST).
+```
+
+If the script then emits a `Normalized --since: ...` line on stderr, that's expected.
+
+## Common workflows
+
+- "Show me unresolved comments on PR 123" → `fetch.sh 123 --unresolved`
+- "What review feedback came in since I pushed?" → resolve commit date, then `fetch.sh <pr> --since <date>`
+- "What unresolved threads need my attention from the last day?" → `fetch.sh <pr> --unresolved --since <24h ago>`
+- "Show me everything reviewers said on this PR" → `fetch.sh <pr>` (no flags)
+
+## Threading details
+
+- Threads come from the GraphQL `pullRequest.reviewThreads` connection, which already groups comments natively. No client-side chain walking is needed.
+- `is_outdated` means the line the comment was anchored to has been changed in a newer push. Outdated comments may have `line: null`; the script falls back to `originalLine`.
+- Inner comments per thread are capped at 100. If any thread exceeds that (extremely rare in practice), the script prints a warning to stderr.
+
+## Dependencies
+
+- `gh` (authenticated via `gh auth login`)
+- `jq` 1.6+
+- `python3` (standard library only, used for natural-language datetime conversion)
+- POSIX shell
+
+## Notes
+
+- The script always emits a single JSON array, including the empty case `[]` when no threads match.
+- Outer pagination (more than 100 threads on a PR) is handled by `gh api graphql --paginate`.
+- Platform differences (Linux GNU `date` vs macOS BSD `date`) are handled inside the script. The agent does not need to branch on platform.

--- a/.opencode/skills/pr-inline-comments/scripts/fetch.sh
+++ b/.opencode/skills/pr-inline-comments/scripts/fetch.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: fetch.sh <pr-number> [--since ISO_DATETIME] [--unresolved] [--repo OWNER/REPO]
+
+Fetches inline (code) review comments on a GitHub pull request, grouped
+into threads, with optional filtering.
+
+Flags:
+  --since ISO_DATETIME   Keep only threads whose latest comment is at or
+                         after the given datetime. ISO 8601 with timezone
+                         is required (e.g. 2026-04-29T14:30:00Z or
+                         2026-04-29T17:00:00+03:00). The script normalizes
+                         to UTC internally.
+  --unresolved           Keep only threads that are not yet resolved.
+  --repo OWNER/REPO      Override the current repo.
+
+Output is a single JSON array of thread objects on stdout. Each thread
+includes is_resolved and is_outdated.
+EOF
+}
+
+# -------- datetime validation + normalization --------
+
+validate_iso8601() {
+  local s="$1"
+  local re='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?(Z|[+-][0-9]{2}:?[0-9]{2})$'
+  [[ "$s" =~ $re ]]
+}
+
+# Normalize an ISO 8601 datetime to UTC with trailing Z. Handles GNU date
+# (Linux) and BSD date (macOS) by feature detection. Echoes the normalized
+# value on stdout, or an error to stderr and returns 1.
+normalize_to_utc_z() {
+  local input="$1"
+
+  if ! validate_iso8601 "$input"; then
+    cat >&2 <<EOF
+Error: --since is not a valid ISO 8601 datetime with timezone.
+  got:      ${input}
+  expected: e.g. 2026-04-29T14:30:00Z or 2026-04-29T17:00:00+03:00
+EOF
+    return 1
+  fi
+
+  local stripped
+  stripped=$(printf '%s' "$input" | sed -E 's/\.[0-9]+(Z|[+-])/\1/')
+
+  local result
+  if date --version >/dev/null 2>&1; then
+    # GNU date (Linux). Forgiving: accepts Z, ±HH:MM, ±HHMM.
+    if ! result=$(date -u -d "$stripped" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null); then
+      echo "Error: --since looked valid but GNU date could not parse it: $stripped" >&2
+      return 1
+    fi
+  else
+    # BSD date (macOS). Strict: needs ±HHMM with no colon, rejects Z.
+    local bsd_in
+    bsd_in=$(printf '%s' "$stripped" \
+      | sed -E 's/Z$/+0000/; s/([+-][0-9]{2}):([0-9]{2})$/\1\2/')
+    if ! result=$(date -u -j -f "%Y-%m-%dT%H:%M:%S%z" "$bsd_in" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null); then
+      echo "Error: --since looked valid but BSD date could not parse it: $bsd_in" >&2
+      return 1
+    fi
+  fi
+
+  printf '%s\n' "$result"
+}
+
+# -------- argument parsing --------
+
+PR_NUMBER=""
+SINCE=""
+REPO=""
+ONLY_UNRESOLVED=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since)      SINCE="${2:?--since requires a value}"; shift 2 ;;
+    --repo)       REPO="${2:?--repo requires a value}";   shift 2 ;;
+    --unresolved) ONLY_UNRESOLVED=1; shift ;;
+    -h|--help)    usage; exit 0 ;;
+    -*)           echo "Unknown flag: $1" >&2; usage; exit 2 ;;
+    *)
+      if [[ -z "$PR_NUMBER" ]]; then
+        PR_NUMBER="$1"
+      else
+        echo "Unexpected positional argument: $1" >&2
+        usage; exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$PR_NUMBER" ]]; then
+  usage; exit 2
+fi
+
+if [[ -n "$SINCE" ]]; then
+  ORIGINAL_SINCE="$SINCE"
+  SINCE=$(normalize_to_utc_z "$SINCE") || exit 1
+  if [[ "$SINCE" != "$ORIGINAL_SINCE" ]]; then
+    echo "Normalized --since: ${ORIGINAL_SINCE} -> ${SINCE}" >&2
+  fi
+fi
+
+if [[ -z "$REPO" ]]; then
+  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+fi
+
+OWNER="${REPO%%/*}"
+REPO_NAME="${REPO##*/}"
+
+# -------- fetch + transform --------
+
+# GraphQL query. reviewThreads gives native threading + isResolved/isOutdated,
+# which the REST /pulls/{n}/comments endpoint does not expose.
+#
+# Pagination: gh api graphql --paginate uses pageInfo.{hasNextPage,endCursor}
+# and re-runs with $endCursor automatically. Inner comments are capped at
+# 100 per thread; we warn if that cap is hit (extremely rare).
+read -r -d '' GRAPHQL_QUERY <<'GQL' || true
+query($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100, after: $endCursor) {
+        nodes {
+          isResolved
+          isOutdated
+          path
+          line
+          originalLine
+          startLine
+          diffSide
+          comments(first: 100) {
+            nodes {
+              databaseId
+              author { login }
+              body
+              createdAt
+              updatedAt
+              url
+              diffHunk
+              commit { oid }
+            }
+            pageInfo { hasNextPage }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+GQL
+
+gh api graphql --paginate \
+  -F owner="$OWNER" \
+  -F repo="$REPO_NAME" \
+  -F pr="$PR_NUMBER" \
+  -f query="$GRAPHQL_QUERY" \
+| jq --slurp \
+     --arg since "$SINCE" \
+     --argjson onlyUnresolved "$ONLY_UNRESOLVED" '
+    # Flatten all pages into a single list of thread nodes.
+    [.[] | .data.repository.pullRequest.reviewThreads.nodes[]] as $threads
+
+    # Surface a warning if any thread truncated its inner comments.
+    | ($threads | map(select(.comments.pageInfo.hasNextPage)) | length) as $truncated
+    | (if $truncated > 0 then
+        ("warning: \($truncated) thread(s) had > 100 comments; output is truncated" | debug)
+       else . end) as $_
+
+    | $threads
+    | map(
+        # Skip empty threads defensively (should not happen).
+        select(.comments.nodes | length > 0)
+        | (.comments.nodes | sort_by(.createdAt)) as $sorted
+        | $sorted[0] as $root
+        | {
+            # Thread-level fields, present once per thread.
+            thread_id:   $root.databaseId,
+            path:        .path,
+            line:        (.line // .originalLine),
+            side:        .diffSide,
+            start_line:  .startLine,
+            is_resolved: .isResolved,
+            is_outdated: .isOutdated,
+            commit_id:   ($root.commit.oid // null),
+            diff_hunk:   $root.diffHunk,
+            url:         $root.url,
+            latest_at:   ($sorted | map(.createdAt) | max),
+
+            # Per-comment fields only.
+            comments: ($sorted | map({
+              id:         .databaseId,
+              user:       (.author.login // "ghost"),
+              body,
+              created_at: .createdAt,
+              updated_at: .updatedAt,
+              html_url:   .url
+            }))
+          }
+      )
+    | if $onlyUnresolved == 1 then map(select(.is_resolved == false)) else . end
+    | if $since != ""           then map(select(.latest_at >= $since)) else . end
+    | sort_by([.path // "", (.line // 0), .thread_id])
+'

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ npm run start:local
 
 ### OAuth (anti-phishing confirmation flow)
 
-The newer flow keeps the client in control of when tokens are issued. The client generates a random 64-char hex `X-Sesori-Session-Token` (case-insensitive on input, canonicalized to lowercase server-side), sends the **raw** value in the header on every request to `/auth/{provider}/init` and `/auth/session/status`, and the server stores only the SHA-256 digest internally — the raw token never touches disk or logs. The browser-side confirmation page shows a 4-char visual code that the client also displays — users only confirm when both match.
+The newer flow keeps the client in control of when tokens are issued. The client generates a random 64-char hex `X-Sesori-Session-Token` (case-insensitive on input, canonicalized to lowercase server-side), sends the **raw** value in the header on every request to `/auth/{provider}/init` and `/auth/session/status`, and the server stores only the SHA-256 digest internally — the raw token never touches disk or logs. The browser-side confirmation page describes the device that started the sign-in — its type/OS (from the enum-bounded `clientType`) plus an optional human-readable device name — and the user explicitly confirms before tokens are issued. The device name is an untrusted recognition aid (HTML-escaped); the trustworthy signal is `clientType`.
 
 | Method | Path                            | Auth | Description                                                                                                  |
 | ------ | ------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------ |
-| `POST` | `/auth/github/init`             | No   | Start pending GitHub OAuth (requires `X-Sesori-Session-Token` header, `clientType` body)                     |
+| `POST` | `/auth/github/init`             | No   | Start pending GitHub OAuth (requires `X-Sesori-Session-Token` header, `clientType` body; optional `device` `{ name, osVersion?, appVersion? }`) |
 | `GET`  | `/auth/github/callback`         | No   | Provider redirect → renders the confirmation interstitial HTML                                               |
 | `POST` | `/auth/github/callback/confirm` | No   | User confirms/denies sign-in (form-encoded body `state`, `action`)                                           |
 | `POST` | `/auth/google/init`             | No   | (same shape as github)                                                                                       |

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["github:sesori-ai/opencode-pr-monitor#v0.1.3"],
+  "references": {
+    "sesori-apps-monorepo": {
+      "repository": "sesori-ai/sesori_apps_monorepo",
+      "description": "Sesori apps monorepo — contains the Sesori client apps and the Sesori bridge"
+    },
+    "sesori-relay": {
+      "repository": "sesori-ai/sesori_relay_server",
+      "description": "Sesori relay server — WebSocket routing of encrypted frames between bridge and client app"
+    }
+  },
+  "permission": {
+    "skill": {
+      "pr-inline-comments": "deny"
+    }
+  }
+}

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -72,8 +72,11 @@ export const oauthClientTypeSchema = z.enum(OAuthClientType);
  */
 export const deviceInfoSchema = z.object({
   name: z.string().trim().min(1).max(120),
-  osVersion: z.string().trim().min(1).max(40).optional(),
-  appVersion: z.string().trim().min(1).max(40).optional(),
+  // Cosmetic version fields: tolerate empty strings / null (auto-generated
+  // client serializers often emit those instead of omitting the key). Falsy
+  // values are simply skipped at render time, so they never reach the page.
+  osVersion: z.string().trim().max(40).nullish(),
+  appVersion: z.string().trim().max(40).nullish(),
 });
 export type DeviceInfo = z.infer<typeof deviceInfoSchema>;
 

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -57,6 +57,26 @@ export enum OAuthClientType {
 
 export const oauthClientTypeSchema = z.enum(OAuthClientType);
 
+/**
+ * Human-readable device descriptor the client may send at init so the
+ * confirmation interstitial can show *which* device is asking to sign in.
+ *
+ * SECURITY: every field here is client-supplied and therefore UNTRUSTED. It is
+ * a recognition aid for the user, NOT an anti-phishing guarantee — an attacker
+ * initiating the flow can set `name` to anything. The trustworthy signal on the
+ * confirmation page remains the enum-bounded `clientType` (device type + OS
+ * family). All values are length-bounded here and HTML-escaped at render time.
+ *
+ * Type + OS family are derived from `clientType` (e.g. `bridge_macos`), so this
+ * object only adds the human name plus optional version specifics.
+ */
+export const deviceInfoSchema = z.object({
+  name: z.string().trim().min(1).max(120),
+  osVersion: z.string().trim().min(1).max(40).optional(),
+  appVersion: z.string().trim().min(1).max(40).optional(),
+});
+export type DeviceInfo = z.infer<typeof deviceInfoSchema>;
+
 export const oauthInitBodySchema = z.object({
   clientType: z
     .string()
@@ -68,6 +88,9 @@ export const oauthInitBodySchema = z.object({
         .replace(/[-\s]+/g, "_"),
     )
     .pipe(oauthClientTypeSchema),
+  // Optional for backwards compatibility: older clients omit it and fall back
+  // to the generic confirmation message.
+  device: deviceInfoSchema.optional(),
 });
 export type OAuthInitBody = z.infer<typeof oauthInitBodySchema>;
 

--- a/src/routes/auth/apple.ts
+++ b/src/routes/auth/apple.ts
@@ -98,13 +98,15 @@ export const appleRoutes: FastifyPluginAsync<AppleRouteOptions> = async (fastify
   });
 
   fastify.post<{ Body: unknown; Reply: OAuthPendingInitReply }>("/auth/apple/init", async (request) => {
-    parseOAuthPendingInitBody(request.body);
+    const { clientType, device } = parseOAuthPendingInitBody(request.body);
 
     const sessionToken = parseSessionTokenHeader(request.headers["x-sesori-session-token"]);
     const { session, codeChallenge } = createPendingOAuthInit({
       provider: OAuthProviderName.Apple,
       pendingAuthStore,
       sessionToken,
+      clientType,
+      device,
     });
 
     const authUrl = new URL("https://appleid.apple.com/auth/authorize");

--- a/src/routes/auth/github.ts
+++ b/src/routes/auth/github.ts
@@ -75,7 +75,7 @@ export const githubRoutes: FastifyPluginAsync<GithubRouteOptions> = async (fasti
   });
 
   fastify.post<{ Body: unknown; Reply: OAuthPendingInitReply }>("/auth/github/init", async (request) => {
-    const { clientType } = parseOAuthPendingInitBody(request.body);
+    const { clientType, device } = parseOAuthPendingInitBody(request.body);
 
     const sessionToken = parseSessionTokenHeader(request.headers["x-sesori-session-token"]);
     const { session, codeChallenge } = createPendingOAuthInit({
@@ -83,6 +83,7 @@ export const githubRoutes: FastifyPluginAsync<GithubRouteOptions> = async (fasti
       pendingAuthStore,
       sessionToken,
       clientType,
+      device,
     });
 
     const authUrl = new URL("https://github.com/login/oauth/authorize");

--- a/src/routes/auth/google.ts
+++ b/src/routes/auth/google.ts
@@ -78,7 +78,7 @@ export const googleRoutes: FastifyPluginAsync<GoogleRouteOptions> = async (fasti
   });
 
   fastify.post<{ Body: unknown; Reply: OAuthPendingInitReply }>("/auth/google/init", async (request) => {
-    const { clientType } = parseOAuthPendingInitBody(request.body);
+    const { clientType, device } = parseOAuthPendingInitBody(request.body);
 
     const sessionToken = parseSessionTokenHeader(request.headers["x-sesori-session-token"]);
     const { session, codeChallenge } = createPendingOAuthInit({
@@ -86,6 +86,7 @@ export const googleRoutes: FastifyPluginAsync<GoogleRouteOptions> = async (fasti
       pendingAuthStore,
       sessionToken,
       clientType,
+      device,
     });
 
     const authUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");

--- a/src/routes/auth/init.ts
+++ b/src/routes/auth/init.ts
@@ -20,6 +20,7 @@ import { BadRequestError } from "../../lib/errors.js";
 import {
   OAuthClientType,
   oauthPendingInitBodySchema,
+  type DeviceInfo,
   type OAuthPendingInitBody,
   type OAuthPendingInitReply,
 } from "../../models/api.js";
@@ -66,6 +67,7 @@ export function createPendingOAuthInit(params: {
   pendingAuthStore: PendingAuthStore;
   sessionToken: string;
   clientType?: OAuthClientType;
+  device?: DeviceInfo;
 }): { session: PendingAuthSession; codeChallenge: string } {
   const pkceVerifier = crypto.randomBytes(PKCE_VERIFIER_BYTE_LENGTH).toString("base64url");
   const codeChallenge = crypto.createHash("sha256").update(pkceVerifier).digest("base64url");
@@ -77,6 +79,7 @@ export function createPendingOAuthInit(params: {
     pkceVerifier,
     state,
     clientType: params.clientType,
+    device: params.device,
   });
 
   return { session, codeChallenge };

--- a/src/routes/auth/provider-callback.ts
+++ b/src/routes/auth/provider-callback.ts
@@ -5,9 +5,15 @@
  * `code` and `state`. Rather than exchanging the code and immediately issuing
  * tokens to whoever triggered the callback (vulnerable to phishing redirects
  * that trick the user into completing sign-in for an attacker-controlled
- * session token), we render a confirmation page showing a 4-character visual
- * code that the Sesori app/bridge also displays. Tokens are issued only after
- * the user explicitly confirms in-browser.
+ * session token), we render a confirmation page describing the device that
+ * started the sign-in. Tokens are issued only after the user explicitly
+ * confirms in-browser.
+ *
+ * The page shows the requesting device's type + OS (derived from the
+ * enum-bounded `clientType` captured at init) and, when the client supplied
+ * one, a human-readable device name. The device name is UNTRUSTED
+ * client-supplied text (recognition aid only, HTML-escaped here); the
+ * trustworthy signal is `clientType`.
  *
  * Two handlers are exported:
  *  - `handleProviderCallbackRedirect`: GET handler invoked by the OAuth
@@ -29,6 +35,7 @@
 import { z } from "zod";
 import type { FastifyInstance, FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
 import type { OAuthClient } from "../../clients/auth/oauth-client.js";
+import { OAuthClientType } from "../../models/api.js";
 import type { AuthService } from "../../services/auth-service.js";
 import {
   PendingAuthStatus,
@@ -131,7 +138,6 @@ export async function handleProviderCallbackRedirect<TClient extends OAuthClient
     case PendingAuthStatus.Denied:
       return sendDeniedPage({
         reply: params.reply,
-        userCode: session.userCode,
         title: "Sign-in cancelled",
         message: "This sign-in request was cancelled. Return to Sesori to start again.",
       });
@@ -239,7 +245,6 @@ async function handleProviderErrorCallback(params: {
     params.pendingAuthStore.denySession(params.session.tokenHash);
     return sendDeniedPage({
       reply: params.reply,
-      userCode: params.session.userCode,
       title: "Sign-in cancelled",
       message: "You cancelled this sign-in request. You can return to Sesori and try again.",
     });
@@ -312,7 +317,6 @@ export async function handleProviderCallbackAction(params: {
     params.pendingAuthStore.denySession(session.tokenHash);
     return sendDeniedPage({
       reply: params.reply,
-      userCode: session.userCode,
       title: "Sign-in cancelled",
       message: "This sign-in request was cancelled. Return to Sesori and try again when you're ready.",
     });
@@ -329,7 +333,6 @@ export async function handleProviderCallbackAction(params: {
   if (session.status === PendingAuthStatus.Denied) {
     return sendDeniedPage({
       reply: params.reply,
-      userCode: session.userCode,
       title: "Sign-in cancelled",
       message: "This sign-in request was already cancelled.",
     });
@@ -357,7 +360,7 @@ export async function handleProviderCallbackAction(params: {
   return sendSuccessPage({
     reply: params.reply,
     title: "Sign-in confirmed",
-    message: `You're all set. Return to Sesori and enter code ${completedSession.userCode} if prompted.`,
+    message: "You're all set. Return to Sesori to finish signing in.",
   });
 }
 
@@ -379,7 +382,9 @@ function sendConfirmationPage(params: {
     <style>
       body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #0f172a; color: #e2e8f0; margin: 0; padding: 24px; }
       .card { max-width: 480px; margin: 48px auto; background: #111827; border: 1px solid #334155; border-radius: 16px; padding: 24px; }
-      .code { font-size: 32px; font-weight: 700; letter-spacing: 0.18em; margin: 16px 0; }
+      .device { margin: 16px 0; padding: 16px; background: #0f172a; border: 1px solid #334155; border-radius: 12px; }
+      .device-name { font-size: 20px; font-weight: 700; }
+      .device-meta { margin-top: 4px; color: #94a3b8; font-size: 14px; }
       .actions { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 24px; }
       button { border: 0; border-radius: 999px; padding: 12px 18px; font: inherit; cursor: pointer; }
       .confirm { background: #22c55e; color: #052e16; }
@@ -390,8 +395,8 @@ function sendConfirmationPage(params: {
   <body>
     <main class="card">
       <h1>Confirm Sesori sign-in</h1>
-      <p>You're signing in with ${escapeHtml(params.providerName)}. Make sure this 4-character code matches the Sesori app before continuing.</p>
-      <div class="code">${escapeHtml(params.session.userCode)}</div>
+      <p>You're signing in with ${escapeHtml(params.providerName)}. Only continue if you just started this sign-in from the device below.</p>
+      ${renderRequestingDeviceHtml(params.session)}
       <p>Sesori will finish sign-in only after you explicitly confirm here.</p>
       <div class="actions">
         <form method="POST" action="${escapeHtml(formAction)}">
@@ -410,20 +415,70 @@ function sendConfirmationPage(params: {
 </html>`);
 }
 
+/**
+ * Renders the "requesting device" panel for the confirmation page. Returns
+ * fully HTML-escaped markup. When the client supplied a `device` object the
+ * human-readable name is shown prominently; otherwise we fall back to a generic
+ * message that still names the device type/OS derived from the trusted,
+ * enum-bounded `clientType`.
+ */
+function renderRequestingDeviceHtml(session: PendingAuthSession): string {
+  const typeLabel = describeClientType(session.clientType);
+  const device = session.device;
+
+  if (!device) {
+    return `<div class="device"><div class="device-meta">A ${escapeHtml(typeLabel)} is requesting to sign in.</div></div>`;
+  }
+
+  const meta = [typeLabel];
+  if (device.osVersion) {
+    meta.push(device.osVersion);
+  }
+  if (device.appVersion) {
+    meta.push(`Sesori ${device.appVersion}`);
+  }
+
+  return `<div class="device"><div class="device-name">${escapeHtml(device.name)}</div><div class="device-meta">${escapeHtml(meta.join(" · "))}</div></div>`;
+}
+
+/**
+ * Maps the enum-bounded `clientType` to a human-readable "device type + OS
+ * family" label. This is the trustworthy half of the device description — it
+ * cannot be set to arbitrary text (unlike the free-text device name).
+ */
+function describeClientType(clientType: OAuthClientType | undefined): string {
+  switch (clientType) {
+    case OAuthClientType.BridgeMacOS:
+    case OAuthClientType.AppMacOS:
+      return "macOS desktop";
+    case OAuthClientType.BridgeWindows:
+    case OAuthClientType.AppWindows:
+      return "Windows desktop";
+    case OAuthClientType.BridgeLinux:
+    case OAuthClientType.AppLinux:
+      return "Linux desktop";
+    case OAuthClientType.AppIOS:
+      return "iPhone or iPad";
+    case OAuthClientType.AppAndroid:
+      return "Android device";
+    case OAuthClientType.Bridge:
+      return "desktop app";
+    case OAuthClientType.App:
+      return "mobile app";
+    case undefined:
+      return "device";
+  }
+}
+
 function sendSuccessPage(params: { reply: FastifyReply; title: string; message: string }): FastifyReply {
   return params.reply.status(200).type("text/html; charset=utf-8").send(renderMessagePage(params));
 }
 
-function sendDeniedPage(params: {
-  reply: FastifyReply;
-  userCode: string;
-  title: string;
-  message: string;
-}): FastifyReply {
+function sendDeniedPage(params: { reply: FastifyReply; title: string; message: string }): FastifyReply {
   return params.reply
     .status(200)
     .type("text/html; charset=utf-8")
-    .send(renderMessagePage({ title: params.title, message: `${params.message} Code ${params.userCode}.` }));
+    .send(renderMessagePage({ title: params.title, message: params.message }));
 }
 
 function sendErrorPage(params: {

--- a/src/services/pending-auth-store.ts
+++ b/src/services/pending-auth-store.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import { LRUCache } from "lru-cache";
-import type { OAuthClientType, UserProfile } from "../models/api.js";
+import type { DeviceInfo, OAuthClientType, UserProfile } from "../models/api.js";
 import { OAuthProviderName } from "../types/oauth.js";
 
 /**
@@ -70,6 +70,11 @@ export type PendingAuthSession = {
   errorMessage?: string;
   /** Client type (bridge / app / per-platform). Recorded at init for audit. */
   clientType?: OAuthClientType;
+  /**
+   * Optional client-supplied device descriptor shown on the confirmation
+   * interstitial. UNTRUSTED — recognition aid only (see `deviceInfoSchema`).
+   */
+  device?: DeviceInfo;
 };
 
 type PendingAuthStoreEntry = {
@@ -138,6 +143,7 @@ export class PendingAuthStore {
     pkceVerifier: string;
     state: string;
     clientType?: OAuthClientType;
+    device?: DeviceInfo;
   }): PendingAuthSession {
     const now = this.#now();
     const session: PendingAuthSessionRecord = {
@@ -150,6 +156,7 @@ export class PendingAuthStore {
       createdAt: now,
       expiresAt: new Date(now.getTime() + this.#sessionTtlMs),
       clientType: params.clientType,
+      device: params.device ? { ...params.device } : undefined,
     };
 
     this.#setSession(session);
@@ -665,6 +672,7 @@ export class PendingAuthStore {
       user: session.user ? { ...session.user } : undefined,
       errorMessage: session.errorMessage,
       clientType: session.clientType,
+      device: session.device ? { ...session.device } : undefined,
     };
   }
 }

--- a/tests/auth/apple.test.ts
+++ b/tests/auth/apple.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
+import crypto from "node:crypto";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
 import { FakeOAuthClient } from "../helpers/fake-oauth-client.js";
+import { PendingAuthStore } from "../../src/services/pending-auth-store.js";
 
 const VALID_CODE_CHALLENGE = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
 const VALID_REDIRECT_URI = "https://app.example.com/oauth/callback";
@@ -134,6 +136,36 @@ describe("Apple OAuth routes", () => {
       });
 
       assert.equal(res.statusCode, 400);
+    });
+  });
+
+  // ── POST /auth/apple/init ──────────────────────────────────────────────────
+
+  describe("POST /auth/apple/init", () => {
+    it("records clientType and the optional device descriptor on the pending session", async () => {
+      const sessionToken = crypto.randomBytes(32).toString("hex");
+      const res = await ctx.app.inject({
+        method: "POST",
+        url: "/auth/apple/init",
+        headers: {
+          "content-type": "application/json",
+          "x-sesori-session-token": sessionToken,
+        },
+        payload: JSON.stringify({
+          clientType: "app_ios",
+          device: { name: "Alex's iPhone", osVersion: "17.2", appVersion: "1.2.0" },
+        }),
+      });
+
+      assert.equal(res.statusCode, 200);
+      const pendingSession = ctx.pendingAuthStore.getSession(PendingAuthStore.hashToken(sessionToken));
+      assert.equal(pendingSession?.provider, "apple");
+      assert.equal(pendingSession?.clientType, "app_ios");
+      assert.deepEqual(pendingSession?.device, {
+        name: "Alex's iPhone",
+        osVersion: "17.2",
+        appVersion: "1.2.0",
+      });
     });
   });
 

--- a/tests/auth/init.test.ts
+++ b/tests/auth/init.test.ts
@@ -99,6 +99,44 @@ describe("OAuth init routes", () => {
     assert.notEqual(authUrl.searchParams.get("code_challenge"), pendingSession?.pkceVerifier);
   });
 
+  it("records the optional structured device descriptor on the pending session", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/auth/github/init",
+      headers: {
+        "content-type": "application/json",
+        "x-sesori-session-token": VALID_GITHUB_SESSION_TOKEN,
+      },
+      payload: JSON.stringify({
+        clientType: "bridge_macos",
+        device: { name: "Alex's MacBook Pro", osVersion: "macOS 14.5", appVersion: "1.2.0" },
+      }),
+    });
+
+    assert.equal(res.statusCode, 200);
+    const pendingSession = pendingAuthStore.getSession(PendingAuthStore.hashToken(VALID_GITHUB_SESSION_TOKEN));
+    assert.deepEqual(pendingSession?.device, {
+      name: "Alex's MacBook Pro",
+      osVersion: "macOS 14.5",
+      appVersion: "1.2.0",
+    });
+  });
+
+  it("returns 400 when the device descriptor is invalid (name exceeds max length)", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/auth/github/init",
+      headers: {
+        "content-type": "application/json",
+        "x-sesori-session-token": VALID_GITHUB_SESSION_TOKEN,
+      },
+      payload: JSON.stringify({ clientType: "bridge_macos", device: { name: "x".repeat(121) } }),
+    });
+
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.json<{ error: string }>().error, "bad_request");
+  });
+
   it("creates a pending Google auth session and returns backend-callback init metadata", async () => {
     const res = await app.inject({
       method: "POST",

--- a/tests/auth/init.test.ts
+++ b/tests/auth/init.test.ts
@@ -122,6 +122,25 @@ describe("OAuth init routes", () => {
     });
   });
 
+  it("tolerates empty / null version fields on the device descriptor (cosmetic, optional)", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/auth/github/init",
+      headers: {
+        "content-type": "application/json",
+        "x-sesori-session-token": VALID_GITHUB_SESSION_TOKEN,
+      },
+      payload: JSON.stringify({
+        clientType: "bridge_macos",
+        device: { name: "Alex's MacBook Pro", osVersion: null, appVersion: "" },
+      }),
+    });
+
+    assert.equal(res.statusCode, 200);
+    const pendingSession = pendingAuthStore.getSession(PendingAuthStore.hashToken(VALID_GITHUB_SESSION_TOKEN));
+    assert.equal(pendingSession?.device?.name, "Alex's MacBook Pro");
+  });
+
   it("returns 400 when the device descriptor is invalid (name exceeds max length)", async () => {
     const res = await app.inject({
       method: "POST",

--- a/tests/auth/oauth-callback-confirmation.test.ts
+++ b/tests/auth/oauth-callback-confirmation.test.ts
@@ -5,6 +5,7 @@ import type { FastifyInstance } from "fastify";
 import type { Config } from "../../src/config.js";
 import { StateStore } from "../../src/lib/state-store.js";
 import { buildApp, type AppServices } from "../../src/server.js";
+import { OAuthClientType } from "../../src/models/api.js";
 import { PendingAuthStore } from "../../src/services/pending-auth-store.js";
 import { OAuthProviderName, type OAuthExchangeParams, type OAuthIdentity } from "../../src/types/oauth.js";
 import { FakeOAuthClient } from "../helpers/fake-oauth-client.js";
@@ -145,8 +146,12 @@ describe("OAuth callback confirmation flow", () => {
     await app.close();
   });
 
-  it("renders a Sesori confirmation page with the pending user code", async () => {
-    const session = createPendingSession({ provider: OAuthProviderName.Github });
+  it("renders a Sesori confirmation page describing the requesting device", async () => {
+    const session = createPendingSession({
+      provider: OAuthProviderName.Github,
+      clientType: OAuthClientType.BridgeMacOS,
+      device: { name: "Alex's MacBook Pro", osVersion: "macOS 14.5", appVersion: "1.2.0" },
+    });
 
     const res = await app.inject({
       method: "GET",
@@ -156,8 +161,15 @@ describe("OAuth callback confirmation flow", () => {
     assert.equal(res.statusCode, 200);
     assert.match(res.headers["content-type"] ?? "", /^text\/html/);
     assert.match(res.body, /Confirm Sesori sign-in/);
-    assert.match(res.body, new RegExp(session.userCode));
+    // Human-readable device name (HTML-escaped) + OS/type derived from clientType.
+    assert.match(res.body, /Alex&#39;s MacBook Pro/);
+    assert.match(res.body, /macOS desktop/);
+    assert.match(res.body, /macOS 14\.5/);
+    assert.match(res.body, /Sesori 1\.2\.0/);
     assert.match(res.body, /Confirm/);
+    // The legacy 4-char visual code element must no longer be rendered.
+    assert.ok(!res.body.includes('class="code"'), "legacy code element must be gone");
+    assert.ok(!res.body.includes("4-character"), "legacy code-matching copy must be gone");
 
     const updatedSession = pendingAuthStore.getSessionByTokenHash(session.tokenHash);
     assert.equal(updatedSession?.status, "awaiting_confirmation");
@@ -168,6 +180,20 @@ describe("OAuth callback confirmation flow", () => {
       clientId: "test-github-client-id",
       clientSecret: "test-github-client-secret",
     });
+  });
+
+  it("falls back to a generic device message when the client sends no device info", async () => {
+    const session = createPendingSession({ provider: OAuthProviderName.Github, tokenSuffix: "c" });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/auth/github/callback?code=test-code-c&state=${session.state}`,
+    });
+
+    assert.equal(res.statusCode, 200);
+    assert.match(res.body, /Confirm Sesori sign-in/);
+    assert.match(res.body, /requesting to sign in/);
+    assert.ok(!res.body.includes('class="code"'), "legacy code element must be gone");
   });
 
   it("completes the pending session only after explicit confirmation", async () => {
@@ -341,8 +367,13 @@ describe("OAuth callback confirmation flow", () => {
     });
   });
 
-  it("renders a Google confirmation page with the pending user code", async () => {
-    const session = createPendingSession({ provider: OAuthProviderName.Google, tokenSuffix: "6" });
+  it("renders a Google confirmation page describing the requesting device", async () => {
+    const session = createPendingSession({
+      provider: OAuthProviderName.Google,
+      tokenSuffix: "6",
+      clientType: OAuthClientType.AppIOS,
+      device: { name: "Alex's iPhone" },
+    });
 
     const res = await app.inject({
       method: "GET",
@@ -352,8 +383,10 @@ describe("OAuth callback confirmation flow", () => {
     assert.equal(res.statusCode, 200);
     assert.match(res.headers["content-type"] ?? "", /^text\/html/);
     assert.match(res.body, /Confirm Sesori sign-in/);
-    assert.match(res.body, new RegExp(session.userCode));
+    assert.match(res.body, /Alex&#39;s iPhone/);
+    assert.match(res.body, /iPhone or iPad/);
     assert.match(res.body, /Confirm/);
+    assert.ok(!res.body.includes('class="code"'), "legacy code element must be gone");
 
     const updatedSession = pendingAuthStore.getSessionByTokenHash(session.tokenHash);
     assert.equal(updatedSession?.status, "awaiting_confirmation");
@@ -491,6 +524,8 @@ describe("OAuth callback confirmation flow", () => {
     provider: OAuthProviderName;
     store?: PendingAuthStore;
     tokenSuffix?: string;
+    clientType?: OAuthClientType;
+    device?: { name: string; osVersion?: string; appVersion?: string };
   }) {
     const sessionToken = `${VALID_SESSION_TOKEN.slice(0, -1)}${params.tokenSuffix ?? "0"}`;
     const tokenHash = PendingAuthStore.hashToken(sessionToken);
@@ -502,6 +537,8 @@ describe("OAuth callback confirmation flow", () => {
       provider: params.provider,
       pkceVerifier: `pkce-verifier-${params.tokenSuffix ?? "0"}`,
       state,
+      clientType: params.clientType,
+      device: params.device,
     });
 
     return {


### PR DESCRIPTION
## Summary

Replaces the 4-character visual **match code** on the OAuth sign-in confirmation interstitial with a description of the **device that started the sign-in**. Clients can now send an optional, structured, human-readable device descriptor at init; the confirmation page shows it (alongside the trusted device type/OS) so the user recognizes the device before approving.

The explicit approve/deny step is unchanged — only what the page displays changed.

## Changes

- **`models/api.ts`** — new optional `device` object on the init body:
  ```ts
  device: { name: string; osVersion?: string; appVersion?: string }
  ```
  All fields trimmed + length-bounded; `name` ≤120, versions ≤40.
- **`provider-callback.ts`** — confirmation page now renders:
  - device **type + OS** derived from the enum-bounded `clientType` (e.g. `bridge_macos` → "macOS desktop", `app_ios` → "iPhone or iPad") — the *trustworthy* signal;
  - the client-supplied **device name** + optional OS/app versions — an *untrusted* recognition aid, HTML-escaped;
  - a **generic** message ("A <type> is requesting to sign in.") when no `device` is sent.
  - `userCode` removed from the confirm / success / denied pages.
- **`pending-auth-store.ts`, `init.ts`, `github.ts`, `google.ts`** — thread `device` through to the in-memory pending session (ephemeral, same treatment as `clientType`).
- **README** — updated the anti-phishing flow description + init endpoint row.

## Backwards compatibility

- `device` is **optional** — older clients that omit it get the generic message.
- `userCode` is **still generated and returned** in the `/auth/{provider}/init` reply so existing clients that parse it don't break. Only its *display* is removed. The whole code-generation subsystem can be deleted in a follow-up once clients migrate.

## Security note

A client-supplied device name is **not** a replacement for the match code's anti-phishing property: it is attacker-controllable and not session-bound. The page therefore leans on the enum-bounded `clientType` for the trustworthy "is this the right device?" signal and treats the free-text name as cosmetic only (escaped, bounded). Location/IP was intentionally left out for privacy.

## Testing

- `npm run build`, `npm run lint`, `npm run format:check`, `npm run circular-dependencies` — all pass.
- `npm test` — **325 pass, 0 fail, 1 skipped** (full suite against MongoDB).
- New tests: device descriptor recorded on the pending session; invalid device rejected (400); confirmation page renders device name + type and no longer renders the legacy code element (GitHub + Google); generic fallback when no device is sent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the 4‑character match code on the OAuth confirmation page with a clear description of the device that started the sign‑in. Backward compatible: `device` is optional and `userCode` is still returned but no longer displayed.

- **New Features**
  - Accept optional `device` on `POST /auth/{provider}/init`: `{ name: string; osVersion?: string; appVersion?: string }` (trimmed; versions accept empty strings or `null`).
  - Confirmation shows device type/OS from `clientType` and, when provided, the device name and versions (HTML‑escaped). Generic fallback when `device` is omitted. Removed code display from confirm/success/denied pages.
  - Thread `device` through the pending session across all providers, including Apple; Apple init now correctly preserves `clientType` and `device`.

- **Dependencies**
  - Added `.opencode` skills and `opencode.json` to enable PR monitoring and inline comment workflows, using `github:sesori-ai/opencode-pr-monitor#v0.1.3`.
  - Added `.gitattributes` to mark test files as generated and collapse their diffs on GitHub.

<sup>Written for commit f52127397eaca398bf2b294bee3ed9b81a0ab20c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

