### PR TITLE
feat(activation): record activation milestones

### DIFF
--- a/.plans/activation-reminders/CONSIDERATIONS.md
+++ b/.plans/activation-reminders/CONSIDERATIONS.md
@@ -32,7 +32,7 @@ Historical reconciliation should include revoked bridges. A revoked bridge still
 
 ### First Session
 
-The selected signal is the first successful request to `/sessions/generate-metadata`. It is specific to creating a new session with a non-empty text prompt, unlike sending a message in an existing session.
+The selected signal is the first valid authenticated request to `/sessions/generate-metadata`. The bridge treats metadata errors as non-fatal and continues session creation with no generated metadata, so a successful HTTP response is not required. Historical `metadataRequestCount` is therefore useful evidence of this signal, although a narrow crash window remains between the metadata call and local session creation.
 
 Known limitation: command-only session creation may not call metadata generation. Such a user can receive a session reminder despite having created a command-only session. The agreed copy asks them to create a new session and remains directionally correct. A dedicated bridge-to-auth session-created event is deferred.
 
@@ -54,12 +54,13 @@ Separate bridge indexes are intentional because bridge reminder 1 and bridge rem
 
 ## Delivery Guarantees
 
-The intended user-level behavior is one attempt per reminder kind. PR3 should use:
+The intended user-level behavior is one recorded completion per reminder kind. Unresolved sends remain eligible for retry, subject to the documented post-FCM/pre-MongoDB crash window. PR3 should use:
 
 - A single-process, single-flight sweep.
 - Conditional sent-marker updates.
 - Completion checks before sending.
-- A sent marker after `NotificationService.sendToUser` resolves, even when zero devices were notified.
+- A sent marker after `NotificationService.sendToUser` resolves while FCM is available, even when zero devices were notified because no registered tokens remain.
+- An explicit unavailable outcome (or a disabled sweep) when Firebase initialization failed, leaving the reminder retryable.
 - Retry when the send call throws before resolving.
 
 Strict exactly-once push delivery is impossible with the current FCM API and MongoDB in separate systems. A process can crash after FCM accepts a push but before MongoDB records `sentAt`, causing a retry after restart. Marking before send would instead create a crash window that permanently loses reminders. The plan prefers the small duplicate-delivery risk over silent loss. Do not claim strict exactly-once delivery in implementation or documentation.
@@ -83,7 +84,7 @@ Activation is secondary telemetry/engagement behavior. Existing endpoint success
 - Applying writes requires an explicit operator flag.
 - The script is idempotent and does not overwrite existing non-null milestones or sent markers.
 - Deterministic jitter avoids changing baselines on repeated runs.
-- Fully activated users never receive activation reminders.
+- Backfill does not intentionally target fully activated users; a narrow send/completion race may still produce a stale reminder.
 - Users without device tokens are not made reminder-eligible.
 - Operational counts are reviewed before applying.
 

--- a/.plans/activation-reminders/CONSIDERATIONS.md
+++ b/.plans/activation-reminders/CONSIDERATIONS.md
@@ -22,7 +22,7 @@ MongoDB TTL indexes are not a scheduler: they delete documents eventually but do
 
 ### Mobile Setup
 
-The first device-token registration is used rather than user creation because it means the app is installed, authenticated, has notification permission, and can actually receive a reminder. Users without a device token may still be represented during active backfill for funnel completeness, but are not reminder-eligible.
+The first device-token registration is used rather than user creation because it means the app is installed, authenticated, has notification permission, and can actually receive a reminder. Users without a device token may still be represented during active backfill for funnel completeness, but are not reminder-eligible. When the same FCM token moves between accounts, its token-document `createdAt` resets for the new owner so one user's setup timestamp is not imported into another user's activation history.
 
 ### Bridge Setup
 
@@ -33,6 +33,8 @@ Historical reconciliation should include revoked bridges. A revoked bridge still
 ### First Session
 
 The selected signal is the first valid authenticated request to `/sessions/generate-metadata`. The bridge treats metadata errors as non-fatal and continues session creation with no generated metadata, so a successful HTTP response is not required. Historical `metadataRequestCount` is therefore useful evidence of this signal, although a narrow crash window remains between the metadata call and local session creation.
+
+Historical daily-usage documents do not store the exact first metadata-request time. Reconciliation uses the earliest qualifying document's `createdAt` as the best available timestamp; it may predate the metadata request within that UTC day when transcription created the document first.
 
 Known limitation: command-only session creation may not call metadata generation. Such a user can receive a session reminder despite having created a command-only session. The agreed copy asks them to create a new session and remains directionally correct. A dedicated bridge-to-auth session-created event is deferred.
 
@@ -45,6 +47,10 @@ Real milestone timestamps and reminder baselines serve different purposes and mu
 - Organic bridge reminders use the mobile setup timestamp.
 - Organic session reminders use the later of mobile and bridge setup.
 - Backfilled incomplete users preserve old real timestamps but use a new, jittered baseline for a controlled re-engagement wave.
+
+## Account Revocation
+
+Logout and account revoke remove device tokens, and account revoke also revokes bridges, but neither clears `activationStates`. Milestones represent lifetime first completion for this user, so re-authentication does not restart first-time onboarding. A future re-engagement campaign must use separate campaign baselines and sent markers rather than erasing activation history.
 
 ## Index Design
 

--- a/.plans/activation-reminders/CONSIDERATIONS.md
+++ b/.plans/activation-reminders/CONSIDERATIONS.md
@@ -1,0 +1,99 @@
+# Activation Reminders - Considerations
+
+## Existing Capabilities
+
+- Push delivery already exists through Firebase Admin in `NotificationService`.
+- Device tokens are stored in MongoDB and registered by the Flutter app.
+- The auth server already receives all three selected milestones.
+- The Flutter app already renders `system_update` notifications.
+- No durable job queue, cron framework, or Redis deployment exists.
+
+## Why Activation State Instead Of A Generic Job Queue
+
+Every reminder is conditional: send at a rough time only if a later milestone is still missing. Persisting the funnel state and deriving due reminders from it avoids stale queued jobs, makes cancellation implicit, and creates the desired analytics dataset. A generic queue would add a second source of truth without solving a current broader requirement.
+
+## Why Poll MongoDB
+
+Reminder timing is measured in hours and does not need exact execution. A roughly 15-minute query interval is acceptable and inexpensive. MongoDB persists eligibility across restarts, while the in-process interval only triggers a stateless sweep. This avoids introducing Redis or another operational dependency.
+
+MongoDB TTL indexes are not a scheduler: they delete documents eventually but do not execute application code, so they are not suitable here.
+
+## Milestone Semantics
+
+### Mobile Setup
+
+The first device-token registration is used rather than user creation because it means the app is installed, authenticated, has notification permission, and can actually receive a reminder. Users without a device token may still be represented during active backfill for funnel completeness, but are not reminder-eligible.
+
+### Bridge Setup
+
+The first bridge registration is used rather than relay connectivity. Registration directly represents installation and first launch, is already handled by the auth server, and avoids coupling activation to relay webhook delivery.
+
+Historical reconciliation should include revoked bridges. A revoked bridge still proves that the user completed this setup stage in the past and must not receive first-time bridge-install copy.
+
+### First Session
+
+The selected signal is the first successful request to `/sessions/generate-metadata`. It is specific to creating a new session with a non-empty text prompt, unlike sending a message in an existing session.
+
+Known limitation: command-only session creation may not call metadata generation. Such a user can receive a session reminder despite having created a command-only session. The agreed copy asks them to create a new session and remains directionally correct. A dedicated bridge-to-auth session-created event is deferred.
+
+## Timestamp Semantics
+
+Real milestone timestamps and reminder baselines serve different purposes and must not be conflated.
+
+- Real timestamps support funnel analytics and historical reconciliation.
+- Reminder baselines control when the current campaign begins.
+- Organic bridge reminders use the mobile setup timestamp.
+- Organic session reminders use the later of mobile and bridge setup.
+- Backfilled incomplete users preserve old real timestamps but use a new, jittered baseline for a controlled re-engagement wave.
+
+## Index Design
+
+Each future due query uses equality conditions for stage completion and sent state followed by a range condition on the reminder baseline. Compound indexes therefore place the completion and sent fields before the baseline field.
+
+Separate bridge indexes are intentional because bridge reminder 1 and bridge reminder 2 have independent sent markers. This avoids relying on a broad scan of all bridge-incomplete users.
+
+## Delivery Guarantees
+
+The intended user-level behavior is one attempt per reminder kind. PR3 should use:
+
+- A single-process, single-flight sweep.
+- Conditional sent-marker updates.
+- Completion checks before sending.
+- A sent marker after `NotificationService.sendToUser` resolves, even when zero devices were notified.
+- Retry when the send call throws before resolving.
+
+Strict exactly-once push delivery is impossible with the current FCM API and MongoDB in separate systems. A process can crash after FCM accepts a push but before MongoDB records `sentAt`, causing a retry after restart. Marking before send would instead create a crash window that permanently loses reminders. The plan prefers the small duplicate-delivery risk over silent loss. Do not claim strict exactly-once delivery in implementation or documentation.
+
+## Stage Races
+
+A user can complete a milestone while the sweep is sending. PR3 should minimize stale reminders by rechecking eligibility through a conditional reservation or update pattern immediately before delivery. Because there is no atomic transaction spanning FCM, an extremely narrow race remains possible after the last database check. This is acceptable for a maximum of three onboarding reminders and should be documented in tests/comments without over-engineering a distributed transaction.
+
+## Failure Isolation
+
+Activation is secondary telemetry/engagement behavior. Existing endpoint success must not depend on it.
+
+- Device-token registration must succeed if activation persistence fails.
+- Bridge registration must succeed if activation persistence fails.
+- Metadata generation must preserve its current response if activation persistence fails.
+- Failures should be structured and observable, not silently ignored.
+
+## Backfill Safety
+
+- Dry-run is the default.
+- Applying writes requires an explicit operator flag.
+- The script is idempotent and does not overwrite existing non-null milestones or sent markers.
+- Deterministic jitter avoids changing baselines on repeated runs.
+- Fully activated users never receive activation reminders.
+- Users without device tokens are not made reminder-eligible.
+- Operational counts are reviewed before applying.
+
+## Production Compatibility
+
+Each slice must be safe to merge and deploy independently:
+
+- PR1 only creates an unused collection and indexes.
+- PR2 only records state and isolates failures.
+- PR3 defaults sending off.
+- PR4 is inert until an operator runs it with apply enabled.
+
+No plaintext environment files or credentials are introduced. Configuration changes in PR3 follow the existing Zod/env conventions and encrypted environment workflow.

--- a/.plans/activation-reminders/PLAN.md
+++ b/.plans/activation-reminders/PLAN.md
@@ -1,0 +1,256 @@
+# Activation Reminders
+
+## Purpose
+
+Improve user activation by measuring and nudging users through this funnel:
+
+1. Mobile setup: the user registers a push-notification device token.
+2. Bridge setup: the user registers the desktop bridge.
+3. Full activation: the user creates a new session, represented by the first successful call to `POST /sessions/generate-metadata`.
+
+This file is the authoritative implementation tracker. A future session should read this file and `.plans/activation-reminders/CONSIDERATIONS.md` before changing code.
+
+## Current State
+
+- Branch: `activation-rate-plan`
+- Implementation checkpoint: PR1 complete; PR2 not started
+- PR1 post-merge status: merged
+- Live GitHub delivery state: do not infer it from this static file; verify with `gh pr list --head activation-rate-plan --state all`
+- Last updated: 2026-07-12
+- If PR1 is still open: review and merge PR1; do not start PR2 on top of an unmerged slice
+- If PR1 is merged: begin PR2 by reviewing the PR1 repository API and adding the activation service/reconciliation methods described below
+
+## Resume Instructions
+
+1. Read this entire file and `CONSIDERATIONS.md`.
+2. Run `git status --short` and inspect existing changes; do not undo unrelated work.
+3. Verify live PR state with GitHub; the table records implementation and intended post-merge state, not live delivery state.
+4. If an earlier slice is implemented but not merged, finish that delivery workflow before starting the next slice.
+5. Find the first PR whose implementation is not complete in the status table below.
+6. Work only on that PR's unchecked acceptance criteria unless the user explicitly expands scope.
+7. Run that PR's verification commands.
+8. Update implementation status, post-merge status, completed checkboxes, verification results, and continuation instructions.
+9. Do not start the next PR in the same session unless the user asks.
+
+## Product Decisions
+
+- V1 implementation is auth-server-only. Full-stack changes remain permissible later, but no Flutter, bridge, or relay changes are needed for V1.
+- Existing FCM infrastructure and the `system_update` notification category are reused.
+- Notification taps rely on the app's default open behavior; V1 adds no activation-specific deep link.
+- Mobile setup is the first device-token registration, not account creation.
+- Bridge setup is the first bridge registration, not the first relay connection.
+- First session is the first `POST /sessions/generate-metadata` call. This deliberately measures creation of a new text-backed session, not messages in existing sessions.
+- Bridge reminder 1 is due approximately 2 hours after mobile setup.
+- Bridge reminder 2 is due approximately 24 hours after mobile setup.
+- The single session reminder is due approximately 24 hours after both mobile and bridge setup. Its organic baseline is `max(mobileSetupAt, bridgeSetupAt)`.
+- A roughly 15-minute sweep is sufficient; reminder timing is intentionally approximate.
+- No quiet-hours handling in V1.
+- Existing users are actively backfilled. Incomplete users enter a controlled re-engagement sequence measured from backfill time with deterministic jitter.
+- V1 reporting consists of structured logs and direct MongoDB queries; no metrics endpoint or dashboard.
+
+## Notification Copy
+
+All reminders use category `system_update`.
+
+| Reminder      | Title                           | Body                                                                                         |
+| ------------- | ------------------------------- | -------------------------------------------------------------------------------------------- |
+| Bridge 1      | Finish setting up Sesori        | Install the Sesori bridge on your computer to start using Sesori from your phone.            |
+| Bridge 2      | Your Sesori setup is unfinished | You haven't connected your computer yet. Install the Sesori bridge to unlock Sesori.         |
+| First session | Start your first session        | You're all set up! You haven't started a new session yet - create one to put Sesori to work. |
+
+## Target Data Model
+
+Collection: `activationStates`. One document per user.
+
+```text
+_id: ObjectId
+userId: ObjectId (unique)
+
+mobileSetupAt: Date | null
+bridgeSetupAt: Date | null
+firstSessionAt: Date | null
+
+bridgeReminderBaseAt: Date | null
+sessionReminderBaseAt: Date | null
+
+bridgeReminder1SentAt: Date | null
+bridgeReminder2SentAt: Date | null
+sessionReminderSentAt: Date | null
+
+backfilledAt: Date | null
+createdAt: Date
+updatedAt: Date
+```
+
+Field invariants:
+
+- `bridgeReminderBaseAt` is set only after mobile setup is known.
+- `sessionReminderBaseAt` is set only after both mobile and bridge setup are known.
+- Milestone timestamps record the best known real event time and are set once.
+- Backfill timestamps remain separate from reminder baselines so analytics are not rewritten to make scheduling convenient.
+- Sent timestamps are independent so each reminder can be measured and suppressed separately.
+
+Planned indexes:
+
+- `{ userId: 1 }`, unique.
+- `{ bridgeSetupAt: 1, bridgeReminder1SentAt: 1, bridgeReminderBaseAt: 1 }`.
+- `{ bridgeSetupAt: 1, bridgeReminder2SentAt: 1, bridgeReminderBaseAt: 1 }`.
+- `{ firstSessionAt: 1, sessionReminderSentAt: 1, sessionReminderBaseAt: 1 }`.
+
+The equality fields precede each due-time range field so the future sweep queries can use the indexes directly.
+
+## Delivery Architecture
+
+- MongoDB is the durable source of truth.
+- An in-process single-flight sweep queries due activation records about every 15 minutes.
+- A process restart loses only the current polling interval, not reminder eligibility.
+- Sending is gated by `ACTIVATION_REMINDERS_ENABLED`, defaulting to false.
+- Milestone recording remains active independently of the sending flag.
+- Activation tracking failures are logged and isolated from the user-facing endpoint that produced the milestone.
+- Reminder attempts are marked after `NotificationService.sendToUser` resolves, including a result with zero notified devices. A thrown send error remains retryable.
+- See `CONSIDERATIONS.md` for the narrow crash window in which strict exactly-once delivery cannot be guaranteed.
+
+## Configuration Target
+
+| Variable                                | Default    | Purpose                                                    |
+| --------------------------------------- | ---------- | ---------------------------------------------------------- |
+| `ACTIVATION_REMINDERS_ENABLED`          | `false`    | Master switch for the reminder sweep.                      |
+| `ACTIVATION_SWEEP_INTERVAL_MS`          | `900000`   | Approximate 15-minute sweep interval.                      |
+| `ACTIVATION_BRIDGE_REMINDER_1_DELAY_MS` | `7200000`  | Two-hour first bridge delay.                               |
+| `ACTIVATION_BRIDGE_REMINDER_2_DELAY_MS` | `86400000` | Twenty-four-hour second bridge delay.                      |
+| `ACTIVATION_SESSION_REMINDER_DELAY_MS`  | `86400000` | Twenty-four-hour session delay after both setups.          |
+| `ACTIVATION_SWEEP_BATCH_LIMIT`          | `500`      | Maximum records processed for one reminder kind per sweep. |
+
+## PR Status
+
+| PR  | Scope                                                                                         | Implementation | Post-merge status | Production behavior                       |
+| --- | --------------------------------------------------------------------------------------------- | -------------- | ----------------- | ----------------------------------------- |
+| PR1 | Plans, collection, indexes, schema, repository, composition wiring, repository tests          | complete       | merged            | Dormant; creates collection/indexes only. |
+| PR2 | Milestone capture, enrollment reconciliation, endpoint hooks, failure isolation               | not started    | pending           | Records state only; sends nothing.        |
+| PR3 | Config, reminder queries/service, FCM sends, 15-minute scheduler, structured logs             | not started    | pending           | Sending remains off by default.           |
+| PR4 | Idempotent dry-run-capable active backfill with controlled re-engagement baselines and jitter | not started    | pending           | No effect until manually executed.        |
+
+## PR1 - Dormant Data Layer
+
+Implementation: complete
+
+Post-merge status: merged
+
+Acceptance criteria:
+
+- [x] Add this resumable plan and considerations document.
+- [x] Add `ActivationStates` to `AuthDbCollection`.
+- [x] Add the four planned indexes to `DATABASE_CONFIG`.
+- [x] Add the complete Zod document schema and inferred type.
+- [x] Add `ActivationStateRepository` with dormant persistence primitives needed by later slices.
+- [x] Instantiate and pass the repository through composition without adding behavior.
+- [x] Add focused repository/index tests.
+- [x] `npm run build` passes.
+- [x] `npm run lint` passes without new warnings.
+- [x] `npm run format:check` passes.
+- [x] Focused PR1 tests pass.
+- [x] Full test suite passes, or any environment blocker is recorded below.
+
+PR1 non-goals:
+
+- No route or service hook records activation yet.
+- No reminder query or scheduler exists yet.
+- No configuration variables are added yet.
+- No push is sent.
+- No backfill script is added.
+
+PR1 verification results:
+
+- `node --import tsx --test --test-concurrency=1 "tests/repositories/activation-state-repo.test.ts"`: passed, 4 tests.
+- `npm run build`: passed.
+- `npm run lint`: passed with no warnings.
+- `npm run format:check`: passed.
+- `npm test`: passed, 331 tests passed, 1 skipped, 0 failed across 37 top-level suites.
+- `npm run circular-dependencies`: passed; no circular dependencies found.
+- `git diff --check`: passed.
+
+## PR2 - Milestone Capture
+
+Status: pending
+
+Planned work:
+
+- Add an `ActivationService` that owns cross-collection reconciliation and milestone invariants.
+- On first device-token registration, enroll the user and reconcile pre-existing bridge/session state.
+- Reconcile bridge state from the earliest historical bridge, including revoked bridges, so a previously completed setup is not presented as new.
+- Reconcile session state from historical `dailyUsage.metadataRequestCount > 0` data, using the best available date.
+- Set `bridgeSetupAt` idempotently after bridge registration.
+- Set `firstSessionAt` idempotently after a successful metadata generation request.
+- Recompute `sessionReminderBaseAt` as the later setup time when both setup timestamps become available.
+- Catch and log activation errors at each endpoint boundary so activation tracking cannot break existing behavior.
+- Add route/service tests for ordering, retries, and failure isolation.
+
+PR2 exit condition:
+
+- Production can collect and query the funnel while sending remains impossible.
+
+## PR3 - Reminder Sweep And Sending
+
+Status: pending
+
+Planned work:
+
+- Add the activation configuration variables with sending disabled by default.
+- Add indexed repository queries for each due reminder.
+- Add conditional sent-marker writes so stale sweep results cannot mark an already-completed stage.
+- Add `ActivationReminderService` with single-flight sweep behavior and bounded batches.
+- Send the approved copy through existing `NotificationService` under category `system_update`.
+- Use distinct collapse keys per reminder kind.
+- Start the interval only when enabled and dispose it during graceful shutdown.
+- Emit structured milestone/reminder logs suitable for initial funnel analysis.
+- Test cutoffs, stage completion races, no-overlap behavior, send outcomes, and retry behavior.
+
+PR3 exit condition:
+
+- Code is deployable with no sends under default configuration; enabling the flag starts organic reminders.
+
+## PR4 - Existing-User Backfill
+
+Status: pending
+
+Planned work:
+
+- Add an idempotent operator-run script and package command.
+- Require dry-run by default and an explicit apply flag for writes.
+- Iterate existing users in bounded batches.
+- Set `mobileSetupAt` from the earliest extant device token; users without a token are recorded but are not reminder-eligible.
+- Set `bridgeSetupAt` from the earliest historical bridge registration.
+- Set `firstSessionAt` from historical metadata usage when available.
+- Preserve real milestone timestamps for analytics.
+- For currently incomplete, push-reachable users, set only the relevant reminder baseline to backfill time plus deterministic jitter.
+- Do not schedule bridge reminders for users who already have a bridge.
+- Do not schedule session reminders unless both mobile and bridge setup are known.
+- Report proposed/applied counts by activation stage and reminder sequence.
+- Test dry-run safety, idempotency, reconciliation, and controlled baseline assignment.
+
+PR4 exit condition:
+
+- Operators can preview and then launch a controlled existing-user re-engagement wave.
+
+## Rollout
+
+1. Merge/deploy PR1. Confirm collection and indexes exist; user behavior is unchanged.
+2. Merge/deploy PR2. Inspect activation records and establish baseline funnel conversion.
+3. Merge/deploy PR3 with `ACTIVATION_REMINDERS_ENABLED=false`. Confirm no sends.
+4. Enable organic reminders and monitor logs/error rate.
+5. Merge PR4, run dry-run, review counts, then apply at a suitable time for primary user regions.
+6. Compare conversion timestamps before/after reminder sends through MongoDB aggregation.
+
+## Deferred
+
+- Dedicated activation notification category and in-app preference.
+- Explicit activation deep links in the Flutter notification dispatcher.
+- Device-timezone capture and local quiet hours.
+- Internal metrics endpoint or dashboard.
+- Generic durable job infrastructure.
+- Multi-instance worker leasing. Current deployment is intentionally single-instance.
+
+## Change Log
+
+- 2026-07-12: Interview completed. Product behavior, scheduling, copy, backfill policy, reporting, and four-PR split agreed.
+- 2026-07-12: PR1 implementation completed. Added the resumable plan, activation-state collection/schema/indexes, dormant repository/composition wiring, and focused tests. All verification passed. This document records PR1's intended post-merge status as merged; live GitHub status must always be verified separately. PR2 is next and has not started.

