### PR TITLE
feat(activation): add dormant activation state data layer

### DIFF
--- a/.plans/activation-reminders/CONSIDERATIONS.md
+++ b/.plans/activation-reminders/CONSIDERATIONS.md
@@ -32,7 +32,7 @@ Historical reconciliation should include revoked bridges. A revoked bridge still
 
 ### First Session
 
-The selected signal is the first successful request to `/sessions/generate-metadata`. It is specific to creating a new session with a non-empty text prompt, unlike sending a message in an existing session.
+The selected signal is the first valid authenticated request to `/sessions/generate-metadata`. The bridge treats metadata errors as non-fatal and continues session creation with no generated metadata, so a successful HTTP response is not required. Historical `metadataRequestCount` is therefore useful evidence of this signal, although a narrow crash window remains between the metadata call and local session creation.
 
 Known limitation: command-only session creation may not call metadata generation. Such a user can receive a session reminder despite having created a command-only session. The agreed copy asks them to create a new session and remains directionally correct. A dedicated bridge-to-auth session-created event is deferred.
 
@@ -54,12 +54,13 @@ Separate bridge indexes are intentional because bridge reminder 1 and bridge rem
 
 ## Delivery Guarantees
 
-The intended user-level behavior is one attempt per reminder kind. PR3 should use:
+The intended user-level behavior is one recorded completion per reminder kind. Unresolved sends remain eligible for retry, subject to the documented post-FCM/pre-MongoDB crash window. PR3 should use:
 
 - A single-process, single-flight sweep.
 - Conditional sent-marker updates.
 - Completion checks before sending.
-- A sent marker after `NotificationService.sendToUser` resolves, even when zero devices were notified.
+- A sent marker after `NotificationService.sendToUser` resolves while FCM is available, even when zero devices were notified because no registered tokens remain.
+- An explicit unavailable outcome (or a disabled sweep) when Firebase initialization failed, leaving the reminder retryable.
 - Retry when the send call throws before resolving.
 
 Strict exactly-once push delivery is impossible with the current FCM API and MongoDB in separate systems. A process can crash after FCM accepts a push but before MongoDB records `sentAt`, causing a retry after restart. Marking before send would instead create a crash window that permanently loses reminders. The plan prefers the small duplicate-delivery risk over silent loss. Do not claim strict exactly-once delivery in implementation or documentation.
@@ -83,7 +84,7 @@ Activation is secondary telemetry/engagement behavior. Existing endpoint success
 - Applying writes requires an explicit operator flag.
 - The script is idempotent and does not overwrite existing non-null milestones or sent markers.
 - Deterministic jitter avoids changing baselines on repeated runs.
-- Fully activated users never receive activation reminders.
+- Backfill does not intentionally target fully activated users; a narrow send/completion race may still produce a stale reminder.
 - Users without device tokens are not made reminder-eligible.
 - Operational counts are reviewed before applying.
 

--- a/.plans/activation-reminders/CONSIDERATIONS.md
+++ b/.plans/activation-reminders/CONSIDERATIONS.md
@@ -1,0 +1,99 @@
+# Activation Reminders - Considerations
+
+## Existing Capabilities
+
+- Push delivery already exists through Firebase Admin in `NotificationService`.
+- Device tokens are stored in MongoDB and registered by the Flutter app.
+- The auth server already receives all three selected milestones.
+- The Flutter app already renders `system_update` notifications.
+- No durable job queue, cron framework, or Redis deployment exists.
+
+## Why Activation State Instead Of A Generic Job Queue
+
+Every reminder is conditional: send at a rough time only if a later milestone is still missing. Persisting the funnel state and deriving due reminders from it avoids stale queued jobs, makes cancellation implicit, and creates the desired analytics dataset. A generic queue would add a second source of truth without solving a current broader requirement.
+
+## Why Poll MongoDB
+
+Reminder timing is measured in hours and does not need exact execution. A roughly 15-minute query interval is acceptable and inexpensive. MongoDB persists eligibility across restarts, while the in-process interval only triggers a stateless sweep. This avoids introducing Redis or another operational dependency.
+
+MongoDB TTL indexes are not a scheduler: they delete documents eventually but do not execute application code, so they are not suitable here.
+
+## Milestone Semantics
+
+### Mobile Setup
+
+The first device-token registration is used rather than user creation because it means the app is installed, authenticated, has notification permission, and can actually receive a reminder. Users without a device token may still be represented during active backfill for funnel completeness, but are not reminder-eligible.
+
+### Bridge Setup
+
+The first bridge registration is used rather than relay connectivity. Registration directly represents installation and first launch, is already handled by the auth server, and avoids coupling activation to relay webhook delivery.
+
+Historical reconciliation should include revoked bridges. A revoked bridge still proves that the user completed this setup stage in the past and must not receive first-time bridge-install copy.
+
+### First Session
+
+The selected signal is the first successful request to `/sessions/generate-metadata`. It is specific to creating a new session with a non-empty text prompt, unlike sending a message in an existing session.
+
+Known limitation: command-only session creation may not call metadata generation. Such a user can receive a session reminder despite having created a command-only session. The agreed copy asks them to create a new session and remains directionally correct. A dedicated bridge-to-auth session-created event is deferred.
+
+## Timestamp Semantics
+
+Real milestone timestamps and reminder baselines serve different purposes and must not be conflated.
+
+- Real timestamps support funnel analytics and historical reconciliation.
+- Reminder baselines control when the current campaign begins.
+- Organic bridge reminders use the mobile setup timestamp.
+- Organic session reminders use the later of mobile and bridge setup.
+- Backfilled incomplete users preserve old real timestamps but use a new, jittered baseline for a controlled re-engagement wave.
+
+## Index Design
+
+Each future due query uses equality conditions for stage completion and sent state followed by a range condition on the reminder baseline. Compound indexes therefore place the completion and sent fields before the baseline field.
+
+Separate bridge indexes are intentional because bridge reminder 1 and bridge reminder 2 have independent sent markers. This avoids relying on a broad scan of all bridge-incomplete users.
+
+## Delivery Guarantees
+
+The intended user-level behavior is one attempt per reminder kind. PR3 should use:
+
+- A single-process, single-flight sweep.
+- Conditional sent-marker updates.
+- Completion checks before sending.
+- A sent marker after `NotificationService.sendToUser` resolves, even when zero devices were notified.
+- Retry when the send call throws before resolving.
+
+Strict exactly-once push delivery is impossible with the current FCM API and MongoDB in separate systems. A process can crash after FCM accepts a push but before MongoDB records `sentAt`, causing a retry after restart. Marking before send would instead create a crash window that permanently loses reminders. The plan prefers the small duplicate-delivery risk over silent loss. Do not claim strict exactly-once delivery in implementation or documentation.
+
+## Stage Races
+
+A user can complete a milestone while the sweep is sending. PR3 should minimize stale reminders by rechecking eligibility through a conditional reservation or update pattern immediately before delivery. Because there is no atomic transaction spanning FCM, an extremely narrow race remains possible after the last database check. This is acceptable for a maximum of three onboarding reminders and should be documented in tests/comments without over-engineering a distributed transaction.
+
+## Failure Isolation
+
+Activation is secondary telemetry/engagement behavior. Existing endpoint success must not depend on it.
+
+- Device-token registration must succeed if activation persistence fails.
+- Bridge registration must succeed if activation persistence fails.
+- Metadata generation must preserve its current response if activation persistence fails.
+- Failures should be structured and observable, not silently ignored.
+
+## Backfill Safety
+
+- Dry-run is the default.
+- Applying writes requires an explicit operator flag.
+- The script is idempotent and does not overwrite existing non-null milestones or sent markers.
+- Deterministic jitter avoids changing baselines on repeated runs.
+- Fully activated users never receive activation reminders.
+- Users without device tokens are not made reminder-eligible.
+- Operational counts are reviewed before applying.
+
+## Production Compatibility
+
+Each slice must be safe to merge and deploy independently:
+
+- PR1 only creates an unused collection and indexes.
+- PR2 only records state and isolates failures.
+- PR3 defaults sending off.
+- PR4 is inert until an operator runs it with apply enabled.
+
+No plaintext environment files or credentials are introduced. Configuration changes in PR3 follow the existing Zod/env conventions and encrypted environment workflow.

--- a/.plans/activation-reminders/PLAN.md
+++ b/.plans/activation-reminders/PLAN.md
@@ -1,0 +1,256 @@
+# Activation Reminders
+
+## Purpose
+
+Improve user activation by measuring and nudging users through this funnel:
+
+1. Mobile setup: the user registers a push-notification device token.
+2. Bridge setup: the user registers the desktop bridge.
+3. Full activation: the user creates a new session, represented by the first successful call to `POST /sessions/generate-metadata`.
+
+This file is the authoritative implementation tracker. A future session should read this file and `.plans/activation-reminders/CONSIDERATIONS.md` before changing code.
+
+## Current State
+
+- Branch: `activation-rate-plan`
+- Implementation checkpoint: PR1 complete; PR2 not started
+- PR1 post-merge status: merged
+- Live GitHub delivery state: do not infer it from this static file; verify with `gh pr list --head activation-rate-plan --state all`
+- Last updated: 2026-07-12
+- If PR1 is still open: review and merge PR1; do not start PR2 on top of an unmerged slice
+- If PR1 is merged: begin PR2 by reviewing the PR1 repository API and adding the activation service/reconciliation methods described below
+
+## Resume Instructions
+
+1. Read this entire file and `CONSIDERATIONS.md`.
+2. Run `git status --short` and inspect existing changes; do not undo unrelated work.
+3. Verify live PR state with GitHub; the table records implementation and intended post-merge state, not live delivery state.
+4. If an earlier slice is implemented but not merged, finish that delivery workflow before starting the next slice.
+5. Find the first PR whose implementation is not complete in the status table below.
+6. Work only on that PR's unchecked acceptance criteria unless the user explicitly expands scope.
+7. Run that PR's verification commands.
+8. Update implementation status, post-merge status, completed checkboxes, verification results, and continuation instructions.
+9. Do not start the next PR in the same session unless the user asks.
+
+## Product Decisions
+
+- V1 implementation is auth-server-only. Full-stack changes remain permissible later, but no Flutter, bridge, or relay changes are needed for V1.
+- Existing FCM infrastructure and the `system_update` notification category are reused.
+- Notification taps rely on the app's default open behavior; V1 adds no activation-specific deep link.
+- Mobile setup is the first device-token registration, not account creation.
+- Bridge setup is the first bridge registration, not the first relay connection.
+- First session is the first `POST /sessions/generate-metadata` call. This deliberately measures creation of a new text-backed session, not messages in existing sessions.
+- Bridge reminder 1 is due approximately 2 hours after mobile setup.
+- Bridge reminder 2 is due approximately 24 hours after mobile setup.
+- The single session reminder is due approximately 24 hours after both mobile and bridge setup. Its organic baseline is `max(mobileSetupAt, bridgeSetupAt)`.
+- A roughly 15-minute sweep is sufficient; reminder timing is intentionally approximate.
+- No quiet-hours handling in V1.
+- Existing users are actively backfilled. Incomplete users enter a controlled re-engagement sequence measured from backfill time with deterministic jitter.
+- V1 reporting consists of structured logs and direct MongoDB queries; no metrics endpoint or dashboard.
+
+## Notification Copy
+
+All reminders use category `system_update`.
+
+| Reminder      | Title                           | Body                                                                                         |
+| ------------- | ------------------------------- | -------------------------------------------------------------------------------------------- |
+| Bridge 1      | Finish setting up Sesori        | Install the Sesori bridge on your computer to start using Sesori from your phone.            |
+| Bridge 2      | Your Sesori setup is unfinished | You haven't connected your computer yet. Install the Sesori bridge to unlock Sesori.         |
+| First session | Start your first session        | You're all set up! You haven't started a new session yet - create one to put Sesori to work. |
+
+## Target Data Model
+
+Collection: `activationStates`. One document per user.
+
+```text
+_id: ObjectId
+userId: ObjectId (unique)
+
+mobileSetupAt: Date | null
+bridgeSetupAt: Date | null
+firstSessionAt: Date | null
+
+bridgeReminderBaseAt: Date | null
+sessionReminderBaseAt: Date | null
+
+bridgeReminder1SentAt: Date | null
+bridgeReminder2SentAt: Date | null
+sessionReminderSentAt: Date | null
+
+backfilledAt: Date | null
+createdAt: Date
+updatedAt: Date
+```
+
+Field invariants:
+
+- `bridgeReminderBaseAt` is set only after mobile setup is known.
+- `sessionReminderBaseAt` is set only after both mobile and bridge setup are known.
+- Milestone timestamps record the best known real event time and are set once.
+- Backfill timestamps remain separate from reminder baselines so analytics are not rewritten to make scheduling convenient.
+- Sent timestamps are independent so each reminder can be measured and suppressed separately.
+
+Planned indexes:
+
+- `{ userId: 1 }`, unique.
+- `{ bridgeSetupAt: 1, bridgeReminder1SentAt: 1, bridgeReminderBaseAt: 1 }`.
+- `{ bridgeSetupAt: 1, bridgeReminder2SentAt: 1, bridgeReminderBaseAt: 1 }`.
+- `{ firstSessionAt: 1, sessionReminderSentAt: 1, sessionReminderBaseAt: 1 }`.
+
+The equality fields precede each due-time range field so the future sweep queries can use the indexes directly.
+
+## Delivery Architecture
+
+- MongoDB is the durable source of truth.
+- An in-process single-flight sweep queries due activation records about every 15 minutes.
+- A process restart loses only the current polling interval, not reminder eligibility.
+- Sending is gated by `ACTIVATION_REMINDERS_ENABLED`, defaulting to false.
+- Milestone recording remains active independently of the sending flag.
+- Activation tracking failures are logged and isolated from the user-facing endpoint that produced the milestone.
+- Reminder attempts are marked after `NotificationService.sendToUser` resolves, including a result with zero notified devices. A thrown send error remains retryable.
+- See `CONSIDERATIONS.md` for the narrow crash window in which strict exactly-once delivery cannot be guaranteed.
+
+## Configuration Target
+
+| Variable                                | Default    | Purpose                                                    |
+| --------------------------------------- | ---------- | ---------------------------------------------------------- |
+| `ACTIVATION_REMINDERS_ENABLED`          | `false`    | Master switch for the reminder sweep.                      |
+| `ACTIVATION_SWEEP_INTERVAL_MS`          | `900000`   | Approximate 15-minute sweep interval.                      |
+| `ACTIVATION_BRIDGE_REMINDER_1_DELAY_MS` | `7200000`  | Two-hour first bridge delay.                               |
+| `ACTIVATION_BRIDGE_REMINDER_2_DELAY_MS` | `86400000` | Twenty-four-hour second bridge delay.                      |
+| `ACTIVATION_SESSION_REMINDER_DELAY_MS`  | `86400000` | Twenty-four-hour session delay after both setups.          |
+| `ACTIVATION_SWEEP_BATCH_LIMIT`          | `500`      | Maximum records processed for one reminder kind per sweep. |
+
+## PR Status
+
+| PR  | Scope                                                                                         | Implementation | Post-merge status | Production behavior                       |
+| --- | --------------------------------------------------------------------------------------------- | -------------- | ----------------- | ----------------------------------------- |
+| PR1 | Plans, collection, indexes, schema, repository, composition wiring, repository tests          | complete       | merged            | Dormant; creates collection/indexes only. |
+| PR2 | Milestone capture, enrollment reconciliation, endpoint hooks, failure isolation               | not started    | pending           | Records state only; sends nothing.        |
+| PR3 | Config, reminder queries/service, FCM sends, 15-minute scheduler, structured logs             | not started    | pending           | Sending remains off by default.           |
+| PR4 | Idempotent dry-run-capable active backfill with controlled re-engagement baselines and jitter | not started    | pending           | No effect until manually executed.        |
+
+## PR1 - Dormant Data Layer
+
+Implementation: complete
+
+Post-merge status: merged
+
+Acceptance criteria:
+
+- [x] Add this resumable plan and considerations document.
+- [x] Add `ActivationStates` to `AuthDbCollection`.
+- [x] Add the four planned indexes to `DATABASE_CONFIG`.
+- [x] Add the complete Zod document schema and inferred type.
+- [x] Add `ActivationStateRepository` with dormant persistence primitives needed by later slices.
+- [x] Instantiate and pass the repository through composition without adding behavior.
+- [x] Add focused repository/index tests.
+- [x] `npm run build` passes.
+- [x] `npm run lint` passes without new warnings.
+- [x] `npm run format:check` passes.
+- [x] Focused PR1 tests pass.
+- [x] Full test suite passes, or any environment blocker is recorded below.
+
+PR1 non-goals:
+
+- No route or service hook records activation yet.
+- No reminder query or scheduler exists yet.
+- No configuration variables are added yet.
+- No push is sent.
+- No backfill script is added.
+
+PR1 verification results:
+
+- `node --import tsx --test --test-concurrency=1 "tests/repositories/activation-state-repo.test.ts"`: passed, 4 tests.
+- `npm run build`: passed.
+- `npm run lint`: passed with no warnings.
+- `npm run format:check`: passed.
+- `npm test`: passed, 331 tests passed, 1 skipped, 0 failed across 37 top-level suites.
+- `npm run circular-dependencies`: passed; no circular dependencies found.
+- `git diff --check`: passed.
+
+## PR2 - Milestone Capture
+
+Status: pending
+
+Planned work:
+
+- Add an `ActivationService` that owns cross-collection reconciliation and milestone invariants.
+- On first device-token registration, enroll the user and reconcile pre-existing bridge/session state.
+- Reconcile bridge state from the earliest historical bridge, including revoked bridges, so a previously completed setup is not presented as new.
+- Reconcile session state from historical `dailyUsage.metadataRequestCount > 0` data, using the best available date.
+- Set `bridgeSetupAt` idempotently after bridge registration.
+- Set `firstSessionAt` idempotently after a successful metadata generation request.
+- Recompute `sessionReminderBaseAt` as the later setup time when both setup timestamps become available.
+- Catch and log activation errors at each endpoint boundary so activation tracking cannot break existing behavior.
+- Add route/service tests for ordering, retries, and failure isolation.
+
+PR2 exit condition:
+
+- Production can collect and query the funnel while sending remains impossible.
+
+## PR3 - Reminder Sweep And Sending
+
+Status: pending
+
+Planned work:
+
+- Add the activation configuration variables with sending disabled by default.
+- Add indexed repository queries for each due reminder.
+- Add conditional sent-marker writes so stale sweep results cannot mark an already-completed stage.
+- Add `ActivationReminderService` with single-flight sweep behavior and bounded batches.
+- Send the approved copy through existing `NotificationService` under category `system_update`.
+- Use distinct collapse keys per reminder kind.
+- Start the interval only when enabled and dispose it during graceful shutdown.
+- Emit structured milestone/reminder logs suitable for initial funnel analysis.
+- Test cutoffs, stage completion races, no-overlap behavior, send outcomes, and retry behavior.
+
+PR3 exit condition:
+
+- Code is deployable with no sends under default configuration; enabling the flag starts organic reminders.
+
+## PR4 - Existing-User Backfill
+
+Status: pending
+
+Planned work:
+
+- Add an idempotent operator-run script and package command.
+- Require dry-run by default and an explicit apply flag for writes.
+- Iterate existing users in bounded batches.
+- Set `mobileSetupAt` from the earliest extant device token; users without a token are recorded but are not reminder-eligible.
+- Set `bridgeSetupAt` from the earliest historical bridge registration.
+- Set `firstSessionAt` from historical metadata usage when available.
+- Preserve real milestone timestamps for analytics.
+- For currently incomplete, push-reachable users, set only the relevant reminder baseline to backfill time plus deterministic jitter.
+- Do not schedule bridge reminders for users who already have a bridge.
+- Do not schedule session reminders unless both mobile and bridge setup are known.
+- Report proposed/applied counts by activation stage and reminder sequence.
+- Test dry-run safety, idempotency, reconciliation, and controlled baseline assignment.
+
+PR4 exit condition:
+
+- Operators can preview and then launch a controlled existing-user re-engagement wave.
+
+## Rollout
+
+1. Merge/deploy PR1. Confirm collection and indexes exist; user behavior is unchanged.
+2. Merge/deploy PR2. Inspect activation records and establish baseline funnel conversion.
+3. Merge/deploy PR3 with `ACTIVATION_REMINDERS_ENABLED=false`. Confirm no sends.
+4. Enable organic reminders and monitor logs/error rate.
+5. Merge PR4, run dry-run, review counts, then apply at a suitable time for primary user regions.
+6. Compare conversion timestamps before/after reminder sends through MongoDB aggregation.
+
+## Deferred
+
+- Dedicated activation notification category and in-app preference.
+- Explicit activation deep links in the Flutter notification dispatcher.
+- Device-timezone capture and local quiet hours.
+- Internal metrics endpoint or dashboard.
+- Generic durable job infrastructure.
+- Multi-instance worker leasing. Current deployment is intentionally single-instance.
+
+## Change Log
+
+- 2026-07-12: Interview completed. Product behavior, scheduling, copy, backfill policy, reporting, and four-PR split agreed.
+- 2026-07-12: PR1 implementation completed. Added the resumable plan, activation-state collection/schema/indexes, dormant repository/composition wiring, and focused tests. All verification passed. This document records PR1's intended post-merge status as merged; live GitHub status must always be verified separately. PR2 is next and has not started.