--- a/.plans/activation-reminders/PLAN.md
+++ b/.plans/activation-reminders/PLAN.md
@@ -97,6 +97,7 @@ Planned indexes:
 - `{ bridgeSetupAt: 1, bridgeReminder1SentAt: 1, bridgeReminderBaseAt: 1 }`.
 - `{ bridgeSetupAt: 1, bridgeReminder2SentAt: 1, bridgeReminderBaseAt: 1 }`.
 - `{ firstSessionAt: 1, sessionReminderSentAt: 1, sessionReminderBaseAt: 1 }`.
+- Supporting historical mobile reconciliation: `deviceTokens { userId: 1, createdAt: 1 }`.
 - Supporting historical bridge reconciliation: `bridges { userId: 1, addedAt: 1 }`.
 
 The equality fields precede each due-time range field so the future sweep queries can use the indexes directly.
@@ -180,13 +181,16 @@ Intended post-merge status: merged
 Acceptance criteria:
 
 - [x] Add `ActivationService` to own reconciliation and milestone invariants.
-- [x] Add an atomic, set-once milestone update that derives reminder baselines correctly for either event order.
+- [x] Add an atomic milestone update that preserves first-event timestamps and derives reminder baselines correctly for either event order.
+- [x] Retain the earliest first-session candidate when concurrent initial writes reach MongoDB out of order.
 - [x] On device-token registration, enroll the user from the earliest extant token, reset transferred-token history for the new owner, and retry unresolved bridge/session reconciliation.
+- [x] Add `{ userId: 1, createdAt: 1 }` to support historical device-token lookup.
 - [x] Reconcile bridge state from the earliest historical bridge, including revoked bridges.
 - [x] Add `{ userId: 1, addedAt: 1 }` to support historical bridge lookup.
 - [x] Reconcile session state from historical `dailyUsage.metadataRequestCount > 0` data using the earliest qualifying document's `createdAt`.
 - [x] Set `bridgeSetupAt` idempotently after bridge registration, using the earliest historical `addedAt` across active and revoked bridges.
 - [x] Set `firstSessionAt` before metadata generation for a valid authenticated request, preferring earlier historical metadata evidence when present, because the bridge proceeds when metadata generation fails.
+- [x] Reconcile all still-missing historical milestones from each event hook so a later event repairs an earlier failure-isolated write.
 - [x] Derive `sessionReminderBaseAt` from the later of mobile and bridge setup.
 - [x] Catch and log activation errors at every endpoint boundary without changing the existing endpoint response.
 - [x] Document that logout/revoke retains lifetime activation history.
@@ -208,11 +212,11 @@ PR2 non-goals:
 
 PR2 verification results:
 
-- Focused activation/repository/route suite: passed, 99 tests.
+- Focused activation/repository/route suite: passed, 103 tests.
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm run format:check`: passed.
-- `npm test`: passed, 351 tests passed, 1 skipped, 0 failed across 39 top-level suites.
+- `npm test`: passed, 355 tests passed, 1 skipped, 0 failed across 39 top-level suites.
 - `npm run circular-dependencies`: passed; no circular dependencies found.
 - `git diff --check`: passed.
 
@@ -289,3 +293,4 @@ PR4 exit condition:
 - 2026-07-15: PR1 review feedback addressed. Clarified metadata-attempt semantics, retry and FCM-unavailable behavior, and backfill race guarantees; added defensive ObjectId validation and tests. All verification passed.
 - 2026-07-15: Human PR1 review feedback addressed. Documented timestamp and index invariants in source, clarified intended status labels, and made concurrent first-enrollment upserts recover from duplicate-key races. All verification passed.
 - 2026-07-15: PR1 merged as #38. PR2 implementation completed: atomic milestone recording, historical reconciliation, three failure-isolated endpoint hooks, lifetime revoke semantics, and comprehensive tests. Pre-delivery review also hardened transferred-token timestamps, direct bridge/session historical reconciliation, retry repair, and concurrent first writes. All verification passed. PR3 is next and has not started.
+- 2026-07-15: PR2 automated review feedback addressed. Added cross-stage repair from every event hook, earliest-wins concurrent session recording, defensive token user validation, and the compound token reconciliation index. Retained the documented metadata-attempt and historical timestamp semantics. All verification passed.

--- a/.plans/activation-reminders/PLAN.md
+++ b/.plans/activation-reminders/PLAN.md
@@ -14,9 +14,9 @@ This file is the authoritative implementation tracker. A future session should r
 
 - Branch: `activation-rate-plan`
 - Implementation checkpoint: PR1 complete; PR2 not started
-- PR1 post-merge status: merged
+- PR1 intended post-merge status: merged
 - Live GitHub delivery state: do not infer it from this static file; verify with `gh pr list --head activation-rate-plan --state all`
-- Last updated: 2026-07-12
+- Last updated: 2026-07-15
 - If PR1 is still open: review and merge PR1; do not start PR2 on top of an unmerged slice
 - If PR1 is merged: begin PR2 by reviewing the PR1 repository API and adding the activation service/reconciliation methods described below
 
@@ -29,7 +29,7 @@ This file is the authoritative implementation tracker. A future session should r
 5. Find the first PR whose implementation is not complete in the status table below.
 6. Work only on that PR's unchecked acceptance criteria unless the user explicitly expands scope.
 7. Run that PR's verification commands.
-8. Update implementation status, post-merge status, completed checkboxes, verification results, and continuation instructions.
+8. Update implementation status, intended post-merge status, completed checkboxes, verification results, and continuation instructions.
 9. Do not start the next PR in the same session unless the user asks.
 
 ## Product Decisions
@@ -123,18 +123,18 @@ The equality fields precede each due-time range field so the future sweep querie
 
 ## PR Status
 
-| PR  | Scope                                                                                         | Implementation | Post-merge status | Production behavior                       |
-| --- | --------------------------------------------------------------------------------------------- | -------------- | ----------------- | ----------------------------------------- |
-| PR1 | Plans, collection, indexes, schema, repository, composition wiring, repository tests          | complete       | merged            | Dormant; creates collection/indexes only. |
-| PR2 | Milestone capture, enrollment reconciliation, endpoint hooks, failure isolation               | not started    | pending           | Records state only; sends nothing.        |
-| PR3 | Config, reminder queries/service, FCM sends, 15-minute scheduler, structured logs             | not started    | pending           | Sending remains off by default.           |
-| PR4 | Idempotent dry-run-capable active backfill with controlled re-engagement baselines and jitter | not started    | pending           | No effect until manually executed.        |
+| PR  | Scope                                                                                         | Implementation | Intended post-merge status | Production behavior                       |
+| --- | --------------------------------------------------------------------------------------------- | -------------- | -------------------------- | ----------------------------------------- |
+| PR1 | Plans, collection, indexes, schema, repository, composition wiring, repository tests          | complete       | merged                     | Dormant; creates collection/indexes only. |
+| PR2 | Milestone capture, enrollment reconciliation, endpoint hooks, failure isolation               | not started    | pending                    | Records state only; sends nothing.        |
+| PR3 | Config, reminder queries/service, FCM sends, 15-minute scheduler, structured logs             | not started    | pending                    | Sending remains off by default.           |
+| PR4 | Idempotent dry-run-capable active backfill with controlled re-engagement baselines and jitter | not started    | pending                    | No effect until manually executed.        |
 
 ## PR1 - Dormant Data Layer
 
 Implementation: complete
 
-Post-merge status: merged
+Intended post-merge status: merged
 
 Acceptance criteria:
 
@@ -161,11 +161,11 @@ PR1 non-goals:
 
 PR1 verification results:
 
-- `node --import tsx --test --test-concurrency=1 "tests/repositories/activation-state-repo.test.ts"`: passed, 6 tests.
+- `node --import tsx --test --test-concurrency=1 "tests/repositories/activation-state-repo.test.ts"`: passed, 7 tests.
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm run format:check`: passed.
-- `npm test`: passed, 333 tests passed, 1 skipped, 0 failed across 37 top-level suites.
+- `npm test`: passed, 334 tests passed, 1 skipped, 0 failed across 37 top-level suites.
 - `npm run circular-dependencies`: passed; no circular dependencies found.
 - `git diff --check`: passed.
 
@@ -256,3 +256,4 @@ PR4 exit condition:
 - 2026-07-12: Interview completed. Product behavior, scheduling, copy, backfill policy, reporting, and four-PR split agreed.
 - 2026-07-12: PR1 implementation completed. Added the resumable plan, activation-state collection/schema/indexes, dormant repository/composition wiring, and focused tests. All verification passed. This document records PR1's intended post-merge status as merged; live GitHub status must always be verified separately. PR2 is next and has not started.
 - 2026-07-15: PR1 review feedback addressed. Clarified metadata-attempt semantics, retry and FCM-unavailable behavior, and backfill race guarantees; added defensive ObjectId validation and tests. All verification passed.
+- 2026-07-15: Human PR1 review feedback addressed. Documented timestamp and index invariants in source, clarified intended status labels, and made concurrent first-enrollment upserts recover from duplicate-key races. All verification passed.

--- a/.plans/activation-reminders/PLAN.md
+++ b/.plans/activation-reminders/PLAN.md
@@ -182,10 +182,10 @@ Acceptance criteria:
 
 - [x] Add `ActivationService` to own reconciliation and milestone invariants.
 - [x] Add an atomic milestone update that preserves first-event timestamps and derives reminder baselines correctly for either event order.
-- [x] Retain the earliest first-session candidate when concurrent initial writes reach MongoDB out of order.
+- [x] Retain the earliest first-session candidate when concurrent initial reads/writes reach MongoDB out of order.
 - [x] On device-token registration, enroll the user from the earliest extant token, reset transferred-token history for the new owner, and retry unresolved bridge/session reconciliation.
 - [x] Add `{ userId: 1, createdAt: 1 }` to support historical device-token lookup.
-- [x] Remove the superseded `{ userId: 1 }` token index after confirming its compound replacement exists.
+- [x] Remove the superseded `{ userId: 1 }` token index only after confirming the exact desired compound replacement exists.
 - [x] Validate token owner IDs with the typed internal error used at repository boundaries.
 - [x] Reconcile bridge state from the earliest historical bridge, including revoked bridges.
 - [x] Add `{ userId: 1, addedAt: 1 }` to support historical bridge lookup.
@@ -214,11 +214,11 @@ PR2 non-goals:
 
 PR2 verification results:
 