--- a/.plans/activation-reminders/PLAN.md
+++ b/.plans/activation-reminders/PLAN.md
@@ -14,9 +14,9 @@ This file is the authoritative implementation tracker. A future session should r
 
 - Branch: `activation-rate-plan`
 - Implementation checkpoint: PR1 complete; PR2 not started
-- PR1 post-merge status: merged
+- PR1 intended post-merge status: merged
 - Live GitHub delivery state: do not infer it from this static file; verify with `gh pr list --head activation-rate-plan --state all`
-- Last updated: 2026-07-12
+- Last updated: 2026-07-15
 - If PR1 is still open: review and merge PR1; do not start PR2 on top of an unmerged slice
 - If PR1 is merged: begin PR2 by reviewing the PR1 repository API and adding the activation service/reconciliation methods described below
 
@@ -29,7 +29,7 @@ This file is the authoritative implementation tracker. A future session should r
 5. Find the first PR whose implementation is not complete in the status table below.
 6. Work only on that PR's unchecked acceptance criteria unless the user explicitly expands scope.
 7. Run that PR's verification commands.
-8. Update implementation status, post-merge status, completed checkboxes, verification results, and continuation instructions.
+8. Update implementation status, intended post-merge status, completed checkboxes, verification results, and continuation instructions.
 9. Do not start the next PR in the same session unless the user asks.
 
 ## Product Decisions