-- Focused activation/repository/route suite: passed, 104 tests.
+- Focused activation/repository/route suite: passed, 106 tests.
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm run format:check`: passed.
-- `npm test`: passed, 356 tests passed, 1 skipped, 0 failed across 39 top-level suites.
+- `npm test`: passed, 358 tests passed, 1 skipped, 0 failed across 39 top-level suites.
 - `npm run circular-dependencies`: passed; no circular dependencies found.
 - `git diff --check`: passed.
 
@@ -297,3 +297,4 @@ PR4 exit condition:
 - 2026-07-15: PR1 merged as #38. PR2 implementation completed: atomic milestone recording, historical reconciliation, three failure-isolated endpoint hooks, lifetime revoke semantics, and comprehensive tests. Pre-delivery review also hardened transferred-token timestamps, direct bridge/session historical reconciliation, retry repair, and concurrent first writes. All verification passed. PR3 is next and has not started.
 - 2026-07-15: PR2 automated review feedback addressed. Added cross-stage repair from every event hook, earliest-wins concurrent session recording, defensive token user validation, and the compound token reconciliation index. Retained the documented metadata-attempt and historical timestamp semantics. All verification passed.
 - 2026-07-15: PR2 second automated review addressed. Added safe cleanup for the superseded device-token index and changed invalid token owner handling to the typed repository-boundary error. Confirmed mobile/bridge concurrency already resolves from earliest durable source timestamps. All verification passed.
+- 2026-07-15: PR2 third automated review addressed. Required a full desired-index option match before cleanup and preserved earlier observed session timestamps when an initial read loses a race. All verification passed.

--- a/.plans/activation-reminders/PLAN.md
+++ b/.plans/activation-reminders/PLAN.md
@@ -13,12 +13,13 @@ This file is the authoritative implementation tracker. A future session should r
 ## Current State
 
 - Branch: `activation-rate-plan`
-- Implementation checkpoint: PR1 complete; PR2 not started
-- PR1 intended post-merge status: merged
+- Implementation checkpoint: PR2 complete; PR3 not started
+- PR1 delivery status: merged as PR #38
+- PR2 intended post-merge status: merged
 - Live GitHub delivery state: do not infer it from this static file; verify with `gh pr list --head activation-rate-plan --state all`
 - Last updated: 2026-07-15
-- If PR1 is still open: review and merge PR1; do not start PR2 on top of an unmerged slice
-- If PR1 is merged: begin PR2 by reviewing the PR1 repository API and adding the activation service/reconciliation methods described below
+- If PR2 is still open: review and merge PR2; do not start PR3 on top of an unmerged slice
+- If PR2 is merged: begin PR3 with the gated reminder sweep and sending behavior described below
 
 ## Resume Instructions
 
@@ -96,6 +97,7 @@ Planned indexes:
 - `{ bridgeSetupAt: 1, bridgeReminder1SentAt: 1, bridgeReminderBaseAt: 1 }`.
 - `{ bridgeSetupAt: 1, bridgeReminder2SentAt: 1, bridgeReminderBaseAt: 1 }`.
 - `{ firstSessionAt: 1, sessionReminderSentAt: 1, sessionReminderBaseAt: 1 }`.
+- Supporting historical bridge reconciliation: `bridges { userId: 1, addedAt: 1 }`.
 
 The equality fields precede each due-time range field so the future sweep queries can use the indexes directly.
 
@@ -126,7 +128,7 @@ The equality fields precede each due-time range field so the future sweep querie
 | PR  | Scope                                                                                         | Implementation | Intended post-merge status | Production behavior                       |
 | --- | --------------------------------------------------------------------------------------------- | -------------- | -------------------------- | ----------------------------------------- |
 | PR1 | Plans, collection, indexes, schema, repository, composition wiring, repository tests          | complete       | merged                     | Dormant; creates collection/indexes only. |
-| PR2 | Milestone capture, enrollment reconciliation, endpoint hooks, failure isolation               | not started    | pending                    | Records state only; sends nothing.        |
+| PR2 | Milestone capture, enrollment reconciliation, endpoint hooks, failure isolation               | complete       | merged                     | Records state only; sends nothing.        |
 | PR3 | Config, reminder queries/service, FCM sends, 15-minute scheduler, structured logs             | not started    | pending                    | Sending remains off by default.           |
 | PR4 | Idempotent dry-run-capable active backfill with controlled re-engagement baselines and jitter | not started    | pending                    | No effect until manually executed.        |
 
@@ -171,19 +173,48 @@ PR1 verification results:
 
 ## PR2 - Milestone Capture
 
-Status: pending
+Implementation: complete
 
-Planned work:
+Intended post-merge status: merged
 
-- Add an `ActivationService` that owns cross-collection reconciliation and milestone invariants.
-- On first device-token registration, enroll the user and reconcile pre-existing bridge/session state.
-- Reconcile bridge state from the earliest historical bridge, including revoked bridges, so a previously completed setup is not presented as new.
-- Reconcile session state from historical `dailyUsage.metadataRequestCount > 0` data, using the best available date.
-- Set `bridgeSetupAt` idempotently after bridge registration.
-- Set `firstSessionAt` idempotently when a valid authenticated metadata request is accepted, before metadata generation, because the bridge proceeds with session creation even when metadata generation fails.
-- Recompute `sessionReminderBaseAt` as the later setup time when both setup timestamps become available.
-- Catch and log activation errors at each endpoint boundary so activation tracking cannot break existing behavior.
-- Add route/service tests for ordering, retries, and failure isolation.
+Acceptance criteria:
+
+- [x] Add `ActivationService` to own reconciliation and milestone invariants.
+- [x] Add an atomic, set-once milestone update that derives reminder baselines correctly for either event order.
+- [x] On device-token registration, enroll the user from the earliest extant token, reset transferred-token history for the new owner, and retry unresolved bridge/session reconciliation.
+- [x] Reconcile bridge state from the earliest historical bridge, including revoked bridges.
+- [x] Add `{ userId: 1, addedAt: 1 }` to support historical bridge lookup.
+- [x] Reconcile session state from historical `dailyUsage.metadataRequestCount > 0` data using the earliest qualifying document's `createdAt`.
+- [x] Set `bridgeSetupAt` idempotently after bridge registration, using the earliest historical `addedAt` across active and revoked bridges.
+- [x] Set `firstSessionAt` before metadata generation for a valid authenticated request, preferring earlier historical metadata evidence when present, because the bridge proceeds when metadata generation fails.
+- [x] Derive `sessionReminderBaseAt` from the later of mobile and bridge setup.
+- [x] Catch and log activation errors at every endpoint boundary without changing the existing endpoint response.
+- [x] Document that logout/revoke retains lifetime activation history.
+- [x] Add repository, service, event-order, reconciliation, route, metadata-failure, and failure-isolation tests.
+- [x] `npm run build` passes.
+- [x] `npm run lint` passes without warnings.
+- [x] `npm run format:check` passes.
+- [x] Focused PR2 tests pass.
+- [x] Full test suite passes.
+- [x] `npm run circular-dependencies` passes.
+- [x] `git diff --check` passes.
+
+PR2 non-goals:
+
+- No reminder due-query or scheduler exists yet.
+- No activation configuration variables are added yet.
+- No activation push is sent.
+- No existing-user backfill command is added.
+
+PR2 verification results:
+
+- Focused activation/repository/route suite: passed, 99 tests.
+- `npm run build`: passed.
+- `npm run lint`: passed with no warnings.
+- `npm run format:check`: passed.
+- `npm test`: passed, 351 tests passed, 1 skipped, 0 failed across 39 top-level suites.
+- `npm run circular-dependencies`: passed; no circular dependencies found.
+- `git diff --check`: passed.
 
 PR2 exit condition:
 
@@ -257,3 +288,4 @@ PR4 exit condition:
 - 2026-07-12: PR1 implementation completed. Added the resumable plan, activation-state collection/schema/indexes, dormant repository/composition wiring, and focused tests. All verification passed. This document records PR1's intended post-merge status as merged; live GitHub status must always be verified separately. PR2 is next and has not started.
 - 2026-07-15: PR1 review feedback addressed. Clarified metadata-attempt semantics, retry and FCM-unavailable behavior, and backfill race guarantees; added defensive ObjectId validation and tests. All verification passed.
 - 2026-07-15: Human PR1 review feedback addressed. Documented timestamp and index invariants in source, clarified intended status labels, and made concurrent first-enrollment upserts recover from duplicate-key races. All verification passed.
+- 2026-07-15: PR1 merged as #38. PR2 implementation completed: atomic milestone recording, historical reconciliation, three failure-isolated endpoint hooks, lifetime revoke semantics, and comprehensive tests. Pre-delivery review also hardened transferred-token timestamps, direct bridge/session historical reconciliation, retry repair, and concurrent first writes. All verification passed. PR3 is next and has not started.

--- a/.plans/activation-reminders/PLAN.md
+++ b/.plans/activation-reminders/PLAN.md
@@ -6,7 +6,7 @@ Improve user activation by measuring and nudging users through this funnel:
 
 1. Mobile setup: the user registers a push-notification device token.
 2. Bridge setup: the user registers the desktop bridge.
-3. Full activation: the user creates a new session, represented by the first successful call to `POST /sessions/generate-metadata`.
+3. Full activation: the user creates a new session, represented by the first valid authenticated call to `POST /sessions/generate-metadata`.
 
 This file is the authoritative implementation tracker. A future session should read this file and `.plans/activation-reminders/CONSIDERATIONS.md` before changing code.
 
@@ -39,7 +39,7 @@ This file is the authoritative implementation tracker. A future session should r
 - Notification taps rely on the app's default open behavior; V1 adds no activation-specific deep link.
 - Mobile setup is the first device-token registration, not account creation.
 - Bridge setup is the first bridge registration, not the first relay connection.
-- First session is the first `POST /sessions/generate-metadata` call. This deliberately measures creation of a new text-backed session, not messages in existing sessions.
+- First session is the first valid authenticated `POST /sessions/generate-metadata` call. Metadata failure is non-fatal in the bridge and session creation continues, so the response does not need to succeed. This deliberately measures creation of a new text-backed session, not messages in existing sessions.
 - Bridge reminder 1 is due approximately 2 hours after mobile setup.
 - Bridge reminder 2 is due approximately 24 hours after mobile setup.
 - The single session reminder is due approximately 24 hours after both mobile and bridge setup. Its organic baseline is `max(mobileSetupAt, bridgeSetupAt)`.
@@ -107,7 +107,7 @@ The equality fields precede each due-time range field so the future sweep querie
 - Sending is gated by `ACTIVATION_REMINDERS_ENABLED`, defaulting to false.
 - Milestone recording remains active independently of the sending flag.
 - Activation tracking failures are logged and isolated from the user-facing endpoint that produced the milestone.
-- Reminder attempts are marked after `NotificationService.sendToUser` resolves, including a result with zero notified devices. A thrown send error remains retryable.
+- Reminder completion is marked after `NotificationService.sendToUser` resolves while FCM is available, including a result with zero registered devices. FCM-unavailable and thrown-send outcomes remain retryable.
 - See `CONSIDERATIONS.md` for the narrow crash window in which strict exactly-once delivery cannot be guaranteed.
 
 ## Configuration Target
@@ -161,11 +161,11 @@ PR1 non-goals:
 
 PR1 verification results:
 
-- `node --import tsx --test --test-concurrency=1 "tests/repositories/activation-state-repo.test.ts"`: passed, 4 tests.
+- `node --import tsx --test --test-concurrency=1 "tests/repositories/activation-state-repo.test.ts"`: passed, 6 tests.
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm run format:check`: passed.
-- `npm test`: passed, 331 tests passed, 1 skipped, 0 failed across 37 top-level suites.
+- `npm test`: passed, 333 tests passed, 1 skipped, 0 failed across 37 top-level suites.
 - `npm run circular-dependencies`: passed; no circular dependencies found.
 - `git diff --check`: passed.
 
@@ -180,7 +180,7 @@ Planned work:
 - Reconcile bridge state from the earliest historical bridge, including revoked bridges, so a previously completed setup is not presented as new.
 - Reconcile session state from historical `dailyUsage.metadataRequestCount > 0` data, using the best available date.
 - Set `bridgeSetupAt` idempotently after bridge registration.
-- Set `firstSessionAt` idempotently after a successful metadata generation request.
+- Set `firstSessionAt` idempotently when a valid authenticated metadata request is accepted, before metadata generation, because the bridge proceeds with session creation even when metadata generation fails.
 - Recompute `sessionReminderBaseAt` as the later setup time when both setup timestamps become available.
 - Catch and log activation errors at each endpoint boundary so activation tracking cannot break existing behavior.
 - Add route/service tests for ordering, retries, and failure isolation.
@@ -199,6 +199,7 @@ Planned work:
 - Add indexed repository queries for each due reminder.
 - Add conditional sent-marker writes so stale sweep results cannot mark an already-completed stage.
 - Add `ActivationReminderService` with single-flight sweep behavior and bounded batches.
+- Expose FCM availability so an uninitialized Firebase client cannot convert eligible reminders into completed zero-device sends.
 - Send the approved copy through existing `NotificationService` under category `system_update`.
 - Use distinct collapse keys per reminder kind.
 - Start the interval only when enabled and dispose it during graceful shutdown.
@@ -254,3 +255,4 @@ PR4 exit condition:
 
 - 2026-07-12: Interview completed. Product behavior, scheduling, copy, backfill policy, reporting, and four-PR split agreed.
 - 2026-07-12: PR1 implementation completed. Added the resumable plan, activation-state collection/schema/indexes, dormant repository/composition wiring, and focused tests. All verification passed. This document records PR1's intended post-merge status as merged; live GitHub status must always be verified separately. PR2 is next and has not started.
+- 2026-07-15: PR1 review feedback addressed. Clarified metadata-attempt semantics, retry and FCM-unavailable behavior, and backfill race guarantees; added defensive ObjectId validation and tests. All verification passed.

--- a/.plans/activation-reminders/PLAN.md
+++ b/.plans/activation-reminders/PLAN.md
@@ -185,6 +185,8 @@ Acceptance criteria:
 - [x] Retain the earliest first-session candidate when concurrent initial writes reach MongoDB out of order.
 - [x] On device-token registration, enroll the user from the earliest extant token, reset transferred-token history for the new owner, and retry unresolved bridge/session reconciliation.
 - [x] Add `{ userId: 1, createdAt: 1 }` to support historical device-token lookup.
+- [x] Remove the superseded `{ userId: 1 }` token index after confirming its compound replacement exists.
+- [x] Validate token owner IDs with the typed internal error used at repository boundaries.
 - [x] Reconcile bridge state from the earliest historical bridge, including revoked bridges.
 - [x] Add `{ userId: 1, addedAt: 1 }` to support historical bridge lookup.
 - [x] Reconcile session state from historical `dailyUsage.metadataRequestCount > 0` data using the earliest qualifying document's `createdAt`.
@@ -212,11 +214,11 @@ PR2 non-goals:
 
 PR2 verification results:
 
-- Focused activation/repository/route suite: passed, 103 tests.
+- Focused activation/repository/route suite: passed, 104 tests.
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm run format:check`: passed.
-- `npm test`: passed, 355 tests passed, 1 skipped, 0 failed across 39 top-level suites.
+- `npm test`: passed, 356 tests passed, 1 skipped, 0 failed across 39 top-level suites.
 - `npm run circular-dependencies`: passed; no circular dependencies found.
 - `git diff --check`: passed.
 
@@ -294,3 +296,4 @@ PR4 exit condition:
 - 2026-07-15: Human PR1 review feedback addressed. Documented timestamp and index invariants in source, clarified intended status labels, and made concurrent first-enrollment upserts recover from duplicate-key races. All verification passed.
 - 2026-07-15: PR1 merged as #38. PR2 implementation completed: atomic milestone recording, historical reconciliation, three failure-isolated endpoint hooks, lifetime revoke semantics, and comprehensive tests. Pre-delivery review also hardened transferred-token timestamps, direct bridge/session historical reconciliation, retry repair, and concurrent first writes. All verification passed. PR3 is next and has not started.
 - 2026-07-15: PR2 automated review feedback addressed. Added cross-stage repair from every event hook, earliest-wins concurrent session recording, defensive token user validation, and the compound token reconciliation index. Retained the documented metadata-attempt and historical timestamp semantics. All verification passed.
+- 2026-07-15: PR2 second automated review addressed. Added safe cleanup for the superseded device-token index and changed invalid token owner handling to the typed repository-boundary error. Confirmed mobile/bridge concurrency already resolves from earliest durable source timestamps. All verification passed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@ Node.js/TypeScript authentication service. Social login (GitHub, Google) via OAu
 ## STRUCTURE
 
 ```
+.plans/
+└── activation-reminders/ # Resumable multi-PR plan + design considerations for the activation funnel
 src/
 ├── types/             # Enums + shared types (mongo.ts, oauth.ts)
 ├── clients/
@@ -19,7 +21,7 @@ src/
 ├── lib/               # Utilities (state-store.ts — LRU singleton, errors.ts — ApiError hierarchy)
 ├── middleware/         # createAuthMiddleware factory → requireAuth preHandler hook
 ├── models/            # Zod schemas — api.ts, bridge.ts (shared bridge enums/schemas), documents.ts, jwt.ts
-├── repositories/      # Data access — user-repo.ts, oauth-account-repo.ts, bridge-repo.ts, glossary-entry-repo.ts
+├── repositories/      # Data access — user-repo.ts, oauth-account-repo.ts, bridge-repo.ts, activation-state-repo.ts, …
 ├── routes/
 │   └── auth/          # OAuth + pending-confirmation flow
 │       ├── github.ts             # GET /auth/github, POST /auth/github/init, POST/GET callbacks
@@ -36,17 +38,18 @@ src/
 
 ## WHERE TO LOOK
 
-| Task                       | Location                                                                 | Notes                                                                                       |
-| -------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
-| Add OAuth provider         | `src/clients/auth/` + `src/routes/auth/`                                 | Extend OAuthClient, implement exchangeCode + resolveIdentity, add route plugin in server.ts |
-| OAuth pending/confirm flow | `src/routes/auth/init.ts` + `provider-callback.ts` + `session-status.ts` | Anti-phishing interstitial; pending state in `src/services/pending-auth-store.ts`           |
-| Modify JWT claims          | `src/models/jwt.ts` + `src/services/token-service.ts`                    | Zod schema defines payload shape                                                            |
-| Add API endpoint           | `src/routes/`                                                            | Register as Fastify plugin in `server.ts`, add to AppServices if deps needed                |
-| Change DB schema           | `src/models/documents.ts` + `src/repositories/`                          | Zod document schemas, raw MongoDB driver                                                    |
-| Add DB collection          | `src/types/mongo.ts` + `src/db/mongo-db-accessor.ts`                     | Add to AuthDbCollection enum + DATABASE_CONFIG                                              |
-| Auth middleware            | `src/middleware/auth.ts`                                                 | `createAuthMiddleware(tokenService)` factory                                                |
+| Task                       | Location                                                                                                                                | Notes                                                                                       |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Add OAuth provider         | `src/clients/auth/` + `src/routes/auth/`                                                                                                | Extend OAuthClient, implement exchangeCode + resolveIdentity, add route plugin in server.ts |
+| OAuth pending/confirm flow | `src/routes/auth/init.ts` + `provider-callback.ts` + `session-status.ts`                                                                | Anti-phishing interstitial; pending state in `src/services/pending-auth-store.ts`           |
+| Modify JWT claims          | `src/models/jwt.ts` + `src/services/token-service.ts`                                                                                   | Zod schema defines payload shape                                                            |
+| Add API endpoint           | `src/routes/`                                                                                                                           | Register as Fastify plugin in `server.ts`, add to AppServices if deps needed                |
+| Change DB schema           | `src/models/documents.ts` + `src/repositories/`                                                                                         | Zod document schemas, raw MongoDB driver                                                    |
+| Add DB collection          | `src/types/mongo.ts` + `src/db/mongo-db-accessor.ts`                                                                                    | Add to AuthDbCollection enum + DATABASE_CONFIG                                              |
+| Auth middleware            | `src/middleware/auth.ts`                                                                                                                | `createAuthMiddleware(tokenService)` factory                                                |
 | Manage bridges             | `src/routes/bridges.ts` + `src/services/bridge-service.ts` + `src/repositories/bridge-repo.ts` + `src/services/bridge-state-tracker.ts` | Per-bridge registry behind `/auth/me bridges[]`; see BRIDGE SUBSYSTEM below                 |
-| Wire dependencies          | `src/index.ts`                                                           | Composition root — all instantiation happens here                                           |
+| Activation reminders       | `.plans/activation-reminders/` + `src/repositories/activation-state-repo.ts`                                                            | Read `PLAN.md` and `CONSIDERATIONS.md` before continuing the staged implementation          |
+| Wire dependencies          | `src/index.ts`                                                                                                                          | Composition root — all instantiation happens here                                           |
 
 ## CONVENTIONS
 