@@ -123,18 +123,18 @@ The equality fields precede each due-time range field so the future sweep querie
 
 ## PR Status
 
-| PR  | Scope                                                                                         | Implementation | Post-merge status | Production behavior                       |
-| --- | --------------------------------------------------------------------------------------------- | -------------- | ----------------- | ----------------------------------------- |
-| PR1 | Plans, collection, indexes, schema, repository, composition wiring, repository tests          | complete       | merged            | Dormant; creates collection/indexes only. |
-| PR2 | Milestone capture, enrollment reconciliation, endpoint hooks, failure isolation               | not started    | pending           | Records state only; sends nothing.        |
-| PR3 | Config, reminder queries/service, FCM sends, 15-minute scheduler, structured logs             | not started    | pending           | Sending remains off by default.           |
-| PR4 | Idempotent dry-run-capable active backfill with controlled re-engagement baselines and jitter | not started    | pending           | No effect until manually executed.        |
+| PR  | Scope                                                                                         | Implementation | Intended post-merge status | Production behavior                       |
+| --- | --------------------------------------------------------------------------------------------- | -------------- | -------------------------- | ----------------------------------------- |
+| PR1 | Plans, collection, indexes, schema, repository, composition wiring, repository tests          | complete       | merged                     | Dormant; creates collection/indexes only. |
+| PR2 | Milestone capture, enrollment reconciliation, endpoint hooks, failure isolation               | not started    | pending                    | Records state only; sends nothing.        |
+| PR3 | Config, reminder queries/service, FCM sends, 15-minute scheduler, structured logs             | not started    | pending                    | Sending remains off by default.           |
+| PR4 | Idempotent dry-run-capable active backfill with controlled re-engagement baselines and jitter | not started    | pending                    | No effect until manually executed.        |
 
 ## PR1 - Dormant Data Layer
 
 Implementation: complete
 
-Post-merge status: merged
+Intended post-merge status: merged
 
 Acceptance criteria:
 
@@ -161,11 +161,11 @@ PR1 non-goals:
 
 PR1 verification results:
 
-- `node --import tsx --test --test-concurrency=1 "tests/repositories/activation-state-repo.test.ts"`: passed, 6 tests.
+- `node --import tsx --test --test-concurrency=1 "tests/repositories/activation-state-repo.test.ts"`: passed, 7 tests.
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm run format:check`: passed.
-- `npm test`: passed, 333 tests passed, 1 skipped, 0 failed across 37 top-level suites.
+- `npm test`: passed, 334 tests passed, 1 skipped, 0 failed across 37 top-level suites.
 - `npm run circular-dependencies`: passed; no circular dependencies found.
 - `git diff --check`: passed.
 
@@ -256,3 +256,4 @@ PR4 exit condition:
 - 2026-07-12: Interview completed. Product behavior, scheduling, copy, backfill policy, reporting, and four-PR split agreed.
 - 2026-07-12: PR1 implementation completed. Added the resumable plan, activation-state collection/schema/indexes, dormant repository/composition wiring, and focused tests. All verification passed. This document records PR1's intended post-merge status as merged; live GitHub status must always be verified separately. PR2 is next and has not started.
 - 2026-07-15: PR1 review feedback addressed. Clarified metadata-attempt semantics, retry and FCM-unavailable behavior, and backfill race guarantees; added defensive ObjectId validation and tests. All verification passed.
+- 2026-07-15: Human PR1 review feedback addressed. Documented timestamp and index invariants in source, clarified intended status labels, and made concurrent first-enrollment upserts recover from duplicate-key races. All verification passed.

--- a/.plans/activation-reminders/PLAN.md
+++ b/.plans/activation-reminders/PLAN.md
@@ -6,7 +6,7 @@ Improve user activation by measuring and nudging users through this funnel:
 
 1. Mobile setup: the user registers a push-notification device token.
 2. Bridge setup: the user registers the desktop bridge.
-3. Full activation: the user creates a new session, represented by the first successful call to `POST /sessions/generate-metadata`.
+3. Full activation: the user creates a new session, represented by the first valid authenticated call to `POST /sessions/generate-metadata`.
 
 This file is the authoritative implementation tracker. A future session should read this file and `.plans/activation-reminders/CONSIDERATIONS.md` before changing code.
 
@@ -39,7 +39,7 @@ This file is the authoritative implementation tracker. A future session should r
 - Notification taps rely on the app's default open behavior; V1 adds no activation-specific deep link.
 - Mobile setup is the first device-token registration, not account creation.
 - Bridge setup is the first bridge registration, not the first relay connection.
-- First session is the first `POST /sessions/generate-metadata` call. This deliberately measures creation of a new text-backed session, not messages in existing sessions.
+- First session is the first valid authenticated `POST /sessions/generate-metadata` call. Metadata failure is non-fatal in the bridge and session creation continues, so the response does not need to succeed. This deliberately measures creation of a new text-backed session, not messages in existing sessions.
 - Bridge reminder 1 is due approximately 2 hours after mobile setup.
 - Bridge reminder 2 is due approximately 24 hours after mobile setup.
 - The single session reminder is due approximately 24 hours after both mobile and bridge setup. Its organic baseline is `max(mobileSetupAt, bridgeSetupAt)`.
@@ -107,7 +107,7 @@ The equality fields precede each due-time range field so the future sweep querie
 - Sending is gated by `ACTIVATION_REMINDERS_ENABLED`, defaulting to false.
 - Milestone recording remains active independently of the sending flag.
 - Activation tracking failures are logged and isolated from the user-facing endpoint that produced the milestone.
-- Reminder attempts are marked after `NotificationService.sendToUser` resolves, including a result with zero notified devices. A thrown send error remains retryable.
+- Reminder completion is marked after `NotificationService.sendToUser` resolves while FCM is available, including a result with zero registered devices. FCM-unavailable and thrown-send outcomes remain retryable.
 - See `CONSIDERATIONS.md` for the narrow crash window in which strict exactly-once delivery cannot be guaranteed.
 
 ## Configuration Target
@@ -161,11 +161,11 @@ PR1 non-goals:
 
 PR1 verification results:
 
-- `node --import tsx --test --test-concurrency=1 "tests/repositories/activation-state-repo.test.ts"`: passed, 4 tests.
+- `node --import tsx --test --test-concurrency=1 "tests/repositories/activation-state-repo.test.ts"`: passed, 6 tests.
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm run format:check`: passed.
-- `npm test`: passed, 331 tests passed, 1 skipped, 0 failed across 37 top-level suites.
+- `npm test`: passed, 333 tests passed, 1 skipped, 0 failed across 37 top-level suites.
 - `npm run circular-dependencies`: passed; no circular dependencies found.
 - `git diff --check`: passed.
 