@@ -64,6 +67,12 @@ src/
 - **Pending OAuth sessions are in-process only.** `PendingAuthStore` is an in-memory LRU with a 5-minute TTL. The store is NOT shared between instances. Horizontal scaling of this service requires either sticky sessions (`X-Sesori-Session-Token` → consistent instance) OR migrating the store to Redis. Until then: **single-instance deploys only**.
 - Tunable via `PENDING_AUTH_MAX_SESSIONS` (default 10k entries ≈ 10 MB) and `PENDING_AUTH_POLL_TIMEOUT_MS` (default 30s long-poll cap).
 - **Bridge notification debounce is in-process only.** `BridgeStateTracker` keeps per-(userId, bridgeId) debounce timers and last-notified state in a process-local Map: pending notifications are lost on restart, the map is unbounded for the process lifetime (acceptable under the 50-bridges-per-user registration cap), and multiple instances would double-notify. Same single-instance constraint as above.
+
+## ACTIVATION REMINDERS
+
+The activation-reminder feature is intentionally split into independently deployable PRs. `.plans/activation-reminders/PLAN.md` is the authoritative implementation checkpoint and `.plans/activation-reminders/CONSIDERATIONS.md` records the product and architecture decisions. Verify live GitHub state before starting the next slice; do not infer merge status from the static plan alone.
+
+`activationStates` stores one document per user. Milestones are real event timestamps, reminder baselines are campaign scheduling timestamps that may diverge during backfill, and sent markers independently suppress each reminder. Do not conflate these categories. PR1 only establishes the dormant collection, indexes, repository, and wiring; later behavior must follow the staged acceptance criteria in the plan.
 
 ## BRIDGE SUBSYSTEM
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ src/
 │       ├── init.ts               # Shared helpers: parseSessionTokenHeader, createPendingOAuthInit, …
 │       ├── provider-callback.ts  # GET interstitial + POST confirm/deny (HTML responses)
 │       └── session-status.ts     # GET /auth/session/status long-poll
-├── services/          # Business logic — auth-service.ts, token-service.ts, voice-service.ts
+├── services/          # Business logic — auth-service.ts, token-service.ts, activation-service.ts, voice-service.ts
 │   └── pending-auth-store.ts     # In-memory LRU of pending OAuth sessions (anti-phishing flow)
 ├── config.ts          # Zod-validated env config
 ├── index.ts           # Composition root (wires all dependencies)
@@ -72,7 +72,7 @@ src/
 
 The activation-reminder feature is intentionally split into independently deployable PRs. `.plans/activation-reminders/PLAN.md` is the authoritative implementation checkpoint and `.plans/activation-reminders/CONSIDERATIONS.md` records the product and architecture decisions. Verify live GitHub state before starting the next slice; do not infer merge status from the static plan alone.
 
-`activationStates` stores one document per user. Milestones are real event timestamps, reminder baselines are campaign scheduling timestamps that may diverge during backfill, and sent markers independently suppress each reminder. Do not conflate these categories. PR1 only establishes the dormant collection, indexes, repository, and wiring; later behavior must follow the staged acceptance criteria in the plan.
+`activationStates` stores one document per user. Milestones are real event timestamps, reminder baselines are campaign scheduling timestamps that may diverge during backfill, and sent markers independently suppress each reminder. Do not conflate these categories. `ActivationService` records milestones from device-token registration, bridge registration, and accepted metadata requests; these secondary writes are failure-isolated from the existing endpoint response. Logout/revoke does not erase lifetime activation history. Later reminder and backfill behavior must follow the staged acceptance criteria in the plan.
 
 ## BRIDGE SUBSYSTEM
 

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -128,6 +128,21 @@ export class MongoDbAccessor {
             throw error;
           }
         }
+
+        // The compound lookup index supersedes PR1's user-only token index.
+        // Drop the old index only after confirming its replacement exists.
+        if (dbName === MongoDbDatabase.Auth && collectionName === AuthDbCollection.DeviceTokens) {
+          const currentIndexes = await collection.indexes();
+          const replacementExists = currentIndexes.some((index) =>
+            indexKeyMatches(index.key as IndexSpecification, { userId: 1, createdAt: 1 }),
+          );
+          const superseded = currentIndexes.find((index) =>
+            indexKeyMatches(index.key as IndexSpecification, { userId: 1 }),
+          );
+          if (replacementExists && superseded?.name) {
+            await collection.dropIndex(superseded.name);
+          }
+        }
       }
     }
   }

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -32,7 +32,10 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
       ],
       [AuthDbCollection.GlossaryEntries]: [{ spec: { userId: 1, word: 1 }, options: { unique: true } }],
       [AuthDbCollection.DailyUsage]: [{ spec: { userId: 1, date: 1 }, options: { unique: true } }],
-      [AuthDbCollection.DeviceTokens]: [{ spec: { token: 1 }, options: { unique: true } }, { spec: { userId: 1 } }],
+      [AuthDbCollection.DeviceTokens]: [
+        { spec: { token: 1 }, options: { unique: true } },
+        { spec: { userId: 1, createdAt: 1 } },
+      ],
       [AuthDbCollection.Bridges]: [
         { spec: { bridgeId: 1 }, options: { unique: true } },
         // Covers the hot /auth/me path: findByUserId and revokeAllForUser

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -134,7 +134,7 @@ export class MongoDbAccessor {
         if (dbName === MongoDbDatabase.Auth && collectionName === AuthDbCollection.DeviceTokens) {
           const currentIndexes = await collection.indexes();
           const replacementExists = currentIndexes.some((index) =>
-            indexKeyMatches(index.key as IndexSpecification, { userId: 1, createdAt: 1 }),
+            indexMatchesDesired(index, { spec: { userId: 1, createdAt: 1 } }),
           );
           const superseded = currentIndexes.find((index) =>
             indexKeyMatches(index.key as IndexSpecification, { userId: 1 }),

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -39,6 +39,12 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
         // filter on { userId, revokedAt: null }. No query filters on status.
         { spec: { userId: 1, revokedAt: 1 } },
       ],
+      [AuthDbCollection.ActivationStates]: [
+        { spec: { userId: 1 }, options: { unique: true } },
+        { spec: { bridgeSetupAt: 1, bridgeReminder1SentAt: 1, bridgeReminderBaseAt: 1 } },
+        { spec: { bridgeSetupAt: 1, bridgeReminder2SentAt: 1, bridgeReminderBaseAt: 1 } },
+        { spec: { firstSessionAt: 1, sessionReminderSentAt: 1, sessionReminderBaseAt: 1 } },
+      ],
     },
   } satisfies DatabaseConfig<AuthDbCollection>,
 };

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -38,6 +38,7 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
         // Covers the hot /auth/me path: findByUserId and revokeAllForUser
         // filter on { userId, revokedAt: null }. No query filters on status.
         { spec: { userId: 1, revokedAt: 1 } },