@@ -180,7 +180,7 @@ Planned work:
 - Reconcile bridge state from the earliest historical bridge, including revoked bridges, so a previously completed setup is not presented as new.
 - Reconcile session state from historical `dailyUsage.metadataRequestCount > 0` data, using the best available date.
 - Set `bridgeSetupAt` idempotently after bridge registration.
-- Set `firstSessionAt` idempotently after a successful metadata generation request.
+- Set `firstSessionAt` idempotently when a valid authenticated metadata request is accepted, before metadata generation, because the bridge proceeds with session creation even when metadata generation fails.
 - Recompute `sessionReminderBaseAt` as the later setup time when both setup timestamps become available.
 - Catch and log activation errors at each endpoint boundary so activation tracking cannot break existing behavior.
 - Add route/service tests for ordering, retries, and failure isolation.
@@ -199,6 +199,7 @@ Planned work:
 - Add indexed repository queries for each due reminder.
 - Add conditional sent-marker writes so stale sweep results cannot mark an already-completed stage.
 - Add `ActivationReminderService` with single-flight sweep behavior and bounded batches.
+- Expose FCM availability so an uninitialized Firebase client cannot convert eligible reminders into completed zero-device sends.
 - Send the approved copy through existing `NotificationService` under category `system_update`.
 - Use distinct collapse keys per reminder kind.
 - Start the interval only when enabled and dispose it during graceful shutdown.
@@ -254,3 +255,4 @@ PR4 exit condition:
 
 - 2026-07-12: Interview completed. Product behavior, scheduling, copy, backfill policy, reporting, and four-PR split agreed.
 - 2026-07-12: PR1 implementation completed. Added the resumable plan, activation-state collection/schema/indexes, dormant repository/composition wiring, and focused tests. All verification passed. This document records PR1's intended post-merge status as merged; live GitHub status must always be verified separately. PR2 is next and has not started.
+- 2026-07-15: PR1 review feedback addressed. Clarified metadata-attempt semantics, retry and FCM-unavailable behavior, and backfill race guarantees; added defensive ObjectId validation and tests. All verification passed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@ Node.js/TypeScript authentication service. Social login (GitHub, Google) via OAu
 ## STRUCTURE
 
 ```
+.plans/
+└── activation-reminders/ # Resumable multi-PR plan + design considerations for the activation funnel
 src/
 ├── types/             # Enums + shared types (mongo.ts, oauth.ts)
 ├── clients/
@@ -19,7 +21,7 @@ src/
 ├── lib/               # Utilities (state-store.ts — LRU singleton, errors.ts — ApiError hierarchy)
 ├── middleware/         # createAuthMiddleware factory → requireAuth preHandler hook
 ├── models/            # Zod schemas — api.ts, bridge.ts (shared bridge enums/schemas), documents.ts, jwt.ts
-├── repositories/      # Data access — user-repo.ts, oauth-account-repo.ts, bridge-repo.ts, glossary-entry-repo.ts
+├── repositories/      # Data access — user-repo.ts, oauth-account-repo.ts, bridge-repo.ts, activation-state-repo.ts, …
 ├── routes/
 │   └── auth/          # OAuth + pending-confirmation flow
 │       ├── github.ts             # GET /auth/github, POST /auth/github/init, POST/GET callbacks
@@ -36,17 +38,18 @@ src/
 
 ## WHERE TO LOOK
 
-| Task                       | Location                                                                 | Notes                                                                                       |
-| -------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
-| Add OAuth provider         | `src/clients/auth/` + `src/routes/auth/`                                 | Extend OAuthClient, implement exchangeCode + resolveIdentity, add route plugin in server.ts |
-| OAuth pending/confirm flow | `src/routes/auth/init.ts` + `provider-callback.ts` + `session-status.ts` | Anti-phishing interstitial; pending state in `src/services/pending-auth-store.ts`           |
-| Modify JWT claims          | `src/models/jwt.ts` + `src/services/token-service.ts`                    | Zod schema defines payload shape                                                            |
-| Add API endpoint           | `src/routes/`                                                            | Register as Fastify plugin in `server.ts`, add to AppServices if deps needed                |
-| Change DB schema           | `src/models/documents.ts` + `src/repositories/`                          | Zod document schemas, raw MongoDB driver                                                    |
-| Add DB collection          | `src/types/mongo.ts` + `src/db/mongo-db-accessor.ts`                     | Add to AuthDbCollection enum + DATABASE_CONFIG                                              |
-| Auth middleware            | `src/middleware/auth.ts`                                                 | `createAuthMiddleware(tokenService)` factory                                                |
+| Task                       | Location                                                                                                                                | Notes                                                                                       |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Add OAuth provider         | `src/clients/auth/` + `src/routes/auth/`                                                                                                | Extend OAuthClient, implement exchangeCode + resolveIdentity, add route plugin in server.ts |
+| OAuth pending/confirm flow | `src/routes/auth/init.ts` + `provider-callback.ts` + `session-status.ts`                                                                | Anti-phishing interstitial; pending state in `src/services/pending-auth-store.ts`           |
+| Modify JWT claims          | `src/models/jwt.ts` + `src/services/token-service.ts`                                                                                   | Zod schema defines payload shape                                                            |
+| Add API endpoint           | `src/routes/`                                                                                                                           | Register as Fastify plugin in `server.ts`, add to AppServices if deps needed                |
+| Change DB schema           | `src/models/documents.ts` + `src/repositories/`                                                                                         | Zod document schemas, raw MongoDB driver                                                    |
+| Add DB collection          | `src/types/mongo.ts` + `src/db/mongo-db-accessor.ts`                                                                                    | Add to AuthDbCollection enum + DATABASE_CONFIG                                              |
+| Auth middleware            | `src/middleware/auth.ts`                                                                                                                | `createAuthMiddleware(tokenService)` factory                                                |
 | Manage bridges             | `src/routes/bridges.ts` + `src/services/bridge-service.ts` + `src/repositories/bridge-repo.ts` + `src/services/bridge-state-tracker.ts` | Per-bridge registry behind `/auth/me bridges[]`; see BRIDGE SUBSYSTEM below                 |
-| Wire dependencies          | `src/index.ts`                                                           | Composition root — all instantiation happens here                                           |
+| Activation reminders       | `.plans/activation-reminders/` + `src/repositories/activation-state-repo.ts`                                                            | Read `PLAN.md` and `CONSIDERATIONS.md` before continuing the staged implementation          |
+| Wire dependencies          | `src/index.ts`                                                                                                                          | Composition root — all instantiation happens here                                           |
 
 ## CONVENTIONS
 
@@ -64,6 +67,12 @@ src/
 - **Pending OAuth sessions are in-process only.** `PendingAuthStore` is an in-memory LRU with a 5-minute TTL. The store is NOT shared between instances. Horizontal scaling of this service requires either sticky sessions (`X-Sesori-Session-Token` → consistent instance) OR migrating the store to Redis. Until then: **single-instance deploys only**.
 - Tunable via `PENDING_AUTH_MAX_SESSIONS` (default 10k entries ≈ 10 MB) and `PENDING_AUTH_POLL_TIMEOUT_MS` (default 30s long-poll cap).
 - **Bridge notification debounce is in-process only.** `BridgeStateTracker` keeps per-(userId, bridgeId) debounce timers and last-notified state in a process-local Map: pending notifications are lost on restart, the map is unbounded for the process lifetime (acceptable under the 50-bridges-per-user registration cap), and multiple instances would double-notify. Same single-instance constraint as above.
+
+## ACTIVATION REMINDERS
+
+The activation-reminder feature is intentionally split into independently deployable PRs. `.plans/activation-reminders/PLAN.md` is the authoritative implementation checkpoint and `.plans/activation-reminders/CONSIDERATIONS.md` records the product and architecture decisions. Verify live GitHub state before starting the next slice; do not infer merge status from the static plan alone.
+
+`activationStates` stores one document per user. Milestones are real event timestamps, reminder baselines are campaign scheduling timestamps that may diverge during backfill, and sent markers independently suppress each reminder. Do not conflate these categories. PR1 only establishes the dormant collection, indexes, repository, and wiring; later behavior must follow the staged acceptance criteria in the plan.
 
 ## BRIDGE SUBSYSTEM
 

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -39,6 +39,12 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
         // filter on { userId, revokedAt: null }. No query filters on status.
         { spec: { userId: 1, revokedAt: 1 } },
       ],
+      [AuthDbCollection.ActivationStates]: [
+        { spec: { userId: 1 }, options: { unique: true } },
+        { spec: { bridgeSetupAt: 1, bridgeReminder1SentAt: 1, bridgeReminderBaseAt: 1 } },
+        { spec: { bridgeSetupAt: 1, bridgeReminder2SentAt: 1, bridgeReminderBaseAt: 1 } },
+        { spec: { firstSessionAt: 1, sessionReminderSentAt: 1, sessionReminderBaseAt: 1 } },
+      ],
     },
   } satisfies DatabaseConfig<AuthDbCollection>,
 };

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -41,6 +41,10 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
       ],
       [AuthDbCollection.ActivationStates]: [
         { spec: { userId: 1 }, options: { unique: true } },
+        // Reminder sweeps filter on stage-completion and sent-marker equality,
+        // then range on the baseline. Keep equality fields before the range;
+        // the two bridge reminders need separate indexes for their sent markers.
+        // See .plans/activation-reminders/CONSIDERATIONS.md, "Index Design".
         { spec: { bridgeSetupAt: 1, bridgeReminder1SentAt: 1, bridgeReminderBaseAt: 1 } },
         { spec: { bridgeSetupAt: 1, bridgeReminder2SentAt: 1, bridgeReminderBaseAt: 1 } },
         { spec: { firstSessionAt: 1, sessionReminderSentAt: 1, sessionReminderBaseAt: 1 } },

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { GlossaryEntryRepository } from "./repositories/glossary-entry-repo.js";
 import { OAuthAccountRepository } from "./repositories/oauth-account-repo.js";
 import { PasswordAccountRepository } from "./repositories/password-account-repo.js";
 import { UserRepository } from "./repositories/user-repo.js";
+import { ActivationStateRepository } from "./repositories/activation-state-repo.js";
 import { buildApp } from "./server.js";
 import { AuthService } from "./services/auth-service.js";
 import { AppleNativeVerifier } from "./services/apple-native-verifier.js";
@@ -60,6 +61,7 @@ async function main() {
   const dailyUsageRepo = new DailyUsageRepository(dbAccessor);
   const deviceTokenRepo = new DeviceTokenRepository(dbAccessor);
   const bridgeRepo = new BridgeRepository(dbAccessor);
+  const activationStateRepo = new ActivationStateRepository(dbAccessor);
 
   const tokenService = new TokenService(config.JWT_PRIVATE_KEY, config.JWT_PUBLIC_KEY);
   const pendingAuthStore = new PendingAuthStore({
@@ -139,6 +141,7 @@ async function main() {
     deviceTokenRepo,
     notificationService,
     bridgeStateTracker,
+    activationStateRepo,
     stateStore,
     githubClient,
     googleClient,

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -92,6 +92,13 @@ export const bridgeSchema = z.object({
 
 export type Bridge = z.infer<typeof bridgeSchema>;
 
+/**
+ * One activation-funnel document per user. Do not conflate these categories:
+ * milestones are real event times; reminder baselines are campaign start times
+ * that may diverge after backfill; sent markers independently suppress each
+ * reminder; backfilledAt records enrollment by the backfill script.
+ * See .plans/activation-reminders/CONSIDERATIONS.md, "Timestamp Semantics".
+ */
 export const activationStateSchema = z.object({
   _id: z.instanceof(ObjectId),
   userId: z.instanceof(ObjectId),

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -91,3 +91,21 @@ export const bridgeSchema = z.object({
 });
 
 export type Bridge = z.infer<typeof bridgeSchema>;
+
+export const activationStateSchema = z.object({
+  _id: z.instanceof(ObjectId),
+  userId: z.instanceof(ObjectId),
+  mobileSetupAt: z.date().nullable(),
+  bridgeSetupAt: z.date().nullable(),
+  firstSessionAt: z.date().nullable(),
+  bridgeReminderBaseAt: z.date().nullable(),
+  sessionReminderBaseAt: z.date().nullable(),
+  bridgeReminder1SentAt: z.date().nullable(),
+  bridgeReminder2SentAt: z.date().nullable(),
+  sessionReminderSentAt: z.date().nullable(),
+  backfilledAt: z.date().nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type ActivationState = z.infer<typeof activationStateSchema>;

--- a/src/repositories/activation-state-repo.ts
+++ b/src/repositories/activation-state-repo.ts
@@ -1,0 +1,47 @@
+import { Collection, ObjectId } from "mongodb";
+import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import { InternalServerError } from "../lib/errors.js";
+import type { ActivationState } from "../models/documents.js";
+import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
+
+export class ActivationStateRepository {
+  readonly #collection: Collection<ActivationState>;
+
+  constructor(accessor: MongoDbAccessor) {
+    this.#collection = accessor.getCollection<ActivationState>(MongoDbDatabase.Auth, AuthDbCollection.ActivationStates);
+  }
+
+  async findByUserId(userId: string): Promise<ActivationState | null> {
+    return this.#collection.findOne({ userId: new ObjectId(userId) });
+  }
+
+  async createIfAbsent(userId: string, at = new Date()): Promise<ActivationState> {
+    const objectUserId = new ObjectId(userId);
+    const state = await this.#collection.findOneAndUpdate(
+      { userId: objectUserId },
+      {
+        $setOnInsert: {
+          _id: new ObjectId(),
+          userId: objectUserId,
+          mobileSetupAt: null,
+          bridgeSetupAt: null,
+          firstSessionAt: null,
+          bridgeReminderBaseAt: null,
+          sessionReminderBaseAt: null,
+          bridgeReminder1SentAt: null,
+          bridgeReminder2SentAt: null,
+          sessionReminderSentAt: null,
+          backfilledAt: null,
+          createdAt: at,
+          updatedAt: at,
+        },
+      },
+      { upsert: true, returnDocument: "after" },
+    );
+
+    if (!state) {
+      throw new InternalServerError({ debugMessage: "Failed to create activation state" });
+    }
+    return state;
+  }
+}

--- a/src/repositories/activation-state-repo.ts
+++ b/src/repositories/activation-state-repo.ts
@@ -1,4 +1,4 @@
-import { Collection, ObjectId } from "mongodb";
+import { Collection, MongoServerError, ObjectId } from "mongodb";
 import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
 import { InternalServerError } from "../lib/errors.js";
 import type { ActivationState } from "../models/documents.js";
@@ -23,31 +23,41 @@ export class ActivationStateRepository {
       throw new InternalServerError({ debugMessage: "Invalid activation state userId" });
     }
     const objectUserId = new ObjectId(userId);
-    const state = await this.#collection.findOneAndUpdate(
-      { userId: objectUserId },
-      {
-        $setOnInsert: {
-          _id: new ObjectId(),
-          userId: objectUserId,
-          mobileSetupAt: null,
-          bridgeSetupAt: null,
-          firstSessionAt: null,
-          bridgeReminderBaseAt: null,
-          sessionReminderBaseAt: null,
-          bridgeReminder1SentAt: null,
-          bridgeReminder2SentAt: null,
-          sessionReminderSentAt: null,
-          backfilledAt: null,
-          createdAt: at,
-          updatedAt: at,
+    try {
+      const state = await this.#collection.findOneAndUpdate(
+        { userId: objectUserId },
+        {
+          $setOnInsert: {
+            _id: new ObjectId(),
+            userId: objectUserId,
+            mobileSetupAt: null,
+            bridgeSetupAt: null,
+            firstSessionAt: null,
+            bridgeReminderBaseAt: null,
+            sessionReminderBaseAt: null,
+            bridgeReminder1SentAt: null,
+            bridgeReminder2SentAt: null,
+            sessionReminderSentAt: null,
+            backfilledAt: null,
+            createdAt: at,
+            updatedAt: at,
+          },
         },
-      },
-      { upsert: true, returnDocument: "after" },
-    );
+        { upsert: true, returnDocument: "after" },
+      );
 
-    if (!state) {
-      throw new InternalServerError({ debugMessage: "Failed to create activation state" });
+      if (!state) {
+        throw new InternalServerError({ debugMessage: "Failed to create activation state" });
+      }
+      return state;
+    } catch (error) {
+      if (error instanceof MongoServerError && error.code === 11000) {
+        const winner = await this.#collection.findOne({ userId: objectUserId });
+        if (winner) {
+          return winner;
+        }
+      }
+      throw error;
     }
-    return state;
   }
 }

--- a/src/repositories/activation-state-repo.ts
+++ b/src/repositories/activation-state-repo.ts
@@ -12,10 +12,16 @@ export class ActivationStateRepository {
   }
 
   async findByUserId(userId: string): Promise<ActivationState | null> {
+    if (!ObjectId.isValid(userId)) {
+      return null;
+    }
     return this.#collection.findOne({ userId: new ObjectId(userId) });
   }
 
   async createIfAbsent(userId: string, at = new Date()): Promise<ActivationState> {
+    if (!ObjectId.isValid(userId)) {
+      throw new InternalServerError({ debugMessage: "Invalid activation state userId" });
+    }
     const objectUserId = new ObjectId(userId);
     const state = await this.#collection.findOneAndUpdate(
       { userId: objectUserId },

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { createAuthMiddleware } from "./middleware/auth.js";
 import { createRelayAuthMiddleware } from "./middleware/relay-auth.js";
 import type { HealthReply } from "./models/api.js";
 import type { DeviceTokenRepository } from "./repositories/device-token-repo.js";
+import type { ActivationStateRepository } from "./repositories/activation-state-repo.js";
 import type { AuthService } from "./services/auth-service.js";
 import type { BridgeService } from "./services/bridge-service.js";
 import type { BridgeStateTracker } from "./services/bridge-state-tracker.js";
@@ -46,6 +47,7 @@ export type AppServices = {
   deviceTokenRepo: DeviceTokenRepository;
   notificationService: NotificationService;
   bridgeStateTracker: BridgeStateTracker;
+  activationStateRepo: ActivationStateRepository;
   stateStore: StateStore;
   githubClient: OAuthClient;
   googleClient: OAuthClient;

--- a/src/types/mongo.ts
+++ b/src/types/mongo.ts
@@ -10,4 +10,5 @@ export enum AuthDbCollection {
   DailyUsage = "dailyUsage",
   DeviceTokens = "deviceTokens",
   Bridges = "bridges",
+  ActivationStates = "activationStates",
 }

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -21,6 +21,7 @@ import { GlossaryEntryRepository } from "../../src/repositories/glossary-entry-r
 import { OAuthAccountRepository } from "../../src/repositories/oauth-account-repo.js";
 import { PasswordAccountRepository } from "../../src/repositories/password-account-repo.js";
 import { UserRepository } from "../../src/repositories/user-repo.js";
+import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
 import { buildApp } from "../../src/server.js";
 import { AuthService } from "../../src/services/auth-service.js";
 import { BridgeService } from "../../src/services/bridge-service.js";
@@ -144,6 +145,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
   const dailyUsageRepo = new DailyUsageRepository(dbAccessor);
   const deviceTokenRepo = new DeviceTokenRepository(dbAccessor);
   const bridgeRepo = new BridgeRepository(dbAccessor);
+  const activationStateRepo = new ActivationStateRepository(dbAccessor);
 
   const tokenService = new TokenService(privPem, pubPem);
   const stateStore = new StateStore();
@@ -189,6 +191,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
     deviceTokenRepo,
     notificationService,
     bridgeStateTracker,
+    activationStateRepo,
     stateStore,
     githubClient,
     googleClient,

--- a/tests/repositories/activation-state-repo.test.ts
+++ b/tests/repositories/activation-state-repo.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
+import { Collection, MongoServerError } from "mongodb";
 import { InternalServerError } from "../../src/lib/errors.js";
 import { activationStateSchema, type ActivationState } from "../../src/models/documents.js";
 import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
@@ -51,6 +52,18 @@ describe("ActivationStateRepository", () => {
     assert.equal(second._id.toHexString(), first._id.toHexString());
     assert.equal(second.createdAt.toISOString(), firstAt.toISOString());
     assert.equal(second.updatedAt.toISOString(), firstAt.toISOString());
+  });
+
+  it("returns the winner after losing a concurrent creation race", async (t) => {
+    const user = await ctx.createUser();
+    const winner = await repo.createIfAbsent(user.userId);
+    t.mock.method(Collection.prototype, "findOneAndUpdate", async () => {
+      throw new MongoServerError({ message: "duplicate key", code: 11000 });
+    });
+
+    const state = await repo.createIfAbsent(user.userId);
+
+    assert.equal(state._id.toHexString(), winner._id.toHexString());
   });
 
   it("rejects creation with an invalid user id", async () => {

--- a/tests/repositories/activation-state-repo.test.ts
+++ b/tests/repositories/activation-state-repo.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { activationStateSchema, type ActivationState } from "../../src/models/documents.js";
+import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
+import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+describe("ActivationStateRepository", () => {
+  let ctx: TestContext;
+  let repo: ActivationStateRepository;
+
+  before(async () => {
+    ctx = await createTestApp();
+    repo = new ActivationStateRepository(ctx.dbAccessor);
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("creates a complete dormant state for a user", async () => {
+    const user = await ctx.createUser();
+    const createdAt = new Date("2026-07-12T10:00:00.000Z");
+
+    const state = await repo.createIfAbsent(user.userId, createdAt);
+
+    assert.equal(state.userId.toHexString(), user.userId);
+    assert.equal(state.createdAt.toISOString(), createdAt.toISOString());
+    assert.equal(state.updatedAt.toISOString(), createdAt.toISOString());
+    assert.equal(state.mobileSetupAt, null);
+    assert.equal(state.bridgeSetupAt, null);
+    assert.equal(state.firstSessionAt, null);
+    assert.equal(state.bridgeReminderBaseAt, null);
+    assert.equal(state.sessionReminderBaseAt, null);
+    assert.equal(state.bridgeReminder1SentAt, null);
+    assert.equal(state.bridgeReminder2SentAt, null);
+    assert.equal(state.sessionReminderSentAt, null);
+    assert.equal(state.backfilledAt, null);
+    assert.equal(activationStateSchema.safeParse(state).success, true);
+  });
+
+  it("returns the existing state without resetting it", async () => {
+    const user = await ctx.createUser();
+    const firstAt = new Date("2026-07-12T10:00:00.000Z");
+    const secondAt = new Date("2026-07-13T10:00:00.000Z");
+
+    const first = await repo.createIfAbsent(user.userId, firstAt);
+    const second = await repo.createIfAbsent(user.userId, secondAt);
+
+    assert.equal(second._id.toHexString(), first._id.toHexString());
+    assert.equal(second.createdAt.toISOString(), firstAt.toISOString());
+    assert.equal(second.updatedAt.toISOString(), firstAt.toISOString());
+  });
+
+  it("finds by user id and returns null for a missing state", async () => {
+    const user = await ctx.createUser();
+    const missingUser = await ctx.createUser();
+    const created = await repo.createIfAbsent(user.userId);
+
+    const found = await repo.findByUserId(user.userId);
+    const missing = await repo.findByUserId(missingUser.userId);
+
+    assert.equal(found?._id.toHexString(), created._id.toHexString());
+    assert.equal(missing, null);
+  });
+
+  it("creates the indexes needed by future reminder sweeps", async () => {
+    const collection = ctx.dbAccessor.getCollection<ActivationState>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.ActivationStates,
+    );
+    const indexes = await collection.indexes();
+    const indexByName = new Map(indexes.map((index) => [index.name, index]));
+
+    assert.equal(indexByName.get("userId_1")?.unique, true);
+    assert.deepEqual(indexByName.get("userId_1")?.key, { userId: 1 });
+    assert.deepEqual(indexByName.get("bridgeSetupAt_1_bridgeReminder1SentAt_1_bridgeReminderBaseAt_1")?.key, {
+      bridgeSetupAt: 1,
+      bridgeReminder1SentAt: 1,
+      bridgeReminderBaseAt: 1,
+    });
+    assert.deepEqual(indexByName.get("bridgeSetupAt_1_bridgeReminder2SentAt_1_bridgeReminderBaseAt_1")?.key, {
+      bridgeSetupAt: 1,
+      bridgeReminder2SentAt: 1,
+      bridgeReminderBaseAt: 1,
+    });
+    assert.deepEqual(indexByName.get("firstSessionAt_1_sessionReminderSentAt_1_sessionReminderBaseAt_1")?.key, {
+      firstSessionAt: 1,
+      sessionReminderSentAt: 1,
+      sessionReminderBaseAt: 1,
+    });
+  });
+});

--- a/tests/repositories/activation-state-repo.test.ts
+++ b/tests/repositories/activation-state-repo.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
+import { InternalServerError } from "../../src/lib/errors.js";
 import { activationStateSchema, type ActivationState } from "../../src/models/documents.js";
 import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
 import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
@@ -52,6 +53,14 @@ describe("ActivationStateRepository", () => {
     assert.equal(second.updatedAt.toISOString(), firstAt.toISOString());
   });
 
+  it("rejects creation with an invalid user id", async () => {
+    await assert.rejects(
+      () => repo.createIfAbsent("invalid-id"),
+      (error: unknown) =>
+        error instanceof InternalServerError && error.debugMessage === "Invalid activation state userId",
+    );
+  });
+
   it("finds by user id and returns null for a missing state", async () => {
     const user = await ctx.createUser();
     const missingUser = await ctx.createUser();
@@ -62,6 +71,10 @@ describe("ActivationStateRepository", () => {
 
     assert.equal(found?._id.toHexString(), created._id.toHexString());
     assert.equal(missing, null);
+  });
+
+  it("returns null when finding with an invalid user id", async () => {
+    assert.equal(await repo.findByUserId("invalid-id"), null);
   });
 
   it("creates the indexes needed by future reminder sweeps", async () => {


### PR DESCRIPTION
## Summary
- add a resumable four-PR activation-reminder plan and design considerations
- add the `activationStates` MongoDB document schema, unique user index, and future reminder-query indexes
- add a dormant idempotent repository and composition/test wiring
- cover state creation, lookup, idempotency, schema validity, and indexes

## Production behavior
- creates the new collection and indexes at startup
- does not record milestones, schedule work, change routes, or send notifications
- leaves all existing endpoint behavior unchanged

## Test plan
- `npm test` (331 passed, 1 skipped, 0 failed)
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run circular-dependencies`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dormant activation-state data layer and docs for the activation reminder subsystem. Creates the collection, schema, repository, indexes, and wiring with no behavior changes.

- **New Features**
  - Added `activationStates` collection with a unique `userId` index and three compound reminder-query indexes.
  - Introduced `activationStateSchema` and `ActivationState` type.
  - Added `ActivationStateRepository` with `createIfAbsent` and `findByUserId`; includes ObjectId validation and duplicate-key race handling.
  - Wired the repository into app and test composition; added `.plans/activation-reminders/{PLAN.md,CONSIDERATIONS.md}` and updated `AGENTS.md`.
  - Added focused tests covering schema, idempotency, indexes, invalid-id handling, and concurrent creation.

- **Migration**
  - No manual steps. The collection and indexes are created automatically on startup.

<sup>Written for commit bddc608461a57a58eb04da423936267de068a761. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