+        { spec: { userId: 1, addedAt: 1 } },
       ],
       [AuthDbCollection.ActivationStates]: [
         { spec: { userId: 1 }, options: { unique: true } },

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -41,6 +41,10 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
       ],
       [AuthDbCollection.ActivationStates]: [
         { spec: { userId: 1 }, options: { unique: true } },
+        // Reminder sweeps filter on stage-completion and sent-marker equality,
+        // then range on the baseline. Keep equality fields before the range;
+        // the two bridge reminders need separate indexes for their sent markers.
+        // See .plans/activation-reminders/CONSIDERATIONS.md, "Index Design".
         { spec: { bridgeSetupAt: 1, bridgeReminder1SentAt: 1, bridgeReminderBaseAt: 1 } },
         { spec: { bridgeSetupAt: 1, bridgeReminder2SentAt: 1, bridgeReminderBaseAt: 1 } },
         { spec: { firstSessionAt: 1, sessionReminderSentAt: 1, sessionReminderBaseAt: 1 } },

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { UserRepository } from "./repositories/user-repo.js";
 import { ActivationStateRepository } from "./repositories/activation-state-repo.js";
 import { buildApp } from "./server.js";
 import { AuthService } from "./services/auth-service.js";
+import { ActivationService } from "./services/activation-service.js";
 import { AppleNativeVerifier } from "./services/apple-native-verifier.js";
 import { BridgeService } from "./services/bridge-service.js";
 import { BridgeStateTracker } from "./services/bridge-state-tracker.js";
@@ -91,6 +92,12 @@ async function main() {
   const notificationService = new NotificationService(deviceTokenRepo, messaging);
   const bridgeStateTracker = new BridgeStateTracker(notificationService);
   const bridgeService = new BridgeService({ bridgeRepo, bridgeStateTracker });
+  const activationService = new ActivationService({
+    activationStateRepo,
+    bridgeRepo,
+    dailyUsageRepo,
+    deviceTokenRepo,
+  });
 
   const openai = new OpenAIClient({ apiKey: config.OPENAI_API_KEY, model: config.OPENAI_TRANSCRIPTION_MODEL });
   console.log(`OpenAI client initialized (model: ${config.OPENAI_TRANSCRIPTION_MODEL})`);
@@ -141,7 +148,7 @@ async function main() {
     deviceTokenRepo,
     notificationService,
     bridgeStateTracker,
-    activationStateRepo,
+    activationService,
     stateStore,
     githubClient,
     googleClient,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { GlossaryEntryRepository } from "./repositories/glossary-entry-repo.js";
 import { OAuthAccountRepository } from "./repositories/oauth-account-repo.js";
 import { PasswordAccountRepository } from "./repositories/password-account-repo.js";
 import { UserRepository } from "./repositories/user-repo.js";
+import { ActivationStateRepository } from "./repositories/activation-state-repo.js";
 import { buildApp } from "./server.js";
 import { AuthService } from "./services/auth-service.js";
 import { AppleNativeVerifier } from "./services/apple-native-verifier.js";
@@ -60,6 +61,7 @@ async function main() {
   const dailyUsageRepo = new DailyUsageRepository(dbAccessor);
   const deviceTokenRepo = new DeviceTokenRepository(dbAccessor);
   const bridgeRepo = new BridgeRepository(dbAccessor);
+  const activationStateRepo = new ActivationStateRepository(dbAccessor);
 
   const tokenService = new TokenService(config.JWT_PRIVATE_KEY, config.JWT_PUBLIC_KEY);
   const pendingAuthStore = new PendingAuthStore({
@@ -139,6 +141,7 @@ async function main() {
     deviceTokenRepo,
     notificationService,
     bridgeStateTracker,
+    activationStateRepo,
     stateStore,
     githubClient,
     googleClient,

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -92,6 +92,13 @@ export const bridgeSchema = z.object({
 
 export type Bridge = z.infer<typeof bridgeSchema>;
 
+/**
+ * One activation-funnel document per user. Do not conflate these categories:
+ * milestones are real event times; reminder baselines are campaign start times
+ * that may diverge after backfill; sent markers independently suppress each
+ * reminder; backfilledAt records enrollment by the backfill script.
+ * See .plans/activation-reminders/CONSIDERATIONS.md, "Timestamp Semantics".
+ */
 export const activationStateSchema = z.object({
   _id: z.instanceof(ObjectId),
   userId: z.instanceof(ObjectId),

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -91,3 +91,21 @@ export const bridgeSchema = z.object({
 });
 
 export type Bridge = z.infer<typeof bridgeSchema>;
+
+export const activationStateSchema = z.object({
+  _id: z.instanceof(ObjectId),
+  userId: z.instanceof(ObjectId),
+  mobileSetupAt: z.date().nullable(),
+  bridgeSetupAt: z.date().nullable(),
+  firstSessionAt: z.date().nullable(),
+  bridgeReminderBaseAt: z.date().nullable(),
+  sessionReminderBaseAt: z.date().nullable(),
+  bridgeReminder1SentAt: z.date().nullable(),
+  bridgeReminder2SentAt: z.date().nullable(),
+  sessionReminderSentAt: z.date().nullable(),
+  backfilledAt: z.date().nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type ActivationState = z.infer<typeof activationStateSchema>;

--- a/src/repositories/activation-state-repo.ts
+++ b/src/repositories/activation-state-repo.ts
@@ -1,0 +1,47 @@
+import { Collection, ObjectId } from "mongodb";
+import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import { InternalServerError } from "../lib/errors.js";
+import type { ActivationState } from "../models/documents.js";
+import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
+
+export class ActivationStateRepository {
+  readonly #collection: Collection<ActivationState>;
+
+  constructor(accessor: MongoDbAccessor) {
+    this.#collection = accessor.getCollection<ActivationState>(MongoDbDatabase.Auth, AuthDbCollection.ActivationStates);
+  }
+
+  async findByUserId(userId: string): Promise<ActivationState | null> {
+    return this.#collection.findOne({ userId: new ObjectId(userId) });
+  }
+
+  async createIfAbsent(userId: string, at = new Date()): Promise<ActivationState> {
+    const objectUserId = new ObjectId(userId);
+    const state = await this.#collection.findOneAndUpdate(
+      { userId: objectUserId },
+      {
+        $setOnInsert: {
+          _id: new ObjectId(),
+          userId: objectUserId,
+          mobileSetupAt: null,
+          bridgeSetupAt: null,
+          firstSessionAt: null,
+          bridgeReminderBaseAt: null,
+          sessionReminderBaseAt: null,
+          bridgeReminder1SentAt: null,
+          bridgeReminder2SentAt: null,
+          sessionReminderSentAt: null,
+          backfilledAt: null,
+          createdAt: at,
+          updatedAt: at,
+        },
+      },
+      { upsert: true, returnDocument: "after" },
+    );
+
+    if (!state) {
+      throw new InternalServerError({ debugMessage: "Failed to create activation state" });
+    }
+    return state;
+  }
+}

--- a/src/repositories/activation-state-repo.ts
+++ b/src/repositories/activation-state-repo.ts
@@ -80,7 +80,21 @@ export class ActivationStateRepository {
           $set: {
             mobileSetupAt: { $ifNull: ["$mobileSetupAt", mobileCandidate] },
             bridgeSetupAt: { $ifNull: ["$bridgeSetupAt", bridgeCandidate] },
-            firstSessionAt: { $ifNull: ["$firstSessionAt", sessionCandidate] },
+            firstSessionAt: {
+              $cond: [
+                { $eq: [sessionCandidate, null] },
+                "$firstSessionAt",
+                {
+                  $cond: [
+                    {
+                      $or: [{ $eq: ["$firstSessionAt", null] }, { $lt: [sessionCandidate, "$firstSessionAt"] }],
+                    },
+                    sessionCandidate,
+                    "$firstSessionAt",
+                  ],
+                },
+              ],
+            },
             bridgeReminderBaseAt: {
               $ifNull: ["$bridgeReminderBaseAt", { $ifNull: ["$mobileSetupAt", mobileCandidate] }],
             },

--- a/src/repositories/activation-state-repo.ts
+++ b/src/repositories/activation-state-repo.ts
@@ -1,4 +1,4 @@
-import { Collection, ObjectId } from "mongodb";
+import { Collection, MongoServerError, ObjectId } from "mongodb";
 import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
 import { InternalServerError } from "../lib/errors.js";
 import type { ActivationState } from "../models/documents.js";
@@ -23,31 +23,41 @@ export class ActivationStateRepository {
       throw new InternalServerError({ debugMessage: "Invalid activation state userId" });
     }
     const objectUserId = new ObjectId(userId);
-    const state = await this.#collection.findOneAndUpdate(
-      { userId: objectUserId },
-      {
-        $setOnInsert: {
-          _id: new ObjectId(),
-          userId: objectUserId,
-          mobileSetupAt: null,
-          bridgeSetupAt: null,
-          firstSessionAt: null,
-          bridgeReminderBaseAt: null,
-          sessionReminderBaseAt: null,
-          bridgeReminder1SentAt: null,
-          bridgeReminder2SentAt: null,
-          sessionReminderSentAt: null,
-          backfilledAt: null,
-          createdAt: at,
-          updatedAt: at,
+    try {
+      const state = await this.#collection.findOneAndUpdate(
+        { userId: objectUserId },
+        {
+          $setOnInsert: {
+            _id: new ObjectId(),
+            userId: objectUserId,
+            mobileSetupAt: null,
+            bridgeSetupAt: null,
+            firstSessionAt: null,
+            bridgeReminderBaseAt: null,
+            sessionReminderBaseAt: null,
+            bridgeReminder1SentAt: null,
+            bridgeReminder2SentAt: null,
+            sessionReminderSentAt: null,
+            backfilledAt: null,
+            createdAt: at,
+            updatedAt: at,
+          },
         },
-      },
-      { upsert: true, returnDocument: "after" },
-    );
+        { upsert: true, returnDocument: "after" },
+      );
 
-    if (!state) {
-      throw new InternalServerError({ debugMessage: "Failed to create activation state" });
+      if (!state) {
+        throw new InternalServerError({ debugMessage: "Failed to create activation state" });
+      }
+      return state;
+    } catch (error) {
+      if (error instanceof MongoServerError && error.code === 11000) {
+        const winner = await this.#collection.findOne({ userId: objectUserId });
+        if (winner) {
+          return winner;
+        }
+      }
+      throw error;
     }
-    return state;
   }
 }

--- a/src/repositories/activation-state-repo.ts
+++ b/src/repositories/activation-state-repo.ts
@@ -12,10 +12,16 @@ export class ActivationStateRepository {
   }
 
   async findByUserId(userId: string): Promise<ActivationState | null> {
+    if (!ObjectId.isValid(userId)) {
+      return null;
+    }
     return this.#collection.findOne({ userId: new ObjectId(userId) });
   }
 
   async createIfAbsent(userId: string, at = new Date()): Promise<ActivationState> {
+    if (!ObjectId.isValid(userId)) {
+      throw new InternalServerError({ debugMessage: "Invalid activation state userId" });
+    }
     const objectUserId = new ObjectId(userId);
     const state = await this.#collection.findOneAndUpdate(
       { userId: objectUserId },

--- a/src/repositories/activation-state-repo.ts
+++ b/src/repositories/activation-state-repo.ts
@@ -4,6 +4,12 @@ import { InternalServerError } from "../lib/errors.js";
 import type { ActivationState } from "../models/documents.js";
 import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
 
+export type ActivationMilestoneUpdate = {
+  mobileSetupAt?: Date;
+  bridgeSetupAt?: Date;
+  firstSessionAt?: Date;
+};
+
 export class ActivationStateRepository {
   readonly #collection: Collection<ActivationState>;
 
@@ -59,5 +65,55 @@ export class ActivationStateRepository {
       }
       throw error;
     }
+  }
+
+  async recordMilestones(userId: string, update: ActivationMilestoneUpdate, at = new Date()): Promise<ActivationState> {
+    await this.createIfAbsent(userId, at);
+    const objectUserId = new ObjectId(userId);
+    const mobileCandidate = update.mobileSetupAt ?? null;
+    const bridgeCandidate = update.bridgeSetupAt ?? null;
+    const sessionCandidate = update.firstSessionAt ?? null;
+    const state = await this.#collection.findOneAndUpdate(
+      { userId: objectUserId },
+      [
+        {
+          $set: {
+            mobileSetupAt: { $ifNull: ["$mobileSetupAt", mobileCandidate] },
+            bridgeSetupAt: { $ifNull: ["$bridgeSetupAt", bridgeCandidate] },
+            firstSessionAt: { $ifNull: ["$firstSessionAt", sessionCandidate] },
+            bridgeReminderBaseAt: {
+              $ifNull: ["$bridgeReminderBaseAt", { $ifNull: ["$mobileSetupAt", mobileCandidate] }],
+            },
+            updatedAt: at,
+          },
+        },
+        {
+          $set: {
+            sessionReminderBaseAt: {
+              $ifNull: [
+                "$sessionReminderBaseAt",
+                {
+                  $cond: [
+                    {
+                      $and: [{ $ne: ["$mobileSetupAt", null] }, { $ne: ["$bridgeSetupAt", null] }],
+                    },
+                    {
+                      $cond: [{ $gte: ["$mobileSetupAt", "$bridgeSetupAt"] }, "$mobileSetupAt", "$bridgeSetupAt"],
+                    },
+                    null,
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      ],
+      { returnDocument: "after" },
+    );
+
+    if (!state) {
+      throw new InternalServerError({ debugMessage: "Failed to record activation milestones" });
+    }
+    return state;
   }
 }

--- a/src/repositories/bridge-repo.ts
+++ b/src/repositories/bridge-repo.ts
@@ -59,6 +59,12 @@ export class BridgeRepository {
       .toArray();
   }
 
+  async findEarliestAddedAt(userId: string): Promise<Date | null> {
+    if (!ObjectId.isValid(userId)) return null;
+    const bridge = await this.#collection.findOne({ userId: new ObjectId(userId) }, { sort: { addedAt: 1 } });
+    return bridge?.addedAt ?? null;
+  }
+
   async register(input: RegisterBridgeInput): Promise<Bridge> {
     if (!ObjectId.isValid(input.userId)) {
       throw new Error("Invalid userId");

--- a/src/repositories/daily-usage-repo.ts
+++ b/src/repositories/daily-usage-repo.ts
@@ -22,6 +22,15 @@ export class DailyUsageRepository {
     return doc?.transcriptionSeconds ?? 0;
   }
 
+  async findEarliestMetadataRequestAt(userId: string): Promise<Date | null> {
+    if (!ObjectId.isValid(userId)) return null;
+    const usage = await this.#collection.findOne(
+      { userId: new ObjectId(userId), metadataRequestCount: { $gt: 0 } },
+      { sort: { date: 1 } },
+    );
+    return usage?.createdAt ?? null;
+  }
+
   /**
    * Atomically increments today's transcription seconds for a user (upsert).
    * Returns the total BEFORE the increment (`previousTotal`) and AFTER (`newTotal`).

--- a/src/repositories/device-token-repo.ts
+++ b/src/repositories/device-token-repo.ts
@@ -1,5 +1,6 @@
 import { Collection, ObjectId } from "mongodb";
 import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import { InternalServerError } from "../lib/errors.js";
 import type { DeviceToken } from "../models/documents.js";
 import { MongoDbDatabase, AuthDbCollection } from "../types/mongo.js";
 
@@ -12,7 +13,7 @@ export class DeviceTokenRepository {
 
   async upsertToken(userId: string, token: string, platform: "ios" | "android"): Promise<void> {
     if (!ObjectId.isValid(userId)) {
-      throw new Error("Invalid userId");
+      throw new InternalServerError({ debugMessage: "Invalid device token userId" });
     }
     const now = new Date();
     const objectUserId = new ObjectId(userId);

--- a/src/repositories/device-token-repo.ts
+++ b/src/repositories/device-token-repo.ts
@@ -12,18 +12,35 @@ export class DeviceTokenRepository {
 
   async upsertToken(userId: string, token: string, platform: "ios" | "android"): Promise<void> {
     const now = new Date();
+    const objectUserId = new ObjectId(userId);
     await this.#collection.updateOne(
       { token },
-      {
-        $set: { userId: new ObjectId(userId), platform, updatedAt: now },
-        $setOnInsert: { createdAt: now },
-      },
+      [
+        {
+          $set: {
+            userId: objectUserId,
+            platform,
+            // A token moved to another account is a new registration for that
+            // user; same-user retries retain the original setup timestamp.
+            createdAt: {
+              $cond: [{ $eq: ["$userId", objectUserId] }, { $ifNull: ["$createdAt", now] }, now],
+            },
+            updatedAt: now,
+          },
+        },
+      ],
       { upsert: true },
     );
   }
 
   async findByUserId(userId: string): Promise<DeviceToken[]> {
     return this.#collection.find({ userId: new ObjectId(userId) }).toArray();
+  }
+
+  async findEarliestCreatedAt(userId: string): Promise<Date | null> {
+    if (!ObjectId.isValid(userId)) return null;
+    const token = await this.#collection.findOne({ userId: new ObjectId(userId) }, { sort: { createdAt: 1 } });
+    return token?.createdAt ?? null;
   }
 
   async deleteByToken(token: string): Promise<void> {

--- a/src/repositories/device-token-repo.ts
+++ b/src/repositories/device-token-repo.ts
@@ -11,6 +11,9 @@ export class DeviceTokenRepository {
   }
 
   async upsertToken(userId: string, token: string, platform: "ios" | "android"): Promise<void> {
+    if (!ObjectId.isValid(userId)) {
+      throw new Error("Invalid userId");
+    }
     const now = new Date();
     const objectUserId = new ObjectId(userId);
     await this.#collection.updateOne(

--- a/src/routes/bridges.ts
+++ b/src/routes/bridges.ts
@@ -7,6 +7,7 @@ import {
   type BridgesListReply,
 } from "../models/api.js";
 import type { BridgeService } from "../services/bridge-service.js";
+import type { ActivationService } from "../services/activation-service.js";
 
 function getUserId(request: FastifyRequest): string {
   if (!request.user) throw new UnauthenticatedError();
@@ -15,11 +16,12 @@ function getUserId(request: FastifyRequest): string {
 
 export type BridgeRouteOptions = {
   bridgeService: BridgeService;
+  activationService: ActivationService;
   requireAuth: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
 };
 
 export const bridgeRoutes: FastifyPluginAsync<BridgeRouteOptions> = async (fastify, opts) => {
-  const { bridgeService, requireAuth } = opts;
+  const { bridgeService, activationService, requireAuth } = opts;
 
   // Idempotent registration: an optional bridgeId that matches a non-revoked
   // bridge owned by the caller updates that bridge (200); otherwise a new
@@ -35,6 +37,11 @@ export const bridgeRoutes: FastifyPluginAsync<BridgeRouteOptions> = async (fasti
 
       const userId = getUserId(request);
       const { bridge, created } = await bridgeService.registerForUser(userId, bodyResult.data);
+      try {
+        await activationService.recordBridgeSetup(userId, new Date(bridge.addedAt));
+      } catch (error) {
+        console.warn("[ActivationService] Failed to record bridge setup", { userId, error });
+      }
       reply.status(created ? 201 : 200);
       return bridge;
     },

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -13,6 +13,7 @@ import type { DeviceTokenRepository } from "../repositories/device-token-repo.js
 import type { BridgeService } from "../services/bridge-service.js";
 import type { BridgeStateTracker } from "../services/bridge-state-tracker.js";
 import type { NotificationService } from "../services/notification-service.js";
+import type { ActivationService } from "../services/activation-service.js";
 import type { Config } from "../config.js";
 
 // Allow up to 5 minutes of NTP clock skew between the relay and this server
@@ -29,6 +30,7 @@ export type NotificationRouteOptions = {
   notificationService: NotificationService;
   bridgeService: BridgeService;
   bridgeStateTracker: BridgeStateTracker;
+  activationService: ActivationService;
   requireAuth: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
   requireRelayAuth: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
 };
@@ -45,6 +47,7 @@ export const notificationRoutes: FastifyPluginAsync<NotificationRouteOptions> = 
     notificationService,
     bridgeService,
     bridgeStateTracker,
+    activationService,
     requireAuth,
     requireRelayAuth,
   } = opts;
@@ -60,6 +63,11 @@ export const notificationRoutes: FastifyPluginAsync<NotificationRouteOptions> = 
 
       const userId = getUserId(request);
       await deviceTokenRepo.upsertToken(userId, bodyResult.data.token, bodyResult.data.platform);
+      try {
+        await activationService.recordMobileSetup(userId);
+      } catch (error) {
+        console.warn("[ActivationService] Failed to record mobile setup", { userId, error });
+      }
       return { ok: true };
     },
   );

--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -3,6 +3,7 @@ import { BadRequestError } from "../lib/errors.js";
 import { generateMetadataBodySchema } from "../models/api.js";
 import type { GenerateMetadataBody, GenerateMetadataReply } from "../models/api.js";
 import type { SessionMetadataService } from "../services/session-metadata-service.js";
+import type { ActivationService } from "../services/activation-service.js";
 
 const METADATA_RATE_LIMIT = {
   max: 5,
@@ -12,11 +13,12 @@ const METADATA_RATE_LIMIT = {
 
 export type SessionRouteOptions = {
   sessionMetadataService: SessionMetadataService;
+  activationService: ActivationService;
   requireAuth: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
 };
 
 export const sessionRoutes: FastifyPluginAsync<SessionRouteOptions> = async (fastify, opts) => {
-  const { sessionMetadataService, requireAuth } = opts;
+  const { sessionMetadataService, activationService, requireAuth } = opts;
 
   fastify.post<{ Body: GenerateMetadataBody; Reply: GenerateMetadataReply }>(
     "/sessions/generate-metadata",
@@ -28,6 +30,11 @@ export const sessionRoutes: FastifyPluginAsync<SessionRouteOptions> = async (fas
       }
 
       const userId = request.user!.userId.toString();
+      try {
+        await activationService.recordFirstSession(userId);
+      } catch (error) {
+        console.warn("[ActivationService] Failed to record first session", { userId, error });
+      }
 
       return sessionMetadataService.generateMetadata({
         userId,

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,7 +9,7 @@ import { createAuthMiddleware } from "./middleware/auth.js";
 import { createRelayAuthMiddleware } from "./middleware/relay-auth.js";
 import type { HealthReply } from "./models/api.js";
 import type { DeviceTokenRepository } from "./repositories/device-token-repo.js";
-import type { ActivationStateRepository } from "./repositories/activation-state-repo.js";
+import type { ActivationService } from "./services/activation-service.js";
 import type { AuthService } from "./services/auth-service.js";
 import type { BridgeService } from "./services/bridge-service.js";
 import type { BridgeStateTracker } from "./services/bridge-state-tracker.js";
@@ -47,7 +47,7 @@ export type AppServices = {
   deviceTokenRepo: DeviceTokenRepository;
   notificationService: NotificationService;
   bridgeStateTracker: BridgeStateTracker;
-  activationStateRepo: ActivationStateRepository;
+  activationService: ActivationService;
   stateStore: StateStore;
   githubClient: OAuthClient;
   googleClient: OAuthClient;
@@ -157,15 +157,18 @@ export async function buildApp(services: AppServices): Promise<FastifyInstance> 
     notificationService: services.notificationService,
     bridgeService: services.bridgeService,
     bridgeStateTracker: services.bridgeStateTracker,
+    activationService: services.activationService,
     requireAuth,
     requireRelayAuth,
   });
   await app.register(bridgeRoutes, {
     bridgeService: services.bridgeService,
+    activationService: services.activationService,
     requireAuth,
   });
   await app.register(sessionRoutes, {
     sessionMetadataService: services.sessionMetadataService,
+    activationService: services.activationService,
     requireAuth,
   });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { createAuthMiddleware } from "./middleware/auth.js";
 import { createRelayAuthMiddleware } from "./middleware/relay-auth.js";
 import type { HealthReply } from "./models/api.js";
 import type { DeviceTokenRepository } from "./repositories/device-token-repo.js";
+import type { ActivationStateRepository } from "./repositories/activation-state-repo.js";
 import type { AuthService } from "./services/auth-service.js";
 import type { BridgeService } from "./services/bridge-service.js";
 import type { BridgeStateTracker } from "./services/bridge-state-tracker.js";
@@ -46,6 +47,7 @@ export type AppServices = {
   deviceTokenRepo: DeviceTokenRepository;
   notificationService: NotificationService;
   bridgeStateTracker: BridgeStateTracker;
+  activationStateRepo: ActivationStateRepository;
   stateStore: StateStore;
   githubClient: OAuthClient;
   googleClient: OAuthClient;

--- a/src/services/activation-service.ts
+++ b/src/services/activation-service.ts
@@ -1,5 +1,5 @@
 import type { ActivationState } from "../models/documents.js";
-import type { ActivationStateRepository } from "../repositories/activation-state-repo.js";
+import type { ActivationMilestoneUpdate, ActivationStateRepository } from "../repositories/activation-state-repo.js";
 import type { BridgeRepository } from "../repositories/bridge-repo.js";
 import type { DailyUsageRepository } from "../repositories/daily-usage-repo.js";
 import type { DeviceTokenRepository } from "../repositories/device-token-repo.js";
@@ -22,17 +22,27 @@ export class ActivationService {
     this.#deviceTokenRepo = deps.deviceTokenRepo;
   }
 
-  async recordMobileSetup(userId: string, observedAt = new Date()): Promise<ActivationState> {
+  async #recordReconciledMilestones(
+    userId: string,
+    observedMilestone: keyof ActivationMilestoneUpdate,
+    observedAt: Date,
+  ): Promise<ActivationState> {
     const existing = await this.#activationStateRepo.findByUserId(userId);
     const [mobileSetupAt, bridgeSetupAt, firstSessionAt] = await Promise.all([
       existing?.mobileSetupAt ? null : this.#deviceTokenRepo.findEarliestCreatedAt(userId),
       existing?.bridgeSetupAt ? null : this.#bridgeRepo.findEarliestAddedAt(userId),
       existing?.firstSessionAt ? null : this.#dailyUsageRepo.findEarliestMetadataRequestAt(userId),
     ]);
-    const update = {
-      mobileSetupAt: existing?.mobileSetupAt ? undefined : (mobileSetupAt ?? observedAt),
-      bridgeSetupAt: existing?.bridgeSetupAt ? undefined : (bridgeSetupAt ?? undefined),
-      firstSessionAt: existing?.firstSessionAt ? undefined : (firstSessionAt ?? undefined),
+    const update: ActivationMilestoneUpdate = {
+      mobileSetupAt: existing?.mobileSetupAt
+        ? undefined
+        : (mobileSetupAt ?? (observedMilestone === "mobileSetupAt" ? observedAt : undefined)),
+      bridgeSetupAt: existing?.bridgeSetupAt
+        ? undefined
+        : (bridgeSetupAt ?? (observedMilestone === "bridgeSetupAt" ? observedAt : undefined)),
+      firstSessionAt: existing?.firstSessionAt
+        ? undefined
+        : (firstSessionAt ?? (observedMilestone === "firstSessionAt" ? observedAt : undefined)),
     };
     if (existing && !update.mobileSetupAt && !update.bridgeSetupAt && !update.firstSessionAt) {
       return existing;
@@ -41,29 +51,15 @@ export class ActivationService {
     return this.#activationStateRepo.recordMilestones(userId, update, observedAt);
   }
 
+  async recordMobileSetup(userId: string, observedAt = new Date()): Promise<ActivationState> {
+    return this.#recordReconciledMilestones(userId, "mobileSetupAt", observedAt);
+  }
+
   async recordBridgeSetup(userId: string, observedAt = new Date()): Promise<ActivationState> {
-    const existing = await this.#activationStateRepo.findByUserId(userId);
-    if (existing?.bridgeSetupAt) {
-      return existing;
-    }
-    const historicalAt = await this.#bridgeRepo.findEarliestAddedAt(userId);
-    return this.#activationStateRepo.recordMilestones(
-      userId,
-      { bridgeSetupAt: historicalAt ?? observedAt },
-      observedAt,
-    );
+    return this.#recordReconciledMilestones(userId, "bridgeSetupAt", observedAt);
   }
 
   async recordFirstSession(userId: string, observedAt = new Date()): Promise<ActivationState> {
-    const existing = await this.#activationStateRepo.findByUserId(userId);
-    if (existing?.firstSessionAt) {
-      return existing;
-    }
-    const historicalAt = await this.#dailyUsageRepo.findEarliestMetadataRequestAt(userId);
-    return this.#activationStateRepo.recordMilestones(
-      userId,
-      { firstSessionAt: historicalAt ?? observedAt },
-      observedAt,
-    );
+    return this.#recordReconciledMilestones(userId, "firstSessionAt", observedAt);
   }
 }

--- a/src/services/activation-service.ts
+++ b/src/services/activation-service.ts
@@ -41,7 +41,9 @@ export class ActivationService {
         ? undefined
         : (bridgeSetupAt ?? (observedMilestone === "bridgeSetupAt" ? observedAt : undefined)),
       firstSessionAt: existing?.firstSessionAt
-        ? undefined
+        ? observedMilestone === "firstSessionAt" && observedAt < existing.firstSessionAt
+          ? observedAt
+          : undefined
         : (firstSessionAt ?? (observedMilestone === "firstSessionAt" ? observedAt : undefined)),
     };
     if (existing && !update.mobileSetupAt && !update.bridgeSetupAt && !update.firstSessionAt) {

--- a/src/services/activation-service.ts
+++ b/src/services/activation-service.ts
@@ -1,0 +1,69 @@
+import type { ActivationState } from "../models/documents.js";
+import type { ActivationStateRepository } from "../repositories/activation-state-repo.js";
+import type { BridgeRepository } from "../repositories/bridge-repo.js";
+import type { DailyUsageRepository } from "../repositories/daily-usage-repo.js";
+import type { DeviceTokenRepository } from "../repositories/device-token-repo.js";
+
+export class ActivationService {
+  readonly #activationStateRepo: ActivationStateRepository;
+  readonly #bridgeRepo: BridgeRepository;
+  readonly #dailyUsageRepo: DailyUsageRepository;
+  readonly #deviceTokenRepo: DeviceTokenRepository;
+
+  constructor(deps: {
+    activationStateRepo: ActivationStateRepository;
+    bridgeRepo: BridgeRepository;
+    dailyUsageRepo: DailyUsageRepository;
+    deviceTokenRepo: DeviceTokenRepository;
+  }) {
+    this.#activationStateRepo = deps.activationStateRepo;
+    this.#bridgeRepo = deps.bridgeRepo;
+    this.#dailyUsageRepo = deps.dailyUsageRepo;
+    this.#deviceTokenRepo = deps.deviceTokenRepo;
+  }
+
+  async recordMobileSetup(userId: string, observedAt = new Date()): Promise<ActivationState> {
+    const existing = await this.#activationStateRepo.findByUserId(userId);
+    const [mobileSetupAt, bridgeSetupAt, firstSessionAt] = await Promise.all([
+      existing?.mobileSetupAt ? null : this.#deviceTokenRepo.findEarliestCreatedAt(userId),
+      existing?.bridgeSetupAt ? null : this.#bridgeRepo.findEarliestAddedAt(userId),
+      existing?.firstSessionAt ? null : this.#dailyUsageRepo.findEarliestMetadataRequestAt(userId),
+    ]);
+    const update = {
+      mobileSetupAt: existing?.mobileSetupAt ? undefined : (mobileSetupAt ?? observedAt),
+      bridgeSetupAt: existing?.bridgeSetupAt ? undefined : (bridgeSetupAt ?? undefined),
+      firstSessionAt: existing?.firstSessionAt ? undefined : (firstSessionAt ?? undefined),
+    };
+    if (existing && !update.mobileSetupAt && !update.bridgeSetupAt && !update.firstSessionAt) {
+      return existing;
+    }
+
+    return this.#activationStateRepo.recordMilestones(userId, update, observedAt);
+  }
+
+  async recordBridgeSetup(userId: string, observedAt = new Date()): Promise<ActivationState> {
+    const existing = await this.#activationStateRepo.findByUserId(userId);
+    if (existing?.bridgeSetupAt) {
+      return existing;
+    }
+    const historicalAt = await this.#bridgeRepo.findEarliestAddedAt(userId);
+    return this.#activationStateRepo.recordMilestones(
+      userId,
+      { bridgeSetupAt: historicalAt ?? observedAt },
+      observedAt,
+    );
+  }
+
+  async recordFirstSession(userId: string, observedAt = new Date()): Promise<ActivationState> {
+    const existing = await this.#activationStateRepo.findByUserId(userId);
+    if (existing?.firstSessionAt) {
+      return existing;
+    }
+    const historicalAt = await this.#dailyUsageRepo.findEarliestMetadataRequestAt(userId);
+    return this.#activationStateRepo.recordMilestones(
+      userId,
+      { firstSessionAt: historicalAt ?? observedAt },
+      observedAt,
+    );
+  }
+}

--- a/src/types/mongo.ts
+++ b/src/types/mongo.ts
@@ -10,4 +10,5 @@ export enum AuthDbCollection {
   DailyUsage = "dailyUsage",
   DeviceTokens = "deviceTokens",
   Bridges = "bridges",
+  ActivationStates = "activationStates",
 }

--- a/tests/auth/oauth-callback-confirmation.test.ts
+++ b/tests/auth/oauth-callback-confirmation.test.ts
@@ -116,6 +116,7 @@ function createTestServices(params: {
     deviceTokenRepo: {} as AppServices["deviceTokenRepo"],
     notificationService: {} as AppServices["notificationService"],
     bridgeStateTracker: {} as AppServices["bridgeStateTracker"],
+    activationService: {} as AppServices["activationService"],
     stateStore: new StateStore(),
     pendingAuthStore: params.pendingAuthStore,
     githubClient: githubClient as unknown as AppServices["githubClient"],

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -21,6 +21,7 @@ import { GlossaryEntryRepository } from "../../src/repositories/glossary-entry-r
 import { OAuthAccountRepository } from "../../src/repositories/oauth-account-repo.js";
 import { PasswordAccountRepository } from "../../src/repositories/password-account-repo.js";
 import { UserRepository } from "../../src/repositories/user-repo.js";
+import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
 import { buildApp } from "../../src/server.js";
 import { AuthService } from "../../src/services/auth-service.js";
 import { BridgeService } from "../../src/services/bridge-service.js";
@@ -144,6 +145,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
   const dailyUsageRepo = new DailyUsageRepository(dbAccessor);
   const deviceTokenRepo = new DeviceTokenRepository(dbAccessor);
   const bridgeRepo = new BridgeRepository(dbAccessor);
+  const activationStateRepo = new ActivationStateRepository(dbAccessor);
 
   const tokenService = new TokenService(privPem, pubPem);
   const stateStore = new StateStore();
@@ -189,6 +191,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
     deviceTokenRepo,
     notificationService,
     bridgeStateTracker,
+    activationStateRepo,
     stateStore,
     githubClient,
     googleClient,

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -24,6 +24,7 @@ import { UserRepository } from "../../src/repositories/user-repo.js";
 import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
 import { buildApp } from "../../src/server.js";
 import { AuthService } from "../../src/services/auth-service.js";
+import { ActivationService } from "../../src/services/activation-service.js";
 import { BridgeService } from "../../src/services/bridge-service.js";
 import { BridgeStateTracker } from "../../src/services/bridge-state-tracker.js";
 import { NotificationService } from "../../src/services/notification-service.js";
@@ -71,6 +72,7 @@ export type TestAppOverrides = {
   sessionMetadataService?: SessionMetadataService;
   installScriptService?: InstallScriptService;
   legalDocumentService?: LegalDocumentService;
+  activationService?: ActivationService;
 };
 
 export type { OAuthClient };
@@ -171,6 +173,9 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
   const notificationService = overrides?.notificationService ?? new NotificationService(deviceTokenRepo, null);
   const bridgeStateTracker = overrides?.bridgeStateTracker ?? new BridgeStateTracker(notificationService);
   const bridgeService = overrides?.bridgeService ?? new BridgeService({ bridgeRepo, bridgeStateTracker });
+  const activationService =
+    overrides?.activationService ??
+    new ActivationService({ activationStateRepo, bridgeRepo, dailyUsageRepo, deviceTokenRepo });
   const authService = new AuthService({ tokenService, userRepo, oauthAccountRepo, passwordAccountRepo, bridgeService });
   const voiceService = new VoiceService({ openai, glossaryRepo, dailyUsageRepo });
   const sessionMetadataService =
@@ -191,7 +196,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
     deviceTokenRepo,
     notificationService,
     bridgeStateTracker,
-    activationStateRepo,
+    activationService,
     stateStore,
     githubClient,
     googleClient,

--- a/tests/notifications/device-token-repo.test.ts
+++ b/tests/notifications/device-token-repo.test.ts
@@ -140,6 +140,32 @@ describe("DeviceTokenRepository", () => {
     });
   });
 
+  it("ensureIndexes retains the user-only index when the compound replacement has conflicting options", async () => {
+    const collection = ctx.dbAccessor.getCollection<DeviceToken>(MongoDbDatabase.Auth, AuthDbCollection.DeviceTokens);
+    await collection.deleteMany({});
+    await collection.dropIndex("userId_1_createdAt_1");
+    await collection.createIndex({ userId: 1, createdAt: 1 }, { unique: true });
+    await collection.createIndex({ userId: 1 });
+
+    await ctx.dbAccessor.ensureIndexes();
+
+    let indexes = await collection.indexes();
+    assert.equal(
+      indexes.some((candidate) => candidate.name === "userId_1"),
+      true,
+    );
+    assert.equal(indexes.find((candidate) => candidate.name === "userId_1_createdAt_1")?.unique, true);
+
+    await collection.dropIndex("userId_1_createdAt_1");
+    await ctx.dbAccessor.ensureIndexes();
+    indexes = await collection.indexes();
+    assert.equal(
+      indexes.some((candidate) => candidate.name === "userId_1"),
+      false,
+    );
+    assert.equal(indexes.find((candidate) => candidate.name === "userId_1_createdAt_1")?.unique, undefined);
+  });
+
   it("deleteByToken removes specific token", async () => {
     const user = await ctx.createUser();
 

--- a/tests/notifications/device-token-repo.test.ts
+++ b/tests/notifications/device-token-repo.test.ts
@@ -70,6 +70,10 @@ describe("DeviceTokenRepository", () => {
     assert.equal(transferred.createdAt.toISOString(), transferred.updatedAt.toISOString());
   });
 
+  it("upsertToken rejects an invalid user id", async () => {
+    await assert.rejects(() => repo.upsertToken("invalid-id", "token-invalid", "ios"), /Invalid userId/);
+  });
+
   it("findByUserId returns all tokens for user", async () => {
     const user = await ctx.createUser();
 
@@ -107,6 +111,8 @@ describe("DeviceTokenRepository", () => {
 
     assert.equal((await repo.findEarliestCreatedAt(user.userId))?.toISOString(), firstAt.toISOString());
     assert.equal(await repo.findEarliestCreatedAt("invalid-id"), null);
+    const index = (await collection.indexes()).find((candidate) => candidate.name === "userId_1_createdAt_1");
+    assert.deepEqual(index?.key, { userId: 1, createdAt: 1 });
   });
 
   it("deleteByToken removes specific token", async () => {

--- a/tests/notifications/device-token-repo.test.ts
+++ b/tests/notifications/device-token-repo.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
+import { ObjectId } from "mongodb";
+import type { DeviceToken } from "../../src/models/documents.js";
 import { DeviceTokenRepository } from "../../src/repositories/device-token-repo.js";
+import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
 
 describe("DeviceTokenRepository", () => {
@@ -32,6 +35,7 @@ describe("DeviceTokenRepository", () => {
 
     await repo.upsertToken(user.userId, "token-idempotent", "ios");
     const first = await repo.findByUserId(user.userId);
+    const firstCreatedAt = first[0]?.createdAt;
     const firstUpdatedAt = first[0]?.updatedAt;
 
     await new Promise((resolve) => setTimeout(resolve, 10));
@@ -40,9 +44,30 @@ describe("DeviceTokenRepository", () => {
     const second = await repo.findByUserId(user.userId);
     assert.equal(second.length, 1);
     assert.equal(second[0]?.platform, "android");
+    assert.ok(firstCreatedAt instanceof Date);
     assert.ok(firstUpdatedAt instanceof Date);
+    assert.equal(second[0]?.createdAt.toISOString(), firstCreatedAt.toISOString());
     assert.ok(second[0]?.updatedAt instanceof Date);
     assert.ok((second[0]?.updatedAt.getTime() ?? 0) >= firstUpdatedAt.getTime());
+  });
+
+  it("upsertToken resets createdAt when a token moves to another user", async () => {
+    const firstUser = await ctx.createUser();
+    const secondUser = await ctx.createUser();
+
+    await repo.upsertToken(firstUser.userId, "token-transferred", "ios");
+    const firstRegistration = (await repo.findByUserId(firstUser.userId))[0];
+    assert.ok(firstRegistration);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    await repo.upsertToken(secondUser.userId, "token-transferred", "android");
+
+    assert.equal((await repo.findByUserId(firstUser.userId)).length, 0);
+    const transferred = (await repo.findByUserId(secondUser.userId))[0];
+    assert.ok(transferred);
+    assert.equal(transferred.platform, "android");
+    assert.ok(transferred.createdAt.getTime() > firstRegistration.createdAt.getTime());
+    assert.equal(transferred.createdAt.toISOString(), transferred.updatedAt.toISOString());
   });
 
   it("findByUserId returns all tokens for user", async () => {
@@ -54,6 +79,34 @@ describe("DeviceTokenRepository", () => {
     const tokens = await repo.findByUserId(user.userId);
     assert.equal(tokens.length, 2);
     assert.deepEqual(new Set(tokens.map((token) => token.token)), new Set(["token-list-1", "token-list-2"]));
+  });
+
+  it("findEarliestCreatedAt returns the first extant token registration", async () => {
+    const user = await ctx.createUser();
+    const firstAt = new Date("2026-07-10T10:00:00.000Z");
+    const secondAt = new Date("2026-07-12T10:00:00.000Z");
+    const collection = ctx.dbAccessor.getCollection<DeviceToken>(MongoDbDatabase.Auth, AuthDbCollection.DeviceTokens);
+    await collection.insertMany([
+      {
+        _id: new ObjectId(),
+        userId: new ObjectId(user.userId),
+        token: `earliest-token-${user.userId}`,
+        platform: "ios",
+        createdAt: firstAt,
+        updatedAt: firstAt,
+      },
+      {
+        _id: new ObjectId(),
+        userId: new ObjectId(user.userId),
+        token: `later-token-${user.userId}`,
+        platform: "android",
+        createdAt: secondAt,
+        updatedAt: secondAt,
+      },
+    ]);
+
+    assert.equal((await repo.findEarliestCreatedAt(user.userId))?.toISOString(), firstAt.toISOString());
+    assert.equal(await repo.findEarliestCreatedAt("invalid-id"), null);
   });
 
   it("deleteByToken removes specific token", async () => {

--- a/tests/notifications/device-token-repo.test.ts
+++ b/tests/notifications/device-token-repo.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
 import { ObjectId } from "mongodb";
+import { InternalServerError } from "../../src/lib/errors.js";
 import type { DeviceToken } from "../../src/models/documents.js";
 import { DeviceTokenRepository } from "../../src/repositories/device-token-repo.js";
 import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
@@ -71,7 +72,14 @@ describe("DeviceTokenRepository", () => {
   });
 
   it("upsertToken rejects an invalid user id", async () => {
-    await assert.rejects(() => repo.upsertToken("invalid-id", "token-invalid", "ios"), /Invalid userId/);
+    await assert.rejects(
+      () => repo.upsertToken("invalid-id", "token-invalid", "ios"),
+      (error: unknown) => {
+        assert.ok(error instanceof InternalServerError);
+        assert.equal(error.debugMessage, "Invalid device token userId");
+        return true;
+      },
+    );
   });
 
   it("findByUserId returns all tokens for user", async () => {
@@ -113,6 +121,23 @@ describe("DeviceTokenRepository", () => {
     assert.equal(await repo.findEarliestCreatedAt("invalid-id"), null);
     const index = (await collection.indexes()).find((candidate) => candidate.name === "userId_1_createdAt_1");
     assert.deepEqual(index?.key, { userId: 1, createdAt: 1 });
+  });
+
+  it("ensureIndexes removes the superseded user-only token index", async () => {
+    const collection = ctx.dbAccessor.getCollection<DeviceToken>(MongoDbDatabase.Auth, AuthDbCollection.DeviceTokens);
+    await collection.createIndex({ userId: 1 });
+
+    await ctx.dbAccessor.ensureIndexes();
+
+    const indexes = await collection.indexes();
+    assert.equal(
+      indexes.some((candidate) => candidate.name === "userId_1"),
+      false,
+    );
+    assert.deepEqual(indexes.find((candidate) => candidate.name === "userId_1_createdAt_1")?.key, {
+      userId: 1,
+      createdAt: 1,
+    });
   });
 
   it("deleteByToken removes specific token", async () => {

--- a/tests/notifications/routes.test.ts
+++ b/tests/notifications/routes.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
-import { after, before, beforeEach, describe, it } from "node:test";
+import { after, afterEach, before, beforeEach, describe, it, mock } from "node:test";
+import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
 import { DeviceTokenRepository } from "../../src/repositories/device-token-repo.js";
+import { ActivationService } from "../../src/services/activation-service.js";
 import type { BridgeStateTracker } from "../../src/services/bridge-state-tracker.js";
 import type { NotificationService } from "../../src/services/notification-service.js";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
@@ -27,6 +29,7 @@ function hasProjectId(payload: unknown): payload is { data: { projectId: string 
 describe("Notification routes", () => {
   let ctx: TestContext;
   let deviceTokenRepo: DeviceTokenRepository;
+  let activationStateRepo: ActivationStateRepository;
   const sendCalls: SendCall[] = [];
   const trackerCalls: TrackerCall[] = [];
   const cancelledLegacyUsers: string[] = [];
@@ -58,12 +61,17 @@ describe("Notification routes", () => {
       bridgeStateTracker: bridgeStateTrackerMock,
     });
     deviceTokenRepo = new DeviceTokenRepository(ctx.dbAccessor);
+    activationStateRepo = new ActivationStateRepository(ctx.dbAccessor);
   });
 
   beforeEach(() => {
     sendCalls.length = 0;
     trackerCalls.length = 0;
     cancelledLegacyUsers.length = 0;
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
   });
 
   after(async () => {
@@ -90,6 +98,32 @@ describe("Notification routes", () => {
     assert.equal(tokens.length, 1);
     assert.equal(tokens[0]?.token, "fcm-token-1");
     assert.equal(tokens[0]?.platform, "ios");
+    const activationState = await activationStateRepo.findByUserId(user.userId);
+    assert.ok(activationState?.mobileSetupAt);
+    assert.equal(activationState.bridgeReminderBaseAt?.toISOString(), activationState.mobileSetupAt.toISOString());
+  });
+
+  it("POST /notifications/register-token succeeds when activation recording fails", async () => {
+    const user = await ctx.createUser();
+    const recordMock = mock.method(ActivationService.prototype, "recordMobileSetup", async () => {
+      throw new Error("activation unavailable");
+    });
+    const warnMock = mock.method(console, "warn", () => {});
+
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/notifications/register-token",
+      headers: {
+        authorization: `Bearer ${user.accessToken}`,
+        "content-type": "application/json",
+      },
+      payload: JSON.stringify({ token: "fcm-token-soft-fail", platform: "android" }),
+    });
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(recordMock.mock.callCount(), 1);
+    assert.equal(warnMock.mock.callCount(), 1);
+    assert.equal((await deviceTokenRepo.findByUserId(user.userId)).length, 1);
   });
 
   it("POST /notifications/register-token returns 401 without auth", async () => {

--- a/tests/repositories/activation-state-repo.test.ts
+++ b/tests/repositories/activation-state-repo.test.ts
@@ -90,6 +90,81 @@ describe("ActivationStateRepository", () => {
     assert.equal(await repo.findByUserId("invalid-id"), null);
   });
 
+  it("derives reminder baselines when mobile setup is recorded before bridge setup", async () => {
+    const user = await ctx.createUser();
+    const mobileAt = new Date("2026-07-12T10:00:00.000Z");
+    const bridgeAt = new Date("2026-07-12T12:00:00.000Z");
+
+    const mobileState = await repo.recordMilestones(user.userId, { mobileSetupAt: mobileAt }, mobileAt);
+    const completeSetupState = await repo.recordMilestones(user.userId, { bridgeSetupAt: bridgeAt }, bridgeAt);
+
+    assert.equal(mobileState.mobileSetupAt?.toISOString(), mobileAt.toISOString());
+    assert.equal(mobileState.bridgeReminderBaseAt?.toISOString(), mobileAt.toISOString());
+    assert.equal(mobileState.sessionReminderBaseAt, null);
+    assert.equal(completeSetupState.bridgeSetupAt?.toISOString(), bridgeAt.toISOString());
+    assert.equal(completeSetupState.sessionReminderBaseAt?.toISOString(), bridgeAt.toISOString());
+  });
+
+  it("derives the session baseline from the later mobile setup when events arrive out of order", async () => {
+    const user = await ctx.createUser();
+    const bridgeAt = new Date("2026-07-12T10:00:00.000Z");
+    const mobileAt = new Date("2026-07-12T12:00:00.000Z");
+
+    const bridgeState = await repo.recordMilestones(user.userId, { bridgeSetupAt: bridgeAt }, bridgeAt);
+    const completeSetupState = await repo.recordMilestones(user.userId, { mobileSetupAt: mobileAt }, mobileAt);
+
+    assert.equal(bridgeState.bridgeSetupAt?.toISOString(), bridgeAt.toISOString());
+    assert.equal(bridgeState.bridgeReminderBaseAt, null);
+    assert.equal(bridgeState.sessionReminderBaseAt, null);
+    assert.equal(completeSetupState.bridgeReminderBaseAt?.toISOString(), mobileAt.toISOString());
+    assert.equal(completeSetupState.sessionReminderBaseAt?.toISOString(), mobileAt.toISOString());
+  });
+
+  it("does not overwrite recorded milestones or reminder baselines", async () => {
+    const user = await ctx.createUser();
+    const firstMobileAt = new Date("2026-07-12T10:00:00.000Z");
+    const firstBridgeAt = new Date("2026-07-12T12:00:00.000Z");
+    const firstSessionAt = new Date("2026-07-12T13:00:00.000Z");
+    await repo.recordMilestones(
+      user.userId,
+      { mobileSetupAt: firstMobileAt, bridgeSetupAt: firstBridgeAt, firstSessionAt },
+      firstSessionAt,
+    );
+
+    const state = await repo.recordMilestones(
+      user.userId,
+      {
+        mobileSetupAt: new Date("2026-07-13T10:00:00.000Z"),
+        bridgeSetupAt: new Date("2026-07-13T12:00:00.000Z"),
+        firstSessionAt: new Date("2026-07-13T13:00:00.000Z"),
+      },
+      new Date("2026-07-13T13:00:00.000Z"),
+    );
+
+    assert.equal(state.mobileSetupAt?.toISOString(), firstMobileAt.toISOString());
+    assert.equal(state.bridgeSetupAt?.toISOString(), firstBridgeAt.toISOString());
+    assert.equal(state.firstSessionAt?.toISOString(), firstSessionAt.toISOString());
+    assert.equal(state.bridgeReminderBaseAt?.toISOString(), firstMobileAt.toISOString());
+    assert.equal(state.sessionReminderBaseAt?.toISOString(), firstBridgeAt.toISOString());
+  });
+
+  it("derives valid baselines from concurrent first milestone writes", async () => {
+    const user = await ctx.createUser();
+    const mobileAt = new Date("2026-07-12T10:00:00.000Z");
+    const bridgeAt = new Date("2026-07-12T12:00:00.000Z");
+
+    await Promise.all([
+      repo.recordMilestones(user.userId, { mobileSetupAt: mobileAt }, mobileAt),
+      repo.recordMilestones(user.userId, { bridgeSetupAt: bridgeAt }, bridgeAt),
+    ]);
+
+    const state = await repo.findByUserId(user.userId);
+    assert.equal(state?.mobileSetupAt?.toISOString(), mobileAt.toISOString());
+    assert.equal(state?.bridgeSetupAt?.toISOString(), bridgeAt.toISOString());
+    assert.equal(state?.bridgeReminderBaseAt?.toISOString(), mobileAt.toISOString());
+    assert.equal(state?.sessionReminderBaseAt?.toISOString(), bridgeAt.toISOString());
+  });
+
   it("creates the indexes needed by future reminder sweeps", async () => {
     const collection = ctx.dbAccessor.getCollection<ActivationState>(
       MongoDbDatabase.Auth,

--- a/tests/repositories/activation-state-repo.test.ts
+++ b/tests/repositories/activation-state-repo.test.ts
@@ -165,6 +165,17 @@ describe("ActivationStateRepository", () => {
     assert.equal(state?.sessionReminderBaseAt?.toISOString(), bridgeAt.toISOString());
   });
 
+  it("retains the earlier first-session candidate when concurrent writes arrive out of order", async () => {
+    const user = await ctx.createUser();
+    const earlierAt = new Date("2026-07-12T10:00:00.000Z");
+    const laterAt = new Date("2026-07-12T10:00:01.000Z");
+
+    await repo.recordMilestones(user.userId, { firstSessionAt: laterAt }, laterAt);
+    const state = await repo.recordMilestones(user.userId, { firstSessionAt: earlierAt }, earlierAt);
+
+    assert.equal(state.firstSessionAt?.toISOString(), earlierAt.toISOString());
+  });
+
   it("creates the indexes needed by future reminder sweeps", async () => {
     const collection = ctx.dbAccessor.getCollection<ActivationState>(
       MongoDbDatabase.Auth,

--- a/tests/repositories/activation-state-repo.test.ts
+++ b/tests/repositories/activation-state-repo.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
+import { Collection, MongoServerError } from "mongodb";
 import { InternalServerError } from "../../src/lib/errors.js";
 import { activationStateSchema, type ActivationState } from "../../src/models/documents.js";
 import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
@@ -51,6 +52,18 @@ describe("ActivationStateRepository", () => {
     assert.equal(second._id.toHexString(), first._id.toHexString());
     assert.equal(second.createdAt.toISOString(), firstAt.toISOString());
     assert.equal(second.updatedAt.toISOString(), firstAt.toISOString());
+  });
+
+  it("returns the winner after losing a concurrent creation race", async (t) => {
+    const user = await ctx.createUser();
+    const winner = await repo.createIfAbsent(user.userId);
+    t.mock.method(Collection.prototype, "findOneAndUpdate", async () => {
+      throw new MongoServerError({ message: "duplicate key", code: 11000 });
+    });
+
+    const state = await repo.createIfAbsent(user.userId);
+
+    assert.equal(state._id.toHexString(), winner._id.toHexString());
   });
 
   it("rejects creation with an invalid user id", async () => {

--- a/tests/repositories/activation-state-repo.test.ts
+++ b/tests/repositories/activation-state-repo.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { activationStateSchema, type ActivationState } from "../../src/models/documents.js";
+import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
+import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+describe("ActivationStateRepository", () => {
+  let ctx: TestContext;
+  let repo: ActivationStateRepository;
+
+  before(async () => {
+    ctx = await createTestApp();
+    repo = new ActivationStateRepository(ctx.dbAccessor);
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("creates a complete dormant state for a user", async () => {
+    const user = await ctx.createUser();
+    const createdAt = new Date("2026-07-12T10:00:00.000Z");
+
+    const state = await repo.createIfAbsent(user.userId, createdAt);
+
+    assert.equal(state.userId.toHexString(), user.userId);
+    assert.equal(state.createdAt.toISOString(), createdAt.toISOString());
+    assert.equal(state.updatedAt.toISOString(), createdAt.toISOString());
+    assert.equal(state.mobileSetupAt, null);
+    assert.equal(state.bridgeSetupAt, null);
+    assert.equal(state.firstSessionAt, null);
+    assert.equal(state.bridgeReminderBaseAt, null);
+    assert.equal(state.sessionReminderBaseAt, null);
+    assert.equal(state.bridgeReminder1SentAt, null);
+    assert.equal(state.bridgeReminder2SentAt, null);
+    assert.equal(state.sessionReminderSentAt, null);
+    assert.equal(state.backfilledAt, null);
+    assert.equal(activationStateSchema.safeParse(state).success, true);
+  });
+
+  it("returns the existing state without resetting it", async () => {
+    const user = await ctx.createUser();
+    const firstAt = new Date("2026-07-12T10:00:00.000Z");
+    const secondAt = new Date("2026-07-13T10:00:00.000Z");
+
+    const first = await repo.createIfAbsent(user.userId, firstAt);
+    const second = await repo.createIfAbsent(user.userId, secondAt);
+
+    assert.equal(second._id.toHexString(), first._id.toHexString());
+    assert.equal(second.createdAt.toISOString(), firstAt.toISOString());
+    assert.equal(second.updatedAt.toISOString(), firstAt.toISOString());
+  });
+
+  it("finds by user id and returns null for a missing state", async () => {
+    const user = await ctx.createUser();
+    const missingUser = await ctx.createUser();
+    const created = await repo.createIfAbsent(user.userId);
+
+    const found = await repo.findByUserId(user.userId);
+    const missing = await repo.findByUserId(missingUser.userId);
+
+    assert.equal(found?._id.toHexString(), created._id.toHexString());
+    assert.equal(missing, null);
+  });
+
+  it("creates the indexes needed by future reminder sweeps", async () => {
+    const collection = ctx.dbAccessor.getCollection<ActivationState>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.ActivationStates,
+    );
+    const indexes = await collection.indexes();
+    const indexByName = new Map(indexes.map((index) => [index.name, index]));
+
+    assert.equal(indexByName.get("userId_1")?.unique, true);
+    assert.deepEqual(indexByName.get("userId_1")?.key, { userId: 1 });
+    assert.deepEqual(indexByName.get("bridgeSetupAt_1_bridgeReminder1SentAt_1_bridgeReminderBaseAt_1")?.key, {
+      bridgeSetupAt: 1,
+      bridgeReminder1SentAt: 1,
+      bridgeReminderBaseAt: 1,
+    });
+    assert.deepEqual(indexByName.get("bridgeSetupAt_1_bridgeReminder2SentAt_1_bridgeReminderBaseAt_1")?.key, {
+      bridgeSetupAt: 1,
+      bridgeReminder2SentAt: 1,
+      bridgeReminderBaseAt: 1,
+    });
+    assert.deepEqual(indexByName.get("firstSessionAt_1_sessionReminderSentAt_1_sessionReminderBaseAt_1")?.key, {
+      firstSessionAt: 1,
+      sessionReminderSentAt: 1,
+      sessionReminderBaseAt: 1,
+    });
+  });
+});

--- a/tests/repositories/activation-state-repo.test.ts
+++ b/tests/repositories/activation-state-repo.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
+import { InternalServerError } from "../../src/lib/errors.js";
 import { activationStateSchema, type ActivationState } from "../../src/models/documents.js";
 import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
 import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
@@ -52,6 +53,14 @@ describe("ActivationStateRepository", () => {
     assert.equal(second.updatedAt.toISOString(), firstAt.toISOString());
   });
 
+  it("rejects creation with an invalid user id", async () => {
+    await assert.rejects(
+      () => repo.createIfAbsent("invalid-id"),
+      (error: unknown) =>
+        error instanceof InternalServerError && error.debugMessage === "Invalid activation state userId",
+    );
+  });
+
   it("finds by user id and returns null for a missing state", async () => {
     const user = await ctx.createUser();
     const missingUser = await ctx.createUser();
@@ -62,6 +71,10 @@ describe("ActivationStateRepository", () => {
 
     assert.equal(found?._id.toHexString(), created._id.toHexString());
     assert.equal(missing, null);
+  });
+
+  it("returns null when finding with an invalid user id", async () => {
+    assert.equal(await repo.findByUserId("invalid-id"), null);
   });
 
   it("creates the indexes needed by future reminder sweeps", async () => {

--- a/tests/repositories/bridge-repo.test.ts
+++ b/tests/repositories/bridge-repo.test.ts
@@ -2,6 +2,8 @@ import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
 import { BridgeRepository } from "../../src/repositories/bridge-repo.js";
+import type { Bridge } from "../../src/models/documents.js";
+import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
 
 describe("BridgeRepository", () => {
   let ctx: TestContext;
@@ -88,6 +90,24 @@ describe("BridgeRepository", () => {
     const bridges = await repo.findByUserId(user.userId);
     assert.equal(bridges.length, 1);
     assert.equal(bridges[0]?.bridgeId, b1.bridgeId);
+  });
+
+  it("findEarliestAddedAt includes revoked bridges", async () => {
+    const user = await ctx.createUser();
+    const repo = new BridgeRepository(ctx.dbAccessor);
+    const first = await repo.register({ userId: user.userId, name: "First", platform: "macos" });
+    const second = await repo.register({ userId: user.userId, name: "Second", platform: "linux" });
+    const firstAt = new Date("2026-07-10T10:00:00.000Z");
+    const secondAt = new Date("2026-07-12T10:00:00.000Z");
+    const collection = ctx.dbAccessor.getCollection<Bridge>(MongoDbDatabase.Auth, AuthDbCollection.Bridges);
+    await collection.updateOne({ bridgeId: first.bridgeId }, { $set: { addedAt: firstAt } });
+    await collection.updateOne({ bridgeId: second.bridgeId }, { $set: { addedAt: secondAt } });
+    await repo.revoke(first.bridgeId, user.userId, new Date("2026-07-13T10:00:00.000Z"));
+
+    assert.equal((await repo.findEarliestAddedAt(user.userId))?.toISOString(), firstAt.toISOString());
+    assert.equal(await repo.findEarliestAddedAt("invalid-id"), null);
+    const index = (await collection.indexes()).find((candidate) => candidate.name === "userId_1_addedAt_1");
+    assert.deepEqual(index?.key, { userId: 1, addedAt: 1 });
   });
 
   it("register is not an upsert — second call creates a new row", async () => {

--- a/tests/repositories/daily-usage-repo.test.ts
+++ b/tests/repositories/daily-usage-repo.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { ObjectId } from "mongodb";
+import type { DailyUsage } from "../../src/models/documents.js";
+import { DailyUsageRepository } from "../../src/repositories/daily-usage-repo.js";
+import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+describe("DailyUsageRepository", () => {
+  let ctx: TestContext;
+  let repo: DailyUsageRepository;
+
+  before(async () => {
+    ctx = await createTestApp();
+    repo = new DailyUsageRepository(ctx.dbAccessor);
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("findEarliestMetadataRequestAt returns the first day with metadata usage", async () => {
+    const user = await ctx.createUser();
+    const noMetadataAt = new Date("2026-07-09T08:00:00.000Z");
+    const firstMetadataAt = new Date("2026-07-10T09:00:00.000Z");
+    const laterMetadataAt = new Date("2026-07-12T10:00:00.000Z");
+    const collection = ctx.dbAccessor.getCollection<DailyUsage>(MongoDbDatabase.Auth, AuthDbCollection.DailyUsage);
+    await collection.insertMany([
+      {
+        _id: new ObjectId(),
+        userId: new ObjectId(user.userId),
+        date: "2026-07-09",
+        transcriptionSeconds: 10,
+        metadataRequestCount: 0,
+        createdAt: noMetadataAt,
+        updatedAt: noMetadataAt,
+      },
+      {
+        _id: new ObjectId(),
+        userId: new ObjectId(user.userId),
+        date: "2026-07-10",
+        transcriptionSeconds: 0,
+        metadataRequestCount: 1,
+        createdAt: firstMetadataAt,
+        updatedAt: firstMetadataAt,
+      },
+      {
+        _id: new ObjectId(),
+        userId: new ObjectId(user.userId),
+        date: "2026-07-12",
+        transcriptionSeconds: 0,
+        metadataRequestCount: 2,
+        createdAt: laterMetadataAt,
+        updatedAt: laterMetadataAt,
+      },
+    ]);
+
+    assert.equal((await repo.findEarliestMetadataRequestAt(user.userId))?.toISOString(), firstMetadataAt.toISOString());
+    assert.equal(await repo.findEarliestMetadataRequestAt("invalid-id"), null);
+  });
+});

--- a/tests/routes/bridges.test.ts
+++ b/tests/routes/bridges.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, before, after, beforeEach } from "node:test";
+import { describe, it, before, after, afterEach, beforeEach, mock } from "node:test";
 import assert from "node:assert/strict";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
+import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
+import { ActivationService } from "../../src/services/activation-service.js";
 import { BridgeStateTracker } from "../../src/services/bridge-state-tracker.js";
 import type { NotificationService } from "../../src/services/notification-service.js";
 
@@ -14,6 +16,7 @@ type BridgeSummaryBody = {
 
 describe("/auth/bridges routes", () => {
   let ctx: TestContext;
+  let activationStateRepo: ActivationStateRepository;
   const cancelledLegacyUsers: string[] = [];
   const cancelledBridgeKeys: { userId: string; bridgeId: string }[] = [];
 
@@ -31,6 +34,7 @@ describe("/auth/bridges routes", () => {
 
   before(async () => {
     ctx = await createTestApp({ bridgeStateTracker: bridgeStateTrackerMock });
+    activationStateRepo = new ActivationStateRepository(ctx.dbAccessor);
   });
 
   after(async () => {
@@ -40,6 +44,10 @@ describe("/auth/bridges routes", () => {
   beforeEach(() => {
     cancelledLegacyUsers.length = 0;
     cancelledBridgeKeys.length = 0;
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
   });
 
   async function registerBridge(accessToken: string, payload: { name: string; platform: string; bridgeId?: string }) {
@@ -68,6 +76,23 @@ describe("/auth/bridges routes", () => {
     assert.ok(typeof body.addedAt === "string");
     assert.ok(!("status" in body), "status must not leak into the API");
     assert.ok(!("bridgeToken" in body), "bridgeToken must not exist in the API");
+    const activationState = await activationStateRepo.findByUserId(user.userId);
+    assert.equal(activationState?.bridgeSetupAt?.toISOString(), body.addedAt);
+    assert.equal(activationState?.sessionReminderBaseAt, null);
+  });
+
+  it("POST /auth/bridges succeeds when activation recording fails", async () => {
+    const user = await ctx.createUser();
+    const recordMock = mock.method(ActivationService.prototype, "recordBridgeSetup", async () => {
+      throw new Error("activation unavailable");
+    });
+    const warnMock = mock.method(console, "warn", () => {});
+
+    const res = await registerBridge(user.accessToken, { name: "Still Registered", platform: "linux" });
+
+    assert.equal(res.statusCode, 201);
+    assert.equal(recordMock.mock.callCount(), 1);
+    assert.equal(warnMock.mock.callCount(), 1);
   });
 
   it("POST /auth/bridges with an owned bridgeId updates it in place and returns 200", async () => {

--- a/tests/services/activation-service.test.ts
+++ b/tests/services/activation-service.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { ObjectId } from "mongodb";
+import type { Bridge, DailyUsage, DeviceToken } from "../../src/models/documents.js";
+import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
+import { BridgeRepository } from "../../src/repositories/bridge-repo.js";
+import { DailyUsageRepository } from "../../src/repositories/daily-usage-repo.js";
+import { DeviceTokenRepository } from "../../src/repositories/device-token-repo.js";
+import { ActivationService } from "../../src/services/activation-service.js";
+import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+describe("ActivationService", () => {
+  let ctx: TestContext;
+  let activationStateRepo: ActivationStateRepository;
+  let bridgeRepo: BridgeRepository;
+  let dailyUsageRepo: DailyUsageRepository;
+  let deviceTokenRepo: DeviceTokenRepository;
+  let service: ActivationService;
+
+  before(async () => {
+    ctx = await createTestApp();
+    activationStateRepo = new ActivationStateRepository(ctx.dbAccessor);
+    bridgeRepo = new BridgeRepository(ctx.dbAccessor);
+    dailyUsageRepo = new DailyUsageRepository(ctx.dbAccessor);
+    deviceTokenRepo = new DeviceTokenRepository(ctx.dbAccessor);
+    service = new ActivationService({ activationStateRepo, bridgeRepo, dailyUsageRepo, deviceTokenRepo });
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("enrolls mobile setup and reconciles historical bridge and session milestones", async () => {
+    const user = await ctx.createUser();
+    const mobileAt = new Date("2026-07-10T08:00:00.000Z");
+    const bridgeAt = new Date("2026-07-11T09:00:00.000Z");
+    const sessionAt = new Date("2026-07-12T10:00:00.000Z");
+    const observedAt = new Date("2026-07-15T10:00:00.000Z");
+    await ctx.dbAccessor.getCollection<DeviceToken>(MongoDbDatabase.Auth, AuthDbCollection.DeviceTokens).insertOne({
+      _id: new ObjectId(),
+      userId: new ObjectId(user.userId),
+      token: `activation-token-${user.userId}`,
+      platform: "ios",
+      createdAt: mobileAt,
+      updatedAt: mobileAt,
+    });
+    const bridge = await bridgeRepo.register({ userId: user.userId, name: "Historical", platform: "macos" });
+    await ctx.dbAccessor
+      .getCollection<Bridge>(MongoDbDatabase.Auth, AuthDbCollection.Bridges)
+      .updateOne({ bridgeId: bridge.bridgeId }, { $set: { addedAt: bridgeAt, revokedAt: observedAt } });
+    await ctx.dbAccessor.getCollection<DailyUsage>(MongoDbDatabase.Auth, AuthDbCollection.DailyUsage).insertOne({
+      _id: new ObjectId(),
+      userId: new ObjectId(user.userId),
+      date: "2026-07-12",
+      transcriptionSeconds: 0,
+      metadataRequestCount: 1,
+      createdAt: sessionAt,
+      updatedAt: sessionAt,
+    });
+
+    const state = await service.recordMobileSetup(user.userId, observedAt);
+
+    assert.equal(state.mobileSetupAt?.toISOString(), mobileAt.toISOString());
+    assert.equal(state.bridgeSetupAt?.toISOString(), bridgeAt.toISOString());
+    assert.equal(state.firstSessionAt?.toISOString(), sessionAt.toISOString());
+    assert.equal(state.bridgeReminderBaseAt?.toISOString(), mobileAt.toISOString());
+    assert.equal(state.sessionReminderBaseAt?.toISOString(), bridgeAt.toISOString());
+  });
+
+  it("records bridge and session milestones before mobile setup without creating reminder baselines", async () => {
+    const user = await ctx.createUser();
+    const bridgeAt = new Date("2026-07-12T10:00:00.000Z");
+    const sessionAt = new Date("2026-07-12T11:00:00.000Z");
+
+    await service.recordBridgeSetup(user.userId, bridgeAt);
+    const state = await service.recordFirstSession(user.userId, sessionAt);
+
+    assert.equal(state.mobileSetupAt, null);
+    assert.equal(state.bridgeSetupAt?.toISOString(), bridgeAt.toISOString());
+    assert.equal(state.firstSessionAt?.toISOString(), sessionAt.toISOString());
+    assert.equal(state.bridgeReminderBaseAt, null);
+    assert.equal(state.sessionReminderBaseAt, null);
+  });
+
+  it("uses the earliest historical bridge when recording a later registration", async () => {
+    const user = await ctx.createUser();
+    const historicalAt = new Date("2026-07-10T10:00:00.000Z");
+    const observedAt = new Date("2026-07-15T10:00:00.000Z");
+    const historical = await bridgeRepo.register({ userId: user.userId, name: "Historical", platform: "macos" });
+    const collection = ctx.dbAccessor.getCollection<Bridge>(MongoDbDatabase.Auth, AuthDbCollection.Bridges);
+    await collection.updateOne(
+      { bridgeId: historical.bridgeId },
+      { $set: { addedAt: historicalAt, revokedAt: observedAt } },
+    );
+    await bridgeRepo.register({ userId: user.userId, name: "Current", platform: "linux" });
+
+    const state = await service.recordBridgeSetup(user.userId, observedAt);
+
+    assert.equal(state.bridgeSetupAt?.toISOString(), historicalAt.toISOString());
+  });
+
+  it("uses historical metadata evidence when recording a later session request", async () => {
+    const user = await ctx.createUser();
+    const historicalAt = new Date("2026-07-10T10:00:00.000Z");
+    const observedAt = new Date("2026-07-15T10:00:00.000Z");
+    await ctx.dbAccessor.getCollection<DailyUsage>(MongoDbDatabase.Auth, AuthDbCollection.DailyUsage).insertOne({
+      _id: new ObjectId(),
+      userId: new ObjectId(user.userId),
+      date: "2026-07-10",
+      transcriptionSeconds: 0,
+      metadataRequestCount: 1,
+      createdAt: historicalAt,
+      updatedAt: historicalAt,
+    });
+
+    const state = await service.recordFirstSession(user.userId, observedAt);
+
+    assert.equal(state.firstSessionAt?.toISOString(), historicalAt.toISOString());
+  });
+
+  it("retries unresolved historical reconciliation on later token registration", async () => {
+    const user = await ctx.createUser();
+    const mobileAt = new Date("2026-07-10T08:00:00.000Z");
+    const bridgeAt = new Date("2026-07-11T09:00:00.000Z");
+    const sessionAt = new Date("2026-07-12T10:00:00.000Z");
+    const collection = ctx.dbAccessor.getCollection<DeviceToken>(MongoDbDatabase.Auth, AuthDbCollection.DeviceTokens);
+    await collection.insertOne({
+      _id: new ObjectId(),
+      userId: new ObjectId(user.userId),
+      token: `retry-token-${user.userId}`,
+      platform: "ios",
+      createdAt: mobileAt,
+      updatedAt: mobileAt,
+    });
+    await service.recordMobileSetup(user.userId, mobileAt);
+
+    const bridge = await bridgeRepo.register({ userId: user.userId, name: "Later", platform: "macos" });
+    await ctx.dbAccessor
+      .getCollection<Bridge>(MongoDbDatabase.Auth, AuthDbCollection.Bridges)
+      .updateOne({ bridgeId: bridge.bridgeId }, { $set: { addedAt: bridgeAt } });
+    await ctx.dbAccessor.getCollection<DailyUsage>(MongoDbDatabase.Auth, AuthDbCollection.DailyUsage).insertOne({
+      _id: new ObjectId(),
+      userId: new ObjectId(user.userId),
+      date: "2026-07-12",
+      transcriptionSeconds: 0,
+      metadataRequestCount: 1,
+      createdAt: sessionAt,
+      updatedAt: sessionAt,
+    });
+
+    const state = await service.recordMobileSetup(user.userId, new Date("2026-07-15T10:00:00.000Z"));
+
+    assert.equal(state.mobileSetupAt?.toISOString(), mobileAt.toISOString());
+    assert.equal(state.bridgeSetupAt?.toISOString(), bridgeAt.toISOString());
+    assert.equal(state.firstSessionAt?.toISOString(), sessionAt.toISOString());
+    assert.equal(state.sessionReminderBaseAt?.toISOString(), bridgeAt.toISOString());
+  });
+
+  it("falls back to the observed registration time when no token history is available", async () => {
+    const user = await ctx.createUser();
+    const observedAt = new Date("2026-07-12T10:00:00.000Z");
+
+    const state = await service.recordMobileSetup(user.userId, observedAt);
+
+    assert.equal(state.mobileSetupAt?.toISOString(), observedAt.toISOString());
+    assert.equal(state.bridgeReminderBaseAt?.toISOString(), observedAt.toISOString());
+  });
+});

--- a/tests/services/activation-service.test.ts
+++ b/tests/services/activation-service.test.ts
@@ -100,6 +100,20 @@ describe("ActivationService", () => {
     assert.equal(state.bridgeSetupAt?.toISOString(), historicalAt.toISOString());
   });
 
+  it("repairs mobile setup from token history when recording bridge setup", async () => {
+    const user = await ctx.createUser();
+    await deviceTokenRepo.upsertToken(user.userId, `bridge-repair-token-${user.userId}`, "ios");
+    const mobileAt = await deviceTokenRepo.findEarliestCreatedAt(user.userId);
+    const bridge = await bridgeRepo.register({ userId: user.userId, name: "Repair", platform: "macos" });
+
+    const state = await service.recordBridgeSetup(user.userId, bridge.addedAt);
+
+    assert.equal(state.mobileSetupAt?.toISOString(), mobileAt?.toISOString());
+    assert.equal(state.bridgeSetupAt?.toISOString(), bridge.addedAt.toISOString());
+    assert.equal(state.bridgeReminderBaseAt?.toISOString(), mobileAt?.toISOString());
+    assert.equal(state.sessionReminderBaseAt?.toISOString(), bridge.addedAt.toISOString());
+  });
+
   it("uses historical metadata evidence when recording a later session request", async () => {
     const user = await ctx.createUser();
     const historicalAt = new Date("2026-07-10T10:00:00.000Z");
@@ -117,6 +131,20 @@ describe("ActivationService", () => {
     const state = await service.recordFirstSession(user.userId, observedAt);
 
     assert.equal(state.firstSessionAt?.toISOString(), historicalAt.toISOString());
+  });
+
+  it("repairs bridge setup from bridge history when recording a session", async () => {
+    const user = await ctx.createUser();
+    const mobileAt = new Date("2026-07-10T10:00:00.000Z");
+    const sessionAt = new Date("2026-07-12T10:00:00.000Z");
+    await activationStateRepo.recordMilestones(user.userId, { mobileSetupAt: mobileAt }, mobileAt);
+    const bridge = await bridgeRepo.register({ userId: user.userId, name: "Repair", platform: "linux" });
+
+    const state = await service.recordFirstSession(user.userId, sessionAt);
+
+    assert.equal(state.bridgeSetupAt?.toISOString(), bridge.addedAt.toISOString());
+    assert.equal(state.firstSessionAt?.toISOString(), sessionAt.toISOString());
+    assert.equal(state.sessionReminderBaseAt?.toISOString(), bridge.addedAt.toISOString());
   });
 
   it("retries unresolved historical reconciliation on later token registration", async () => {

--- a/tests/services/activation-service.test.ts
+++ b/tests/services/activation-service.test.ts
@@ -147,6 +147,17 @@ describe("ActivationService", () => {
     assert.equal(state.sessionReminderBaseAt?.toISOString(), bridge.addedAt.toISOString());
   });
 
+  it("preserves an earlier observed session time when its initial read loses a race", async () => {
+    const user = await ctx.createUser();
+    const earlierAt = new Date("2026-07-12T10:00:00.000Z");
+    const laterAt = new Date("2026-07-12T10:00:01.000Z");
+    await activationStateRepo.recordMilestones(user.userId, { firstSessionAt: laterAt }, laterAt);
+
+    const state = await service.recordFirstSession(user.userId, earlierAt);
+
+    assert.equal(state.firstSessionAt?.toISOString(), earlierAt.toISOString());
+  });
+
   it("retries unresolved historical reconciliation on later token registration", async () => {
     const user = await ctx.createUser();
     const mobileAt = new Date("2026-07-10T08:00:00.000Z");

--- a/tests/session-metadata.test.ts
+++ b/tests/session-metadata.test.ts
@@ -2,13 +2,17 @@ import { describe, it, before, after, mock, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { createTestApp, type TestContext } from "./helpers/setup.js";
 import { SessionMetadataService } from "../src/services/session-metadata-service.js";
+import { ActivationService } from "../src/services/activation-service.js";
+import { ActivationStateRepository } from "../src/repositories/activation-state-repo.js";
 import { QuotaExceededError, InternalServerError } from "../src/lib/errors.js";
 
 describe("POST /sessions/generate-metadata", () => {
   let ctx: TestContext;
+  let activationStateRepo: ActivationStateRepository;
 
   before(async () => {
     ctx = await createTestApp();
+    activationStateRepo = new ActivationStateRepository(ctx.dbAccessor);
   });
 
   after(async () => {
@@ -43,6 +47,34 @@ describe("POST /sessions/generate-metadata", () => {
     assert.equal(body.title, "Fix Auth Bug");
     assert.equal(body.branchName, "fix-auth-bug");
     assert.equal(body.worktreeName, "fix-auth-bug");
+    assert.ok((await activationStateRepo.findByUserId(user.userId))?.firstSessionAt);
+  });
+
+  it("returns 200 when activation recording fails", async () => {
+    const user = await ctx.createUser();
+    const recordMock = mock.method(ActivationService.prototype, "recordFirstSession", async () => {
+      throw new Error("activation unavailable");
+    });
+    const warnMock = mock.method(console, "warn", () => {});
+    mock.method(SessionMetadataService.prototype, "generateMetadata", async () => ({
+      title: "Still Works",
+      branchName: "still-works",
+      worktreeName: "still-works",
+    }));
+
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/sessions/generate-metadata",
+      headers: {
+        authorization: `Bearer ${user.accessToken}`,
+        "content-type": "application/json",
+      },
+      payload: JSON.stringify({ firstMessage: "Keep creating the session" }),
+    });
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(recordMock.mock.callCount(), 1);
+    assert.equal(warnMock.mock.callCount(), 1);
   });
 
   it("returns 401 when no Authorization header is provided", async () => {
@@ -113,5 +145,6 @@ describe("POST /sessions/generate-metadata", () => {
 
     assert.equal(res.statusCode, 500);
     assert.deepEqual(res.json(), { error: "internal_server_error" });
+    assert.ok((await activationStateRepo.findByUserId(user.userId))?.firstSessionAt);
   });
 });


### PR DESCRIPTION
## Summary

- Record set-once activation milestones and derive reminder baselines atomically.
- Reconcile the earliest mobile, bridge, and session evidence and wire failure-isolated hooks into token, bridge, and metadata endpoints.
- Preserve historical correctness for revoked bridges, transferred device tokens, retry repair, and lifetime activation state.
- Update the staged implementation plan so PR3 remains the next unstarted slice.

## Behavior

- This slice records state only; it adds no scheduler, reminder configuration, push sends, or backfill command.
- The first-session milestone is recorded before metadata generation because metadata failures are non-fatal to bridge session creation.
- Activation persistence failures do not change existing endpoint responses.

## Testing

- Focused activation/repository/route suite: 99 passed.
- `npm test`: 351 passed, 1 skipped, 0 failed.
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run circular-dependencies`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records activation milestones for mobile setup, bridge setup, and first session with atomic, set-once writes, historical reconciliation, and tightened race/index guards. Hooks are failure-isolated; no reminders are sent yet.

- New Features
  - Added ActivationService to reconcile and record milestones using device tokens, bridges (including revoked), and daily usage; repairs missing milestones from any event hook.
  - Implemented atomic `recordMilestones` in `ActivationStateRepository`, with earliest-wins for concurrent first-session writes; derives `bridgeReminderBaseAt` and the later-of mobile/bridge `sessionReminderBaseAt`.
  - Updated `DeviceTokenRepository.upsertToken` to reset `createdAt` when a token transfers accounts and validate `userId`; added `findEarliestCreatedAt` and index `{ userId: 1, createdAt: 1 }`.
  - Added `BridgeRepository.findEarliestAddedAt` and index `{ userId: 1, addedAt: 1 }`.
  - Added `DailyUsageRepository.findEarliestMetadataRequestAt` from `metadataRequestCount > 0` (uses earliest day’s `createdAt`).
  - Wired hooks in `/notifications/register-token`, `/auth/bridges`, and `/sessions/generate-metadata` (first session recorded before metadata generation); errors are logged and do not affect responses.
  - Documented that logout/account revoke does not clear lifetime activation history.

- Bug Fixes
  - Tightened race and index guards: retain earlier first-session timestamps when out-of-order writes occur, and drop the superseded token index `{ userId: 1 }` only after confirming the compound `{ userId: 1, createdAt: 1 }` exists with matching options.

<sup>Written for commit 4d7d5701362b4c16e961724de2ceccebb9952ea3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

