### PR TITLE
fix(notifications): support desktop token platforms

### DIFF
--- a/.plans/activation-reminders/CONSIDERATIONS.md
+++ b/.plans/activation-reminders/CONSIDERATIONS.md
@@ -30,7 +30,9 @@ Reminder delivery is sequential within each kind. The default batch is 100, whic
 
 ### Mobile Setup
 
-The first device-token registration is used rather than user creation because it means the app is installed, authenticated, has notification permission, and can actually receive a reminder. Users without a device token may still be represented during active backfill for funnel completeness, but are not reminder-eligible. When the same FCM token moves between accounts, its token-document `createdAt` resets for the new owner so one user's setup timestamp is not imported into another user's activation history.
+The first iOS/Android device-token registration is used rather than user creation because it means the mobile app is installed, authenticated, has notification permission, and can actually receive a reminder. Desktop tokens remain valid notification endpoints but do not establish or reconcile this phone-oriented milestone. Users without a mobile device token may still be represented during active backfill for funnel completeness, but are not reminder-eligible. When the same FCM token moves between accounts, its token-document `createdAt` resets for the new owner so one user's setup timestamp is not imported into another user's activation history.
+
+Token timestamps also preserve the mobile boundary when one FCM token changes platform for the same owner. Mobile-to-mobile and desktop-to-desktop updates retain the original `createdAt`. Mobile-to-desktop updates retain it while the document is excluded from mobile evidence. Desktop-to-mobile updates reset `createdAt` at the first qualifying mobile registration. Concurrent updates to one token serialize atomically; each update evaluates the owner and platform left by the preceding write, and the last serialized update determines the final owner and platform.
 
 ### Bridge Setup
 
@@ -109,7 +111,7 @@ Milestone logs are emitted only by the atomic update that first claims a previou
 - The first apply claims `backfilledAt` atomically and may replace only the currently relevant unsent stage's old organic baseline with `backfilledAt + jitter`; later runs cannot move it again. The update pipeline chooses that stage after merging historical evidence and milestones committed before the atomic write. A milestone committed afterward follows the normal organic stage-transition baseline rules.
 - The two bridge reminders share one baseline. If bridge reminder 1 was already sent, bridge reminder 2 is the currently relevant unsent reminder and receives the controlled baseline.
 - Backfill does not intentionally target fully activated users; a narrow send/completion race may still produce a stale reminder.
-- Users without device tokens are not made reminder-eligible.
+- Users without iOS/Android device tokens are not made reminder-eligible by backfill; desktop-only tokens are not mobile setup evidence.
 - Operational counts are reviewed before applying. Proposed counts describe the pre-write snapshot; applied counts describe the atomic post-write state and may differ when organic milestones race the command.
 - Dry-run performs no writes, including index creation.
 
@@ -123,3 +125,20 @@ Each slice must be safe to merge and deploy independently:
 - PR4 is inert until an operator runs it with apply enabled.
 
 No plaintext environment files or credentials are introduced. Configuration changes in PR3 follow the existing Zod/env conventions and encrypted environment workflow.
+
+### Desktop Token Rollback
+
+PR #43 deploys desktop-token acceptance together with mobile-only activation reconciliation. Its `master` base rejects desktop platforms and assumes every persisted token is mobile evidence, so rolling back to that code while desktop token documents remain is unsafe. Prefer rolling forward. If rollback is unavoidable:
+
+1. Quiesce every auth-server instance so no token can be inserted during cleanup.
+2. Record the affected document count, without logging token values, then delete desktop token documents:
+
+   ```javascript
+   db.deviceTokens.countDocuments({ platform: { $in: ["macos", "windows", "linux"] } });
+   db.deviceTokens.deleteMany({ platform: { $in: ["macos", "windows", "linux"] } });
+   ```
+
+3. Verify the same `countDocuments` query returns `0`.
+4. Only then deploy the old server and resume traffic. Do not run activation backfill before the zero-count check.
+
+This preserves iOS/Android tokens and valid lifetime activation history, but desktop push delivery remains unavailable until the fixed version is restored.

--- a/.plans/activation-reminders/CONSIDERATIONS.md
+++ b/.plans/activation-reminders/CONSIDERATIONS.md
@@ -28,11 +28,11 @@ Reminder delivery is sequential within each kind. The default batch is 100, whic
 
 ## Milestone Semantics
 
-### Mobile Setup
+### App Setup
 
-The first iOS/Android device-token registration is used rather than user creation because it means the mobile app is installed, authenticated, has notification permission, and can actually receive a reminder. Desktop tokens remain valid notification endpoints but do not establish or reconcile this phone-oriented milestone. Users without a mobile device token may still be represented during active backfill for funnel completeness, but are not reminder-eligible. When the same FCM token moves between accounts, its token-document `createdAt` resets for the new owner so one user's setup timestamp is not imported into another user's activation history.
+The first device-token registration from any supported app platform is used rather than user creation because it proves that an app is installed, authenticated, and has produced a push token. iOS, Android, macOS, Windows, and Linux registrations are equal evidence for this first funnel stage. Users without any device token may still be represented during active backfill for funnel completeness, but are not reminder-eligible. When the same FCM token moves between accounts, its token-document `createdAt` resets for the new owner so one user's setup timestamp is not imported into another user's activation history.
 
-Token timestamps also preserve the mobile boundary when one FCM token changes platform for the same owner. Mobile-to-mobile and desktop-to-desktop updates retain the original `createdAt`. Mobile-to-desktop updates retain it while the document is excluded from mobile evidence. Desktop-to-mobile updates reset `createdAt` at the first qualifying mobile registration. Concurrent updates to one token serialize atomically; each update evaluates the owner and platform left by the preceding write, and the last serialized update determines the final owner and platform.
+The persisted `mobileSetupAt` field, `MobileIncomplete` stage value, and `mobile_setup` structured-log value are historical names retained to avoid a data migration and analytics break. They all mean app setup across every supported platform. A same-owner token update retains its original `createdAt` even when its platform changes; an ownership change resets `createdAt`. Concurrent updates to one token serialize atomically, each update evaluates the owner left by the preceding write, and the last serialized update determines the final owner and platform.
 
 ### Bridge Setup
 
@@ -54,8 +54,8 @@ Real milestone timestamps and reminder baselines serve different purposes and mu
 
 - Real timestamps support funnel analytics and historical reconciliation.
 - Reminder baselines control when the current campaign begins.
-- Organic bridge reminders use the mobile setup timestamp.
-- Organic session reminders use the later of mobile and bridge setup.
+- Organic bridge reminders use the app setup timestamp stored in `mobileSetupAt`.
+- Organic session reminders use the later of app and bridge setup.
 - Backfilled incomplete users preserve old real timestamps but use a new, jittered baseline for a controlled re-engagement wave.
 
 ## Account Revocation
@@ -111,7 +111,7 @@ Milestone logs are emitted only by the atomic update that first claims a previou
 - The first apply claims `backfilledAt` atomically and may replace only the currently relevant unsent stage's old organic baseline with `backfilledAt + jitter`; later runs cannot move it again. The update pipeline chooses that stage after merging historical evidence and milestones committed before the atomic write. A milestone committed afterward follows the normal organic stage-transition baseline rules.
 - The two bridge reminders share one baseline. If bridge reminder 1 was already sent, bridge reminder 2 is the currently relevant unsent reminder and receives the controlled baseline.
 - Backfill does not intentionally target fully activated users; a narrow send/completion race may still produce a stale reminder.
-- Users without iOS/Android device tokens are not made reminder-eligible by backfill; desktop-only tokens are not mobile setup evidence.
+- Users without a device token on any supported app platform are not made reminder-eligible by backfill.
 - Operational counts are reviewed before applying. Proposed counts describe the pre-write snapshot; applied counts describe the atomic post-write state and may differ when organic milestones race the command.
 - Dry-run performs no writes, including index creation.
 
@@ -126,19 +126,10 @@ Each slice must be safe to merge and deploy independently:
 
 No plaintext environment files or credentials are introduced. Configuration changes in PR3 follow the existing Zod/env conventions and encrypted environment workflow.
 
-### Desktop Token Rollback
+### App-Platform Deployment And Rollback
 
-PR #43 deploys desktop-token acceptance together with mobile-only activation reconciliation. Its `master` base rejects desktop platforms and assumes every persisted token is mobile evidence, so rolling back to that code while desktop token documents remain is unsafe. Prefer rolling forward. If rollback is unavoidable:
+PR #43 widens the token-registration boundary from iOS/Android to iOS, Android, macOS, Windows, and Linux. Deploy it before releasing a future Windows or Linux app producer. The current apps producer emits iOS, Android, and macOS.
 
-1. Quiesce every auth-server instance so no token can be inserted during cleanup.
-2. Record the affected document count, without logging token values, then delete desktop token documents:
+If a newly supported registration reaches the older auth server, the request receives a 400 and the client logs the failure. The current client does not retry on a timer; registration remains absent until application restart, a subsequent authentication-state transition, or FCM token refresh. A future Windows/Linux producer must therefore enforce the auth-first release gate or add and test bounded retry behavior.
 
-   ```javascript
-   db.deviceTokens.countDocuments({ platform: { $in: ["macos", "windows", "linux"] } });
-   db.deviceTokens.deleteMany({ platform: { $in: ["macos", "windows", "linux"] } });
-   ```
-
-3. Verify the same `countDocuments` query returns `0`.
-4. Only then deploy the old server and resume traffic. Do not run activation backfill before the zero-count check.
-
-This preserves iOS/Android tokens and valid lifetime activation history, but desktop push delivery remains unavailable until the fixed version is restored.
+Rolling back to the pre-PR server restores iOS/Android-only request validation, so desktop clients cannot add or refresh registrations until the fixed version returns. Existing desktop token documents do not require cleanup: repository reads do not runtime-parse or branch on their platform, and those documents remain valid push endpoints and app-setup evidence. Prefer rolling forward so desktop registrations continue to work.

--- a/.plans/activation-reminders/PLAN.md
+++ b/.plans/activation-reminders/PLAN.md
@@ -4,7 +4,7 @@
 
 Improve user activation by measuring and nudging users through this funnel:
 
-1. Mobile setup: the user registers a push-notification device token.
+1. Mobile setup: the user registers an iOS or Android push-notification device token.
 2. Bridge setup: the user registers the desktop bridge.
 3. Full activation: the user creates a new session, represented by the first valid authenticated call to `POST /sessions/generate-metadata`.
 
@@ -39,7 +39,7 @@ This file is the authoritative implementation tracker. A future session should r
 - V1 implementation is auth-server-only. Full-stack changes remain permissible later, but no Flutter, bridge, or relay changes are needed for V1.
 - Existing FCM infrastructure and the `system_update` notification category are reused.
 - Notification taps rely on the app's default open behavior; V1 adds no activation-specific deep link.
-- Mobile setup is the first device-token registration, not account creation.
+- Mobile setup is the first iOS/Android device-token registration, not account creation. Desktop tokens remain valid push endpoints but do not establish this milestone.
 - Bridge setup is the first bridge registration, not the first relay connection.
 - First session is the first valid authenticated `POST /sessions/generate-metadata` call. Metadata failure is non-fatal in the bridge and session creation continues, so the response does not need to succeed. This deliberately measures creation of a new text-backed session, not messages in existing sessions.
 - Bridge reminder 1 is due approximately 2 hours after mobile setup.
@@ -98,7 +98,7 @@ Planned indexes:
 - `{ bridgeSetupAt: 1, bridgeReminder1SentAt: 1, bridgeReminderBaseAt: 1 }`.
 - `{ bridgeSetupAt: 1, bridgeReminder2SentAt: 1, bridgeReminderBaseAt: 1 }`.
 - `{ firstSessionAt: 1, sessionReminderSentAt: 1, sessionReminderBaseAt: 1 }`.
-- Supporting historical mobile reconciliation: `deviceTokens { userId: 1, createdAt: 1 }`.
+- Supporting historical iOS/Android token reconciliation: `deviceTokens { userId: 1, createdAt: 1 }`.
 - Supporting historical bridge reconciliation: `bridges { userId: 1, addedAt: 1 }`.
 
 The equality fields precede each due-time range field so the future sweep queries can use the indexes directly.
@@ -184,7 +184,7 @@ Acceptance criteria:
 - [x] Add `ActivationService` to own reconciliation and milestone invariants.
 - [x] Add an atomic milestone update that preserves first-event timestamps and derives reminder baselines correctly for either event order.
 - [x] Retain the earliest first-session candidate when concurrent initial reads/writes reach MongoDB out of order.
-- [x] On device-token registration, enroll the user from the earliest extant token, reset transferred-token history for the new owner, and retry unresolved bridge/session reconciliation.
+- [x] On iOS/Android device-token registration, enroll the user from the earliest extant mobile token, reset transferred-token history for the new owner, and retry unresolved bridge/session reconciliation. Desktop token registration does not establish mobile setup.
 - [x] Add `{ userId: 1, createdAt: 1 }` to support historical device-token lookup.
 - [x] Remove the superseded `{ userId: 1 }` token index only after confirming the exact desired compound replacement exists.
 - [x] Validate token owner IDs with the typed internal error used at repository boundaries.
@@ -286,7 +286,7 @@ Acceptance criteria:
 - [x] Add an idempotent operator-run script and package command.
 - [x] Require dry-run by default and an explicit apply flag for writes.
 - [x] Iterate existing users in bounded keyset batches, with each command's cohort fixed at its start timestamp.
-- [x] Set `mobileSetupAt` from the earliest extant device token; record users without a current token without making them reminder-eligible.
+- [x] Set `mobileSetupAt` from the earliest extant iOS/Android device token; record users without a current mobile token without making them reminder-eligible.
 - [x] Set `bridgeSetupAt` from the earliest historical bridge registration, including revoked bridges.
 - [x] Set `firstSessionAt` from historical metadata usage when available without replacing precise organic timestamps.
 - [x] Preserve real milestone timestamps and sent markers for analytics and suppression.
@@ -352,3 +352,4 @@ PR4 exit condition:
 - 2026-07-15: PR2 merged as #40. PR3 implementation completed and opened as #41: default-off configuration, indexed due queries, conditional markers, FCM delivery, a bounded single-flight scheduler, graceful disposal, and structured logs. Pre-delivery review hardened transient per-token retries, timer validation, shutdown cancellation, and concurrent milestone-log ownership. All verification passed. PR4 must wait for live merge verification.
 - 2026-07-15: PR3 review feedback addressed. Restored the plan's static intended-status semantics and staged overdue bridge reminders across separate sweeps so enabling a delayed scheduler cannot send both messages back-to-back.
 - 2026-07-16: PR3 merged as #41 (`c0ec782`). PR4 implementation completed on `activation-reminder-backfill`: dry-run-first operator tooling, fixed-cohort keyset batching, historical reconciliation, atomic controlled baselines, deterministic jitter, progress/final reporting, an operations runbook, and comprehensive tests. Post-merge PR3 feedback was also addressed with enums, CAS semantics, bounded disposal, token-safe logging, structured-log regressions, throughput defaults, and architecture documentation. All verification passed; PR4 delivery is pending.
+- 2026-07-16: PR #43 expands push-token storage to macOS, Windows, and Linux while shipping mobile-only activation reconciliation and desktop-to-mobile timestamp resets in the same deployment. Only iOS/Android token registrations establish or reconcile `mobileSetupAt`; desktop tokens remain notification endpoints without entering the phone-oriented onboarding funnel. Rolling back to the pre-PR code requires the quiesced desktop-token cleanup documented in `CONSIDERATIONS.md`.

--- a/.plans/activation-reminders/PLAN.md
+++ b/.plans/activation-reminders/PLAN.md
@@ -18,7 +18,7 @@ This file is the authoritative implementation tracker. A future session should r
 - PR2 delivery status: merged as PR #40
 - PR3 delivery status: merged as PR #41 (`c0ec782`)
 - PR4 delivery status: merged as PR #42
-- Live GitHub delivery state: verify with `gh pr list --head activation-reminder-backfill --state all`
+- Live GitHub delivery state: verify with `gh pr list --head invalid-request-body-log --state all`
 - Last updated: 2026-07-16
 - PR4 is the final planned implementation slice. PR #43 preserves the all-app activation semantics while widening token registration to all supported platforms.
 

--- a/.plans/activation-reminders/PLAN.md
+++ b/.plans/activation-reminders/PLAN.md
@@ -4,7 +4,7 @@
 
 Improve user activation by measuring and nudging users through this funnel:
 
-1. Mobile setup: the user registers an iOS or Android push-notification device token.
+1. App setup: the user registers a push-notification device token from any supported app platform.
 2. Bridge setup: the user registers the desktop bridge.
 3. Full activation: the user creates a new session, represented by the first valid authenticated call to `POST /sessions/generate-metadata`.
 
@@ -12,15 +12,15 @@ This file is the authoritative implementation tracker. A future session should r
 
 ## Current State
 
-- Branch: `activation-reminder-backfill`
-- Implementation checkpoint: PR4 complete; delivery pending
+- Branch: `invalid-request-body-log`
+- Implementation checkpoint: PR4 merged; PR #43 app-platform follow-up open
 - PR1 delivery status: merged as PR #38
 - PR2 delivery status: merged as PR #40
 - PR3 delivery status: merged as PR #41 (`c0ec782`)
-- PR4 intended post-merge status: merged; verify live state rather than inferring it from this file
+- PR4 delivery status: merged as PR #42
 - Live GitHub delivery state: verify with `gh pr list --head activation-reminder-backfill --state all`
 - Last updated: 2026-07-16
-- PR4 is the final planned implementation slice. Finish its commit, review, PR, and merge workflow before running the production backfill.
+- PR4 is the final planned implementation slice. PR #43 preserves the all-app activation semantics while widening token registration to all supported platforms.
 
 ## Resume Instructions
 
@@ -39,12 +39,12 @@ This file is the authoritative implementation tracker. A future session should r
 - V1 implementation is auth-server-only. Full-stack changes remain permissible later, but no Flutter, bridge, or relay changes are needed for V1.
 - Existing FCM infrastructure and the `system_update` notification category are reused.
 - Notification taps rely on the app's default open behavior; V1 adds no activation-specific deep link.
-- Mobile setup is the first iOS/Android device-token registration, not account creation. Desktop tokens remain valid push endpoints but do not establish this milestone.
+- App setup is the first device-token registration from any supported app platform, not account creation. The supported values are iOS, Android, macOS, Windows, and Linux.
 - Bridge setup is the first bridge registration, not the first relay connection.
 - First session is the first valid authenticated `POST /sessions/generate-metadata` call. Metadata failure is non-fatal in the bridge and session creation continues, so the response does not need to succeed. This deliberately measures creation of a new text-backed session, not messages in existing sessions.
-- Bridge reminder 1 is due approximately 2 hours after mobile setup.
-- Bridge reminder 2 is due approximately 24 hours after mobile setup, but only after bridge reminder 1 completed in an earlier sweep.
-- The single session reminder is due approximately 24 hours after both mobile and bridge setup. Its organic baseline is `max(mobileSetupAt, bridgeSetupAt)`.
+- Bridge reminder 1 is due approximately 2 hours after app setup.
+- Bridge reminder 2 is due approximately 24 hours after app setup, but only after bridge reminder 1 completed in an earlier sweep.
+- The single session reminder is due approximately 24 hours after both app and bridge setup. Its organic baseline is `max(mobileSetupAt, bridgeSetupAt)`.
 - A roughly 15-minute sweep is sufficient; reminder timing is intentionally approximate.
 - No quiet-hours handling in V1.
 - Existing users are actively backfilled. Incomplete users enter a controlled re-engagement sequence measured from backfill time with deterministic jitter.
@@ -56,7 +56,7 @@ All reminders use category `system_update`.
 
 | Reminder      | Title                           | Body                                                                                         |
 | ------------- | ------------------------------- | -------------------------------------------------------------------------------------------- |
-| Bridge 1      | Finish setting up Sesori        | Install the Sesori bridge on your computer to start using Sesori from your phone.            |
+| Bridge 1      | Finish setting up Sesori        | Install the Sesori bridge on your computer to connect your coding agents.                    |
 | Bridge 2      | Your Sesori setup is unfinished | You haven't connected your computer yet. Install the Sesori bridge to unlock Sesori.         |
 | First session | Start your first session        | You're all set up! You haven't started a new session yet - create one to put Sesori to work. |
 
@@ -86,9 +86,10 @@ updatedAt: Date
 
 Field invariants:
 
-- `bridgeReminderBaseAt` is set only after mobile setup is known.
-- `sessionReminderBaseAt` is set only after both mobile and bridge setup are known.
-- Mobile and bridge timestamps are set once; `firstSessionAt` retains the earliest observed candidate when better evidence arrives.
+- `mobileSetupAt`, `MobileIncomplete`, and the `mobile_setup` log value are historical persisted/operational names retained for compatibility; they represent app setup across every supported platform.
+- `bridgeReminderBaseAt` is set only after app setup is known.
+- `sessionReminderBaseAt` is set only after both app and bridge setup are known.
+- App and bridge timestamps are set once; `firstSessionAt` retains the earliest observed candidate when better evidence arrives.
 - Backfill timestamps remain separate from reminder baselines so analytics are not rewritten to make scheduling convenient.
 - Sent timestamps are independent so each reminder can be measured and suppressed separately.
 
@@ -98,7 +99,7 @@ Planned indexes:
 - `{ bridgeSetupAt: 1, bridgeReminder1SentAt: 1, bridgeReminderBaseAt: 1 }`.
 - `{ bridgeSetupAt: 1, bridgeReminder2SentAt: 1, bridgeReminderBaseAt: 1 }`.
 - `{ firstSessionAt: 1, sessionReminderSentAt: 1, sessionReminderBaseAt: 1 }`.
-- Supporting historical iOS/Android token reconciliation: `deviceTokens { userId: 1, createdAt: 1 }`.
+- Supporting historical app-token reconciliation: `deviceTokens { userId: 1, createdAt: 1 }`.
 - Supporting historical bridge reconciliation: `bridges { userId: 1, addedAt: 1 }`.
 
 The equality fields precede each due-time range field so the future sweep queries can use the indexes directly.
@@ -184,7 +185,7 @@ Acceptance criteria:
 - [x] Add `ActivationService` to own reconciliation and milestone invariants.
 - [x] Add an atomic milestone update that preserves first-event timestamps and derives reminder baselines correctly for either event order.
 - [x] Retain the earliest first-session candidate when concurrent initial reads/writes reach MongoDB out of order.
-- [x] On iOS/Android device-token registration, enroll the user from the earliest extant mobile token, reset transferred-token history for the new owner, and retry unresolved bridge/session reconciliation. Desktop token registration does not establish mobile setup.
+- [x] On device-token registration from any supported app platform, enroll the user from the earliest extant token, reset transferred-token history for the new owner, preserve same-owner history across platform changes, and retry unresolved bridge/session reconciliation.
 - [x] Add `{ userId: 1, createdAt: 1 }` to support historical device-token lookup.
 - [x] Remove the superseded `{ userId: 1 }` token index only after confirming the exact desired compound replacement exists.
 - [x] Validate token owner IDs with the typed internal error used at repository boundaries.
@@ -194,7 +195,7 @@ Acceptance criteria:
 - [x] Set `bridgeSetupAt` idempotently after bridge registration, using the earliest historical `addedAt` across active and revoked bridges.
 - [x] Set `firstSessionAt` before metadata generation for a valid authenticated request, preferring earlier historical metadata evidence when present, because the bridge proceeds when metadata generation fails.
 - [x] Reconcile all still-missing historical milestones from each event hook so a later event repairs an earlier failure-isolated write.
-- [x] Derive `sessionReminderBaseAt` from the later of mobile and bridge setup.
+- [x] Derive `sessionReminderBaseAt` from the later of app and bridge setup.
 - [x] Catch and log activation errors at every endpoint boundary without changing the existing endpoint response.
 - [x] Document that logout/revoke retains lifetime activation history.
 - [x] Add repository, service, event-order, reconciliation, route, metadata-failure, and failure-isolation tests.
@@ -286,14 +287,14 @@ Acceptance criteria:
 - [x] Add an idempotent operator-run script and package command.
 - [x] Require dry-run by default and an explicit apply flag for writes.
 - [x] Iterate existing users in bounded keyset batches, with each command's cohort fixed at its start timestamp.
-- [x] Set `mobileSetupAt` from the earliest extant iOS/Android device token; record users without a current mobile token without making them reminder-eligible.
+- [x] Set the historically named `mobileSetupAt` from the earliest extant device token on any supported app platform; record users without a current token without making them reminder-eligible.
 - [x] Set `bridgeSetupAt` from the earliest historical bridge registration, including revoked bridges.
 - [x] Set `firstSessionAt` from historical metadata usage when available without replacing precise organic timestamps.
 - [x] Preserve real milestone timestamps and sent markers for analytics and suppression.
 - [x] For currently incomplete, push-reachable users, atomically set only the current unsent reminder baseline to backfill time plus deterministic jitter.
 - [x] Re-evaluate the current stage in the atomic write so a milestone committed during reconciliation cannot strand the controlled baseline on a completed stage.
 - [x] Do not schedule bridge reminders for users who already have a bridge.
-- [x] Do not schedule session reminders unless both mobile and bridge setup are known.
+- [x] Do not schedule session reminders unless both app and bridge setup are known.
 - [x] Report cumulative and final proposed/applied counts by activation stage and reminder sequence.
 - [x] Document dry-run review, apply, timing, interruption, rerun, and monitoring operations.
 - [x] Test dry-run safety, explicit apply gating, idempotency, reconciliation, fixed cohorts, stage races, tokenless users, and controlled baseline assignment.
@@ -351,5 +352,5 @@ PR4 exit condition:
 - 2026-07-15: PR2 third automated review addressed. Required a full desired-index option match before cleanup and preserved earlier observed session timestamps when an initial read loses a race. All verification passed.
 - 2026-07-15: PR2 merged as #40. PR3 implementation completed and opened as #41: default-off configuration, indexed due queries, conditional markers, FCM delivery, a bounded single-flight scheduler, graceful disposal, and structured logs. Pre-delivery review hardened transient per-token retries, timer validation, shutdown cancellation, and concurrent milestone-log ownership. All verification passed. PR4 must wait for live merge verification.
 - 2026-07-15: PR3 review feedback addressed. Restored the plan's static intended-status semantics and staged overdue bridge reminders across separate sweeps so enabling a delayed scheduler cannot send both messages back-to-back.
-- 2026-07-16: PR3 merged as #41 (`c0ec782`). PR4 implementation completed on `activation-reminder-backfill`: dry-run-first operator tooling, fixed-cohort keyset batching, historical reconciliation, atomic controlled baselines, deterministic jitter, progress/final reporting, an operations runbook, and comprehensive tests. Post-merge PR3 feedback was also addressed with enums, CAS semantics, bounded disposal, token-safe logging, structured-log regressions, throughput defaults, and architecture documentation. All verification passed; PR4 delivery is pending.
-- 2026-07-16: PR #43 expands push-token storage to macOS, Windows, and Linux while shipping mobile-only activation reconciliation and desktop-to-mobile timestamp resets in the same deployment. Only iOS/Android token registrations establish or reconcile `mobileSetupAt`; desktop tokens remain notification endpoints without entering the phone-oriented onboarding funnel. Rolling back to the pre-PR code requires the quiesced desktop-token cleanup documented in `CONSIDERATIONS.md`.
+- 2026-07-16: PR3 merged as #41 (`c0ec782`). PR4 implemented dry-run-first operator tooling, fixed-cohort keyset batching, historical reconciliation, atomic controlled baselines, deterministic jitter, progress/final reporting, an operations runbook, and comprehensive tests, then merged as PR #42. Post-merge PR3 feedback was also addressed with enums, CAS semantics, bounded disposal, token-safe logging, structured-log regressions, throughput defaults, and architecture documentation. All verification passed.
+- 2026-07-16: PR #43 expands push-token storage to macOS, Windows, and Linux while preserving the product funnel's all-app activation semantics. Every supported app token establishes or reconciles the historically named `mobileSetupAt`; same-owner platform changes retain the first registration timestamp, ownership transfers reset it, and bridge-reminder copy is platform-neutral.

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { BridgePlatform, bridgeIdSchema, bridgePlatformSchema } from "./bridge.js";
+import { devicePlatformSchema } from "./device.js";
 
 export { BridgePlatform, bridgeIdSchema, bridgePlatformSchema };
 
@@ -184,7 +185,7 @@ export type GlossaryRemoveReply = {
 
 export const registerTokenBodySchema = z.object({
   token: z.string().min(1),
-  platform: z.enum(["ios", "android"]),
+  platform: devicePlatformSchema,
 });
 export type RegisterTokenBody = z.infer<typeof registerTokenBodySchema>;
 

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -8,4 +8,10 @@ export enum DevicePlatform {
   linux = "linux",
 }
 
+export const MOBILE_DEVICE_PLATFORMS: readonly DevicePlatform[] = [DevicePlatform.ios, DevicePlatform.android];
+
+export function isMobileDevicePlatform(platform: DevicePlatform): boolean {
+  return MOBILE_DEVICE_PLATFORMS.includes(platform);
+}
+
 export const devicePlatformSchema = z.enum(DevicePlatform);

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -8,10 +8,4 @@ export enum DevicePlatform {
   linux = "linux",
 }
 
-export const MOBILE_DEVICE_PLATFORMS: readonly DevicePlatform[] = [DevicePlatform.ios, DevicePlatform.android];
-
-export function isMobileDevicePlatform(platform: DevicePlatform): boolean {
-  return MOBILE_DEVICE_PLATFORMS.includes(platform);
-}
-
 export const devicePlatformSchema = z.enum(DevicePlatform);

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export enum DevicePlatform {
+  ios = "ios",
+  android = "android",
+  macos = "macos",
+  windows = "windows",
+  linux = "linux",
+}
+
+export const devicePlatformSchema = z.enum(DevicePlatform);

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -1,6 +1,7 @@
 import { ObjectId } from "mongodb";
 import { z } from "zod";
 import { bridgeIdSchema, bridgePlatformSchema, bridgeStatusSchema } from "./bridge.js";
+import { devicePlatformSchema } from "./device.js";
 
 export const userSchema = z.object({
   _id: z.instanceof(ObjectId),
@@ -68,7 +69,7 @@ export const deviceTokenSchema = z.object({
   _id: z.instanceof(ObjectId),
   userId: z.instanceof(ObjectId),
   token: z.string(),
-  platform: z.enum(["ios", "android"]),
+  platform: devicePlatformSchema,
   createdAt: z.date(),
   updatedAt: z.date(),
 });

--- a/src/repositories/device-token-repo.ts
+++ b/src/repositories/device-token-repo.ts
@@ -1,6 +1,7 @@
 import { Collection, ObjectId } from "mongodb";
 import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
 import { InternalServerError } from "../lib/errors.js";
+import type { DevicePlatform } from "../models/device.js";
 import type { DeviceToken } from "../models/documents.js";
 import { MongoDbDatabase, AuthDbCollection } from "../types/mongo.js";
 
@@ -11,7 +12,7 @@ export class DeviceTokenRepository {
     this.#collection = accessor.getCollection<DeviceToken>(MongoDbDatabase.Auth, AuthDbCollection.DeviceTokens);
   }
 
-  async upsertToken(userId: string, token: string, platform: "ios" | "android"): Promise<void> {
+  async upsertToken(userId: string, token: string, platform: DevicePlatform): Promise<void> {
     if (!ObjectId.isValid(userId)) {
       throw new InternalServerError({ debugMessage: "Invalid device token userId" });
     }

--- a/src/repositories/device-token-repo.ts
+++ b/src/repositories/device-token-repo.ts
@@ -1,7 +1,7 @@
 import { Collection, ObjectId } from "mongodb";
 import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
 import { InternalServerError } from "../lib/errors.js";
-import { isMobileDevicePlatform, MOBILE_DEVICE_PLATFORMS, type DevicePlatform } from "../models/device.js";
+import type { DevicePlatform } from "../models/device.js";
 import type { DeviceToken } from "../models/documents.js";
 import { MongoDbDatabase, AuthDbCollection } from "../types/mongo.js";
 
@@ -20,12 +20,8 @@ export class DeviceTokenRepository {
     const objectUserId = new ObjectId(userId);
     const sameOwner = { $eq: ["$userId", objectUserId] };
     // Concurrent writes to one token serialize, so these predicates inspect the
-    // owner/platform left by the preceding write. Ownership changes and
-    // same-owner desktop-to-mobile transitions reset the qualifying timestamp;
-    // all other same-owner platform changes preserve it.
-    const preserveCreatedAt = isMobileDevicePlatform(platform)
-      ? { $and: [sameOwner, { $in: ["$platform", MOBILE_DEVICE_PLATFORMS] }] }
-      : sameOwner;
+    // owner left by the preceding write. Same-owner platform changes preserve
+    // the first app-registration timestamp; ownership changes reset it.
     await this.#collection.updateOne(
       { token },
       [
@@ -34,7 +30,7 @@ export class DeviceTokenRepository {
             userId: objectUserId,
             platform,
             createdAt: {
-              $cond: [preserveCreatedAt, { $ifNull: ["$createdAt", now] }, now],
+              $cond: [sameOwner, { $ifNull: ["$createdAt", now] }, now],
             },
             updatedAt: now,
           },
@@ -48,12 +44,12 @@ export class DeviceTokenRepository {
     return this.#collection.find({ userId: new ObjectId(userId) }).toArray();
   }
 
-  async findEarliestMobileCreatedAt(userId: string): Promise<Date | null> {
-    if (!ObjectId.isValid(userId)) return null;
-    const token = await this.#collection.findOne(
-      { userId: new ObjectId(userId), platform: { $in: MOBILE_DEVICE_PLATFORMS } },
-      { sort: { createdAt: 1 } },
-    );
+  async findEarliestCreatedAt(userId: string): Promise<Date | null> {
+    if (!ObjectId.isValid(userId)) {
+      return null;
+    }
+
+    const token = await this.#collection.findOne({ userId: new ObjectId(userId) }, { sort: { createdAt: 1 } });
     return token?.createdAt ?? null;
   }
 

--- a/src/repositories/device-token-repo.ts
+++ b/src/repositories/device-token-repo.ts
@@ -1,7 +1,7 @@
 import { Collection, ObjectId } from "mongodb";
 import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
 import { InternalServerError } from "../lib/errors.js";
-import type { DevicePlatform } from "../models/device.js";
+import { isMobileDevicePlatform, MOBILE_DEVICE_PLATFORMS, type DevicePlatform } from "../models/device.js";
 import type { DeviceToken } from "../models/documents.js";
 import { MongoDbDatabase, AuthDbCollection } from "../types/mongo.js";
 
@@ -18,6 +18,14 @@ export class DeviceTokenRepository {
     }
     const now = new Date();
     const objectUserId = new ObjectId(userId);
+    const sameOwner = { $eq: ["$userId", objectUserId] };
+    // Concurrent writes to one token serialize, so these predicates inspect the
+    // owner/platform left by the preceding write. Ownership changes and
+    // same-owner desktop-to-mobile transitions reset the qualifying timestamp;
+    // all other same-owner platform changes preserve it.
+    const preserveCreatedAt = isMobileDevicePlatform(platform)
+      ? { $and: [sameOwner, { $in: ["$platform", MOBILE_DEVICE_PLATFORMS] }] }
+      : sameOwner;
     await this.#collection.updateOne(
       { token },
       [
@@ -25,10 +33,8 @@ export class DeviceTokenRepository {
           $set: {
             userId: objectUserId,
             platform,
-            // A token moved to another account is a new registration for that
-            // user; same-user retries retain the original setup timestamp.
             createdAt: {
-              $cond: [{ $eq: ["$userId", objectUserId] }, { $ifNull: ["$createdAt", now] }, now],
+              $cond: [preserveCreatedAt, { $ifNull: ["$createdAt", now] }, now],
             },
             updatedAt: now,
           },
@@ -42,9 +48,12 @@ export class DeviceTokenRepository {
     return this.#collection.find({ userId: new ObjectId(userId) }).toArray();
   }
 
-  async findEarliestCreatedAt(userId: string): Promise<Date | null> {
+  async findEarliestMobileCreatedAt(userId: string): Promise<Date | null> {
     if (!ObjectId.isValid(userId)) return null;
-    const token = await this.#collection.findOne({ userId: new ObjectId(userId) }, { sort: { createdAt: 1 } });
+    const token = await this.#collection.findOne(
+      { userId: new ObjectId(userId), platform: { $in: MOBILE_DEVICE_PLATFORMS } },
+      { sort: { createdAt: 1 } },
+    );
     return token?.createdAt ?? null;
   }
 

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -64,9 +64,9 @@ export const notificationRoutes: FastifyPluginAsync<NotificationRouteOptions> = 
       const userId = getUserId(request);
       await deviceTokenRepo.upsertToken(userId, bodyResult.data.token, bodyResult.data.platform);
       try {
-        await activationService.recordDeviceTokenRegistration(userId, bodyResult.data.platform);
+        await activationService.recordAppSetup(userId);
       } catch (error) {
-        console.warn("[ActivationService] Failed to record device token registration", { userId, error });
+        console.warn("[ActivationService] Failed to record app setup", { userId, error });
       }
       return { ok: true };
     },

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -64,9 +64,9 @@ export const notificationRoutes: FastifyPluginAsync<NotificationRouteOptions> = 
       const userId = getUserId(request);
       await deviceTokenRepo.upsertToken(userId, bodyResult.data.token, bodyResult.data.platform);
       try {
-        await activationService.recordMobileSetup(userId);
+        await activationService.recordDeviceTokenRegistration(userId, bodyResult.data.platform);
       } catch (error) {
-        console.warn("[ActivationService] Failed to record mobile setup", { userId, error });
+        console.warn("[ActivationService] Failed to record device token registration", { userId, error });
       }
       return { ok: true };
     },

--- a/src/services/activation-backfill-service.ts
+++ b/src/services/activation-backfill-service.ts
@@ -230,7 +230,7 @@ export class ActivationBackfillService {
     }
 
     const [mobileSetupAt, bridgeSetupAt, firstSessionAt] = await Promise.all([
-      this.#deviceTokenRepo.findEarliestCreatedAt(userId),
+      this.#deviceTokenRepo.findEarliestMobileCreatedAt(userId),
       this.#bridgeRepo.findEarliestAddedAt(userId),
       this.#dailyUsageRepo.findEarliestMetadataRequestAt(userId),
     ]);

--- a/src/services/activation-backfill-service.ts
+++ b/src/services/activation-backfill-service.ts
@@ -230,7 +230,7 @@ export class ActivationBackfillService {
     }
 
     const [mobileSetupAt, bridgeSetupAt, firstSessionAt] = await Promise.all([
-      this.#deviceTokenRepo.findEarliestMobileCreatedAt(userId),
+      this.#deviceTokenRepo.findEarliestCreatedAt(userId),
       this.#bridgeRepo.findEarliestAddedAt(userId),
       this.#dailyUsageRepo.findEarliestMetadataRequestAt(userId),
     ]);

--- a/src/services/activation-reminder-service.ts
+++ b/src/services/activation-reminder-service.ts
@@ -19,7 +19,7 @@ const REMINDER_PAYLOADS: Record<ActivationReminderKind, NotificationPayload> = {
   [ActivationReminderKind.Bridge1]: {
     category: "system_update",
     title: "Finish setting up Sesori",
-    body: "Install the Sesori bridge on your computer to start using Sesori from your phone.",
+    body: "Install the Sesori bridge on your computer to connect your coding agents.",
     collapseKey: "activation_bridge_1",
   },
   [ActivationReminderKind.Bridge2]: {

--- a/src/services/activation-service.ts
+++ b/src/services/activation-service.ts
@@ -1,4 +1,3 @@
-import { isMobileDevicePlatform, type DevicePlatform } from "../models/device.js";
 import type { ActivationState } from "../models/documents.js";
 import type { ActivationMilestoneUpdate, ActivationStateRepository } from "../repositories/activation-state-repo.js";
 import type { BridgeRepository } from "../repositories/bridge-repo.js";
@@ -30,7 +29,7 @@ export class ActivationService {
   ): Promise<ActivationState> {
     const existing = await this.#activationStateRepo.findByUserId(userId);
     const [mobileSetupAt, bridgeSetupAt, firstSessionAt] = await Promise.all([
-      existing?.mobileSetupAt ? null : this.#deviceTokenRepo.findEarliestMobileCreatedAt(userId),
+      existing?.mobileSetupAt ? null : this.#deviceTokenRepo.findEarliestCreatedAt(userId),
       existing?.bridgeSetupAt ? null : this.#bridgeRepo.findEarliestAddedAt(userId),
       existing?.firstSessionAt ? null : this.#dailyUsageRepo.findEarliestMetadataRequestAt(userId),
     ]);
@@ -69,15 +68,7 @@ export class ActivationService {
     return state;
   }
 
-  async recordDeviceTokenRegistration(
-    userId: string,
-    platform: DevicePlatform,
-    observedAt = new Date(),
-  ): Promise<ActivationState | null> {
-    if (!isMobileDevicePlatform(platform)) {
-      return null;
-    }
-
+  async recordAppSetup(userId: string, observedAt = new Date()): Promise<ActivationState> {
     return this.#recordReconciledMilestones(userId, "mobileSetupAt", observedAt);
   }
 

--- a/src/services/activation-service.ts
+++ b/src/services/activation-service.ts
@@ -1,3 +1,4 @@
+import { isMobileDevicePlatform, type DevicePlatform } from "../models/device.js";
 import type { ActivationState } from "../models/documents.js";
 import type { ActivationMilestoneUpdate, ActivationStateRepository } from "../repositories/activation-state-repo.js";
 import type { BridgeRepository } from "../repositories/bridge-repo.js";
@@ -29,7 +30,7 @@ export class ActivationService {
   ): Promise<ActivationState> {
     const existing = await this.#activationStateRepo.findByUserId(userId);
     const [mobileSetupAt, bridgeSetupAt, firstSessionAt] = await Promise.all([
-      existing?.mobileSetupAt ? null : this.#deviceTokenRepo.findEarliestCreatedAt(userId),
+      existing?.mobileSetupAt ? null : this.#deviceTokenRepo.findEarliestMobileCreatedAt(userId),
       existing?.bridgeSetupAt ? null : this.#bridgeRepo.findEarliestAddedAt(userId),
       existing?.firstSessionAt ? null : this.#dailyUsageRepo.findEarliestMetadataRequestAt(userId),
     ]);
@@ -68,7 +69,15 @@ export class ActivationService {
     return state;
   }
 
-  async recordMobileSetup(userId: string, observedAt = new Date()): Promise<ActivationState> {
+  async recordDeviceTokenRegistration(
+    userId: string,
+    platform: DevicePlatform,
+    observedAt = new Date(),
+  ): Promise<ActivationState | null> {
+    if (!isMobileDevicePlatform(platform)) {
+      return null;
+    }
+
     return this.#recordReconciledMilestones(userId, "mobileSetupAt", observedAt);
   }
 

--- a/tests/notifications/device-token-repo.test.ts
+++ b/tests/notifications/device-token-repo.test.ts
@@ -31,7 +31,7 @@ describe("DeviceTokenRepository", () => {
     assert.equal(tokens[0]?.platform, "ios");
   });
 
-  it("upsertToken with same token updates timestamp (idempotent)", async () => {
+  it("upsertToken preserves createdAt for a same-owner mobile-to-mobile update", async () => {
     const user = await ctx.createUser();
 
     await repo.upsertToken(user.userId, "token-idempotent", "ios");
@@ -52,6 +52,54 @@ describe("DeviceTokenRepository", () => {
     assert.ok((second[0]?.updatedAt.getTime() ?? 0) >= firstUpdatedAt.getTime());
   });
 
+  it("upsertToken preserves createdAt for a same-owner desktop-to-desktop update", async () => {
+    const user = await ctx.createUser();
+    await repo.upsertToken(user.userId, "token-desktop-retry", "macos");
+    const first = (await repo.findByUserId(user.userId))[0];
+    assert.ok(first);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    await repo.upsertToken(user.userId, "token-desktop-retry", "linux");
+
+    const updated = (await repo.findByUserId(user.userId))[0];
+    assert.ok(updated);
+    assert.equal(updated.platform, "linux");
+    assert.equal(updated.createdAt.toISOString(), first.createdAt.toISOString());
+    assert.ok(updated.updatedAt.getTime() > first.updatedAt.getTime());
+  });
+
+  it("upsertToken preserves createdAt for a same-owner mobile-to-desktop update", async () => {
+    const user = await ctx.createUser();
+    await repo.upsertToken(user.userId, "token-mobile-to-desktop", "ios");
+    const first = (await repo.findByUserId(user.userId))[0];
+    assert.ok(first);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    await repo.upsertToken(user.userId, "token-mobile-to-desktop", "macos");
+
+    const updated = (await repo.findByUserId(user.userId))[0];
+    assert.ok(updated);
+    assert.equal(updated.platform, "macos");
+    assert.equal(updated.createdAt.toISOString(), first.createdAt.toISOString());
+    assert.ok(updated.updatedAt.getTime() > first.updatedAt.getTime());
+  });
+
+  it("upsertToken resets createdAt for a same-owner desktop-to-mobile update", async () => {
+    const user = await ctx.createUser();
+    await repo.upsertToken(user.userId, "token-desktop-to-mobile", "macos");
+    const first = (await repo.findByUserId(user.userId))[0];
+    assert.ok(first);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    await repo.upsertToken(user.userId, "token-desktop-to-mobile", "ios");
+
+    const updated = (await repo.findByUserId(user.userId))[0];
+    assert.ok(updated);
+    assert.equal(updated.platform, "ios");
+    assert.ok(updated.createdAt.getTime() > first.createdAt.getTime());
+    assert.equal(updated.createdAt.toISOString(), updated.updatedAt.toISOString());
+  });
+
   it("upsertToken resets createdAt when a token moves to another user", async () => {
     const firstUser = await ctx.createUser();
     const secondUser = await ctx.createUser();
@@ -69,6 +117,33 @@ describe("DeviceTokenRepository", () => {
     assert.equal(transferred.platform, "android");
     assert.ok(transferred.createdAt.getTime() > firstRegistration.createdAt.getTime());
     assert.equal(transferred.createdAt.toISOString(), transferred.updatedAt.toISOString());
+  });
+
+  it("upsertToken serializes concurrent owner and platform transitions", async () => {
+    const firstUser = await ctx.createUser();
+    const secondUser = await ctx.createUser();
+    await repo.upsertToken(firstUser.userId, "token-concurrent-transition", "macos");
+    const seeded = (await repo.findByUserId(firstUser.userId))[0];
+    assert.ok(seeded);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    await Promise.all([
+      repo.upsertToken(firstUser.userId, "token-concurrent-transition", "ios"),
+      repo.upsertToken(secondUser.userId, "token-concurrent-transition", "linux"),
+    ]);
+
+    const firstOwnerTokens = await repo.findByUserId(firstUser.userId);
+    const secondOwnerTokens = await repo.findByUserId(secondUser.userId);
+    assert.equal(firstOwnerTokens.length + secondOwnerTokens.length, 1);
+    const finalToken = firstOwnerTokens[0] ?? secondOwnerTokens[0];
+    assert.ok(finalToken);
+    if (firstOwnerTokens.length === 1) {
+      assert.equal(finalToken.platform, "ios");
+    } else {
+      assert.equal(finalToken.platform, "linux");
+    }
+    assert.ok(finalToken.createdAt.getTime() > seeded.createdAt.getTime());
+    assert.equal(finalToken.createdAt.toISOString(), finalToken.updatedAt.toISOString());
   });
 
   it("upsertToken rejects an invalid user id", async () => {
@@ -93,32 +168,41 @@ describe("DeviceTokenRepository", () => {
     assert.deepEqual(new Set(tokens.map((token) => token.token)), new Set(["token-list-1", "token-list-2"]));
   });
 
-  it("findEarliestCreatedAt returns the first extant token registration", async () => {
+  it("findEarliestMobileCreatedAt ignores desktop token registrations", async () => {
     const user = await ctx.createUser();
-    const firstAt = new Date("2026-07-10T10:00:00.000Z");
-    const secondAt = new Date("2026-07-12T10:00:00.000Z");
+    const desktopAt = new Date("2026-07-09T10:00:00.000Z");
+    const firstMobileAt = new Date("2026-07-10T10:00:00.000Z");
+    const secondMobileAt = new Date("2026-07-12T10:00:00.000Z");
     const collection = ctx.dbAccessor.getCollection<DeviceToken>(MongoDbDatabase.Auth, AuthDbCollection.DeviceTokens);
     await collection.insertMany([
       {
         _id: new ObjectId(),
         userId: new ObjectId(user.userId),
-        token: `earliest-token-${user.userId}`,
-        platform: "ios",
-        createdAt: firstAt,
-        updatedAt: firstAt,
+        token: `desktop-token-${user.userId}`,
+        platform: "macos",
+        createdAt: desktopAt,
+        updatedAt: desktopAt,
       },
       {
         _id: new ObjectId(),
         userId: new ObjectId(user.userId),
-        token: `later-token-${user.userId}`,
+        token: `earliest-mobile-token-${user.userId}`,
+        platform: "ios",
+        createdAt: firstMobileAt,
+        updatedAt: firstMobileAt,
+      },
+      {
+        _id: new ObjectId(),
+        userId: new ObjectId(user.userId),
+        token: `later-mobile-token-${user.userId}`,
         platform: "android",
-        createdAt: secondAt,
-        updatedAt: secondAt,
+        createdAt: secondMobileAt,
+        updatedAt: secondMobileAt,
       },
     ]);
 
-    assert.equal((await repo.findEarliestCreatedAt(user.userId))?.toISOString(), firstAt.toISOString());
-    assert.equal(await repo.findEarliestCreatedAt("invalid-id"), null);
+    assert.equal((await repo.findEarliestMobileCreatedAt(user.userId))?.toISOString(), firstMobileAt.toISOString());
+    assert.equal(await repo.findEarliestMobileCreatedAt("invalid-id"), null);
     const index = (await collection.indexes()).find((candidate) => candidate.name === "userId_1_createdAt_1");
     assert.deepEqual(index?.key, { userId: 1, createdAt: 1 });
   });

--- a/tests/notifications/device-token-repo.test.ts
+++ b/tests/notifications/device-token-repo.test.ts
@@ -84,7 +84,7 @@ describe("DeviceTokenRepository", () => {
     assert.ok(updated.updatedAt.getTime() > first.updatedAt.getTime());
   });
 
-  it("upsertToken resets createdAt for a same-owner desktop-to-mobile update", async () => {
+  it("upsertToken preserves createdAt for a same-owner desktop-to-mobile update", async () => {
     const user = await ctx.createUser();
     await repo.upsertToken(user.userId, "token-desktop-to-mobile", "macos");
     const first = (await repo.findByUserId(user.userId))[0];
@@ -96,8 +96,8 @@ describe("DeviceTokenRepository", () => {
     const updated = (await repo.findByUserId(user.userId))[0];
     assert.ok(updated);
     assert.equal(updated.platform, "ios");
-    assert.ok(updated.createdAt.getTime() > first.createdAt.getTime());
-    assert.equal(updated.createdAt.toISOString(), updated.updatedAt.toISOString());
+    assert.equal(updated.createdAt.toISOString(), first.createdAt.toISOString());
+    assert.ok(updated.updatedAt.getTime() > first.updatedAt.getTime());
   });
 
   it("upsertToken resets createdAt when a token moves to another user", async () => {
@@ -168,7 +168,7 @@ describe("DeviceTokenRepository", () => {
     assert.deepEqual(new Set(tokens.map((token) => token.token)), new Set(["token-list-1", "token-list-2"]));
   });
 
-  it("findEarliestMobileCreatedAt ignores desktop token registrations", async () => {
+  it("findEarliestCreatedAt returns the first app registration on any platform", async () => {
     const user = await ctx.createUser();
     const desktopAt = new Date("2026-07-09T10:00:00.000Z");
     const firstMobileAt = new Date("2026-07-10T10:00:00.000Z");
@@ -201,8 +201,8 @@ describe("DeviceTokenRepository", () => {
       },
     ]);
 
-    assert.equal((await repo.findEarliestMobileCreatedAt(user.userId))?.toISOString(), firstMobileAt.toISOString());
-    assert.equal(await repo.findEarliestMobileCreatedAt("invalid-id"), null);
+    assert.equal((await repo.findEarliestCreatedAt(user.userId))?.toISOString(), desktopAt.toISOString());
+    assert.equal(await repo.findEarliestCreatedAt("invalid-id"), null);
     const index = (await collection.indexes()).find((candidate) => candidate.name === "userId_1_createdAt_1");
     assert.deepEqual(index?.key, { userId: 1, createdAt: 1 });
   });

--- a/tests/notifications/device-token-repo.test.ts
+++ b/tests/notifications/device-token-repo.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
 import { ObjectId } from "mongodb";
 import { InternalServerError } from "../../src/lib/errors.js";
+import { DevicePlatform } from "../../src/models/device.js";
 import type { DeviceToken } from "../../src/models/documents.js";
 import { DeviceTokenRepository } from "../../src/repositories/device-token-repo.js";
 import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
@@ -23,7 +24,7 @@ describe("DeviceTokenRepository", () => {
   it("upsertToken creates new token", async () => {
     const user = await ctx.createUser();
 
-    await repo.upsertToken(user.userId, "token-create", "ios");
+    await repo.upsertToken(user.userId, "token-create", DevicePlatform.ios);
 
     const tokens = await repo.findByUserId(user.userId);
     assert.equal(tokens.length, 1);
@@ -34,13 +35,13 @@ describe("DeviceTokenRepository", () => {
   it("upsertToken preserves createdAt for a same-owner mobile-to-mobile update", async () => {
     const user = await ctx.createUser();
 
-    await repo.upsertToken(user.userId, "token-idempotent", "ios");
+    await repo.upsertToken(user.userId, "token-idempotent", DevicePlatform.ios);
     const first = await repo.findByUserId(user.userId);
     const firstCreatedAt = first[0]?.createdAt;
     const firstUpdatedAt = first[0]?.updatedAt;
 
     await new Promise((resolve) => setTimeout(resolve, 10));
-    await repo.upsertToken(user.userId, "token-idempotent", "android");
+    await repo.upsertToken(user.userId, "token-idempotent", DevicePlatform.android);
 
     const second = await repo.findByUserId(user.userId);
     assert.equal(second.length, 1);
@@ -54,12 +55,12 @@ describe("DeviceTokenRepository", () => {
 
   it("upsertToken preserves createdAt for a same-owner desktop-to-desktop update", async () => {
     const user = await ctx.createUser();
-    await repo.upsertToken(user.userId, "token-desktop-retry", "macos");
+    await repo.upsertToken(user.userId, "token-desktop-retry", DevicePlatform.macos);
     const first = (await repo.findByUserId(user.userId))[0];
     assert.ok(first);
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    await repo.upsertToken(user.userId, "token-desktop-retry", "linux");
+    await repo.upsertToken(user.userId, "token-desktop-retry", DevicePlatform.linux);
 
     const updated = (await repo.findByUserId(user.userId))[0];
     assert.ok(updated);
@@ -70,12 +71,12 @@ describe("DeviceTokenRepository", () => {
 
   it("upsertToken preserves createdAt for a same-owner mobile-to-desktop update", async () => {
     const user = await ctx.createUser();
-    await repo.upsertToken(user.userId, "token-mobile-to-desktop", "ios");
+    await repo.upsertToken(user.userId, "token-mobile-to-desktop", DevicePlatform.ios);
     const first = (await repo.findByUserId(user.userId))[0];
     assert.ok(first);
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    await repo.upsertToken(user.userId, "token-mobile-to-desktop", "macos");
+    await repo.upsertToken(user.userId, "token-mobile-to-desktop", DevicePlatform.macos);
 
     const updated = (await repo.findByUserId(user.userId))[0];
     assert.ok(updated);
@@ -86,12 +87,12 @@ describe("DeviceTokenRepository", () => {
 
   it("upsertToken preserves createdAt for a same-owner desktop-to-mobile update", async () => {
     const user = await ctx.createUser();
-    await repo.upsertToken(user.userId, "token-desktop-to-mobile", "macos");
+    await repo.upsertToken(user.userId, "token-desktop-to-mobile", DevicePlatform.macos);
     const first = (await repo.findByUserId(user.userId))[0];
     assert.ok(first);
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    await repo.upsertToken(user.userId, "token-desktop-to-mobile", "ios");
+    await repo.upsertToken(user.userId, "token-desktop-to-mobile", DevicePlatform.ios);
 
     const updated = (await repo.findByUserId(user.userId))[0];
     assert.ok(updated);
@@ -104,12 +105,12 @@ describe("DeviceTokenRepository", () => {
     const firstUser = await ctx.createUser();
     const secondUser = await ctx.createUser();
 
-    await repo.upsertToken(firstUser.userId, "token-transferred", "ios");
+    await repo.upsertToken(firstUser.userId, "token-transferred", DevicePlatform.ios);
     const firstRegistration = (await repo.findByUserId(firstUser.userId))[0];
     assert.ok(firstRegistration);
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    await repo.upsertToken(secondUser.userId, "token-transferred", "android");
+    await repo.upsertToken(secondUser.userId, "token-transferred", DevicePlatform.android);
 
     assert.equal((await repo.findByUserId(firstUser.userId)).length, 0);
     const transferred = (await repo.findByUserId(secondUser.userId))[0];
@@ -122,14 +123,14 @@ describe("DeviceTokenRepository", () => {
   it("upsertToken serializes concurrent owner and platform transitions", async () => {
     const firstUser = await ctx.createUser();
     const secondUser = await ctx.createUser();
-    await repo.upsertToken(firstUser.userId, "token-concurrent-transition", "macos");
+    await repo.upsertToken(firstUser.userId, "token-concurrent-transition", DevicePlatform.macos);
     const seeded = (await repo.findByUserId(firstUser.userId))[0];
     assert.ok(seeded);
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     await Promise.all([
-      repo.upsertToken(firstUser.userId, "token-concurrent-transition", "ios"),
-      repo.upsertToken(secondUser.userId, "token-concurrent-transition", "linux"),
+      repo.upsertToken(firstUser.userId, "token-concurrent-transition", DevicePlatform.ios),
+      repo.upsertToken(secondUser.userId, "token-concurrent-transition", DevicePlatform.linux),
     ]);
 
     const firstOwnerTokens = await repo.findByUserId(firstUser.userId);
@@ -148,7 +149,7 @@ describe("DeviceTokenRepository", () => {
 
   it("upsertToken rejects an invalid user id", async () => {
     await assert.rejects(
-      () => repo.upsertToken("invalid-id", "token-invalid", "ios"),
+      () => repo.upsertToken("invalid-id", "token-invalid", DevicePlatform.ios),
       (error: unknown) => {
         assert.ok(error instanceof InternalServerError);
         assert.equal(error.debugMessage, "Invalid device token userId");
@@ -160,8 +161,8 @@ describe("DeviceTokenRepository", () => {
   it("findByUserId returns all tokens for user", async () => {
     const user = await ctx.createUser();
 
-    await repo.upsertToken(user.userId, "token-list-1", "ios");
-    await repo.upsertToken(user.userId, "token-list-2", "android");
+    await repo.upsertToken(user.userId, "token-list-1", DevicePlatform.ios);
+    await repo.upsertToken(user.userId, "token-list-2", DevicePlatform.android);
 
     const tokens = await repo.findByUserId(user.userId);
     assert.equal(tokens.length, 2);
@@ -179,7 +180,7 @@ describe("DeviceTokenRepository", () => {
         _id: new ObjectId(),
         userId: new ObjectId(user.userId),
         token: `desktop-token-${user.userId}`,
-        platform: "macos",
+        platform: DevicePlatform.macos,
         createdAt: desktopAt,
         updatedAt: desktopAt,
       },
@@ -187,7 +188,7 @@ describe("DeviceTokenRepository", () => {
         _id: new ObjectId(),
         userId: new ObjectId(user.userId),
         token: `earliest-mobile-token-${user.userId}`,
-        platform: "ios",
+        platform: DevicePlatform.ios,
         createdAt: firstMobileAt,
         updatedAt: firstMobileAt,
       },
@@ -195,7 +196,7 @@ describe("DeviceTokenRepository", () => {
         _id: new ObjectId(),
         userId: new ObjectId(user.userId),
         token: `later-mobile-token-${user.userId}`,
-        platform: "android",
+        platform: DevicePlatform.android,
         createdAt: secondMobileAt,
         updatedAt: secondMobileAt,
       },
@@ -253,7 +254,7 @@ describe("DeviceTokenRepository", () => {
   it("deleteByToken removes specific token", async () => {
     const user = await ctx.createUser();
 
-    await repo.upsertToken(user.userId, "token-delete-one", "ios");
+    await repo.upsertToken(user.userId, "token-delete-one", DevicePlatform.ios);
     await repo.deleteByToken("token-delete-one");
 
     const tokens = await repo.findByUserId(user.userId);
@@ -263,9 +264,9 @@ describe("DeviceTokenRepository", () => {
   it("deleteByTokens removes provided tokens", async () => {
     const user = await ctx.createUser();
 
-    await repo.upsertToken(user.userId, "token-delete-many-1", "ios");
-    await repo.upsertToken(user.userId, "token-delete-many-2", "android");
-    await repo.upsertToken(user.userId, "token-delete-many-3", "ios");
+    await repo.upsertToken(user.userId, "token-delete-many-1", DevicePlatform.ios);
+    await repo.upsertToken(user.userId, "token-delete-many-2", DevicePlatform.android);
+    await repo.upsertToken(user.userId, "token-delete-many-3", DevicePlatform.ios);
 
     await repo.deleteByTokens(["token-delete-many-1", "token-delete-many-2"]);
 
@@ -277,8 +278,8 @@ describe("DeviceTokenRepository", () => {
   it("deleteAllForUser removes all tokens for user", async () => {
     const user = await ctx.createUser();
 
-    await repo.upsertToken(user.userId, "token-delete-all-1", "ios");
-    await repo.upsertToken(user.userId, "token-delete-all-2", "android");
+    await repo.upsertToken(user.userId, "token-delete-all-1", DevicePlatform.ios);
+    await repo.upsertToken(user.userId, "token-delete-all-2", DevicePlatform.android);
 
     await repo.deleteAllForUser(user.userId);
 

--- a/tests/notifications/routes.test.ts
+++ b/tests/notifications/routes.test.ts
@@ -80,9 +80,9 @@ describe("Notification routes", () => {
 
   it("POST /notifications/register-token accepts and persists every supported platform", async () => {
     const user = await ctx.createUser();
-    const supportedPlatforms = ["ios", "android", "macos", "windows", "linux"] as const;
-
-    for (const platform of supportedPlatforms) {
+    const desktopPlatforms = ["macos", "windows", "linux"] as const;
+    const mobilePlatforms = ["ios", "android"] as const;
+    const register = async (platform: (typeof desktopPlatforms)[number] | (typeof mobilePlatforms)[number]) => {
       const res = await ctx.app.inject({
         method: "POST",
         url: "/notifications/register-token",
@@ -93,10 +93,20 @@ describe("Notification routes", () => {
         payload: JSON.stringify({ token: `fcm-token-${platform}`, platform }),
       });
 
-      assert.equal(res.statusCode, 200);
-      assert.deepEqual(res.json(), { ok: true });
+      assert.equal(res.statusCode, 200, platform);
+      assert.deepEqual(res.json(), { ok: true }, platform);
+    };
+
+    for (const platform of desktopPlatforms) {
+      await register(platform);
+    }
+    assert.equal(await activationStateRepo.findByUserId(user.userId), null);
+
+    for (const platform of mobilePlatforms) {
+      await register(platform);
     }
 
+    const supportedPlatforms = [...desktopPlatforms, ...mobilePlatforms];
     const tokens = await deviceTokenRepo.findByUserId(user.userId);
     assert.equal(tokens.length, supportedPlatforms.length);
     const platformsByToken = new Map(tokens.map((token) => [token.token, token.platform]));
@@ -109,9 +119,43 @@ describe("Notification routes", () => {
     assert.equal(activationState.bridgeReminderBaseAt?.toISOString(), activationState.mobileSetupAt.toISOString());
   });
 
+  it("POST /notifications/register-token starts mobile activation when a desktop token becomes mobile", async () => {
+    const user = await ctx.createUser();
+    const token = `fcm-transition-${user.userId}`;
+    const register = (platform: "macos" | "ios") =>
+      ctx.app.inject({
+        method: "POST",
+        url: "/notifications/register-token",
+        headers: {
+          authorization: `Bearer ${user.accessToken}`,
+          "content-type": "application/json",
+        },
+        payload: JSON.stringify({ token, platform }),
+      });
+
+    const desktopResponse = await register("macos");
+    assert.equal(desktopResponse.statusCode, 200);
+    const desktopToken = (await deviceTokenRepo.findByUserId(user.userId))[0];
+    assert.ok(desktopToken);
+    assert.equal(await activationStateRepo.findByUserId(user.userId), null);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const mobileResponse = await register("ios");
+    assert.equal(mobileResponse.statusCode, 200);
+    const mobileToken = (await deviceTokenRepo.findByUserId(user.userId))[0];
+    const activationState = await activationStateRepo.findByUserId(user.userId);
+
+    assert.ok(mobileToken);
+    assert.equal(mobileToken.platform, "ios");
+    assert.ok(mobileToken.createdAt.getTime() > desktopToken.createdAt.getTime());
+    assert.equal(mobileToken.createdAt.toISOString(), mobileToken.updatedAt.toISOString());
+    assert.equal(activationState?.mobileSetupAt?.toISOString(), mobileToken.createdAt.toISOString());
+    assert.equal(activationState?.bridgeReminderBaseAt?.toISOString(), mobileToken.createdAt.toISOString());
+  });
+
   it("POST /notifications/register-token succeeds when activation recording fails", async () => {
     const user = await ctx.createUser();
-    const recordMock = mock.method(ActivationService.prototype, "recordMobileSetup", async () => {
+    const recordMock = mock.method(ActivationService.prototype, "recordDeviceTokenRegistration", async () => {
       throw new Error("activation unavailable");
     });
     const warnMock = mock.method(console, "warn", () => {});
@@ -128,6 +172,7 @@ describe("Notification routes", () => {
 
     assert.equal(res.statusCode, 200);
     assert.equal(recordMock.mock.callCount(), 1);
+    assert.equal(recordMock.mock.calls[0]?.arguments[1], "android");
     assert.equal(warnMock.mock.callCount(), 1);
     assert.equal((await deviceTokenRepo.findByUserId(user.userId)).length, 1);
   });

--- a/tests/notifications/routes.test.ts
+++ b/tests/notifications/routes.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { after, afterEach, before, beforeEach, describe, it, mock } from "node:test";
+import { DevicePlatform } from "../../src/models/device.js";
 import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
 import { DeviceTokenRepository } from "../../src/repositories/device-token-repo.js";
 import { ActivationService } from "../../src/services/activation-service.js";
@@ -214,7 +215,7 @@ describe("Notification routes", () => {
   it("DELETE /notifications/tokens/:token returns 200 with auth", async () => {
     const user = await ctx.createUser();
     const token = "token/with:special?chars";
-    await deviceTokenRepo.upsertToken(user.userId, token, "android");
+    await deviceTokenRepo.upsertToken(user.userId, token, DevicePlatform.android);
 
     const res = await ctx.app.inject({
       method: "DELETE",

--- a/tests/notifications/routes.test.ts
+++ b/tests/notifications/routes.test.ts
@@ -100,7 +100,12 @@ describe("Notification routes", () => {
     for (const platform of desktopPlatforms) {
       await register(platform);
     }
-    assert.equal(await activationStateRepo.findByUserId(user.userId), null);
+    const firstAppToken = (await deviceTokenRepo.findByUserId(user.userId)).find(
+      (token) => token.token === "fcm-token-macos",
+    );
+    const desktopActivationState = await activationStateRepo.findByUserId(user.userId);
+    assert.ok(firstAppToken);
+    assert.equal(desktopActivationState?.mobileSetupAt?.toISOString(), firstAppToken.createdAt.toISOString());
 
     for (const platform of mobilePlatforms) {
       await register(platform);
@@ -116,10 +121,11 @@ describe("Notification routes", () => {
 
     const activationState = await activationStateRepo.findByUserId(user.userId);
     assert.ok(activationState?.mobileSetupAt);
-    assert.equal(activationState.bridgeReminderBaseAt?.toISOString(), activationState.mobileSetupAt.toISOString());
+    assert.equal(activationState.mobileSetupAt.toISOString(), firstAppToken.createdAt.toISOString());
+    assert.equal(activationState.bridgeReminderBaseAt?.toISOString(), firstAppToken.createdAt.toISOString());
   });
 
-  it("POST /notifications/register-token starts mobile activation when a desktop token becomes mobile", async () => {
+  it("POST /notifications/register-token preserves first app activation when a token changes platform", async () => {
     const user = await ctx.createUser();
     const token = `fcm-transition-${user.userId}`;
     const register = (platform: "macos" | "ios") =>
@@ -136,8 +142,9 @@ describe("Notification routes", () => {
     const desktopResponse = await register("macos");
     assert.equal(desktopResponse.statusCode, 200);
     const desktopToken = (await deviceTokenRepo.findByUserId(user.userId))[0];
+    const desktopActivationState = await activationStateRepo.findByUserId(user.userId);
     assert.ok(desktopToken);
-    assert.equal(await activationStateRepo.findByUserId(user.userId), null);
+    assert.equal(desktopActivationState?.mobileSetupAt?.toISOString(), desktopToken.createdAt.toISOString());
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     const mobileResponse = await register("ios");
@@ -147,15 +154,15 @@ describe("Notification routes", () => {
 
     assert.ok(mobileToken);
     assert.equal(mobileToken.platform, "ios");
-    assert.ok(mobileToken.createdAt.getTime() > desktopToken.createdAt.getTime());
-    assert.equal(mobileToken.createdAt.toISOString(), mobileToken.updatedAt.toISOString());
-    assert.equal(activationState?.mobileSetupAt?.toISOString(), mobileToken.createdAt.toISOString());
-    assert.equal(activationState?.bridgeReminderBaseAt?.toISOString(), mobileToken.createdAt.toISOString());
+    assert.equal(mobileToken.createdAt.toISOString(), desktopToken.createdAt.toISOString());
+    assert.ok(mobileToken.updatedAt.getTime() > desktopToken.updatedAt.getTime());
+    assert.equal(activationState?.mobileSetupAt?.toISOString(), desktopToken.createdAt.toISOString());
+    assert.equal(activationState?.bridgeReminderBaseAt?.toISOString(), desktopToken.createdAt.toISOString());
   });
 
   it("POST /notifications/register-token succeeds when activation recording fails", async () => {
     const user = await ctx.createUser();
-    const recordMock = mock.method(ActivationService.prototype, "recordDeviceTokenRegistration", async () => {
+    const recordMock = mock.method(ActivationService.prototype, "recordAppSetup", async () => {
       throw new Error("activation unavailable");
     });
     const warnMock = mock.method(console, "warn", () => {});
@@ -172,7 +179,6 @@ describe("Notification routes", () => {
 
     assert.equal(res.statusCode, 200);
     assert.equal(recordMock.mock.callCount(), 1);
-    assert.equal(recordMock.mock.calls[0]?.arguments[1], "android");
     assert.equal(warnMock.mock.callCount(), 1);
     assert.equal((await deviceTokenRepo.findByUserId(user.userId)).length, 1);
   });

--- a/tests/notifications/routes.test.ts
+++ b/tests/notifications/routes.test.ts
@@ -78,26 +78,32 @@ describe("Notification routes", () => {
     await ctx.cleanup();
   });
 
-  it("POST /notifications/register-token returns 200 with valid body and auth", async () => {
+  it("POST /notifications/register-token accepts and persists every supported platform", async () => {
     const user = await ctx.createUser();
+    const supportedPlatforms = ["ios", "android", "macos", "windows", "linux"] as const;
 
-    const res = await ctx.app.inject({
-      method: "POST",
-      url: "/notifications/register-token",
-      headers: {
-        authorization: `Bearer ${user.accessToken}`,
-        "content-type": "application/json",
-      },
-      payload: JSON.stringify({ token: "fcm-token-1", platform: "ios" }),
-    });
+    for (const platform of supportedPlatforms) {
+      const res = await ctx.app.inject({
+        method: "POST",
+        url: "/notifications/register-token",
+        headers: {
+          authorization: `Bearer ${user.accessToken}`,
+          "content-type": "application/json",
+        },
+        payload: JSON.stringify({ token: `fcm-token-${platform}`, platform }),
+      });
 
-    assert.equal(res.statusCode, 200);
-    assert.deepEqual(res.json(), { ok: true });
+      assert.equal(res.statusCode, 200);
+      assert.deepEqual(res.json(), { ok: true });
+    }
 
     const tokens = await deviceTokenRepo.findByUserId(user.userId);
-    assert.equal(tokens.length, 1);
-    assert.equal(tokens[0]?.token, "fcm-token-1");
-    assert.equal(tokens[0]?.platform, "ios");
+    assert.equal(tokens.length, supportedPlatforms.length);
+    const platformsByToken = new Map(tokens.map((token) => [token.token, token.platform]));
+    for (const platform of supportedPlatforms) {
+      assert.equal(platformsByToken.get(`fcm-token-${platform}`), platform);
+    }
+
     const activationState = await activationStateRepo.findByUserId(user.userId);
     assert.ok(activationState?.mobileSetupAt);
     assert.equal(activationState.bridgeReminderBaseAt?.toISOString(), activationState.mobileSetupAt.toISOString());
@@ -151,6 +157,7 @@ describe("Notification routes", () => {
     });
 
     assert.equal(res.statusCode, 400);
+    assert.deepEqual(res.json(), { error: "bad_request" });
   });
 
   it("DELETE /notifications/tokens/:token returns 200 with auth", async () => {

--- a/tests/services/activation-backfill-cli.test.ts
+++ b/tests/services/activation-backfill-cli.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { after, afterEach, before, beforeEach, describe, it, mock } from "node:test";
 import { ObjectId } from "mongodb";
+import { DevicePlatform } from "../../src/models/device.js";
 import { parseActivationBackfillArgs, runActivationBackfillCli } from "../../src/scripts/backfill-activation.js";
 import type { DeviceToken } from "../../src/models/documents.js";
 import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
@@ -67,7 +68,7 @@ describe("activation backfill CLI", () => {
       _id: new ObjectId(),
       userId: new ObjectId(user.userId),
       token: `cli-backfill-token-${user.userId}`,
-      platform: "ios",
+      platform: DevicePlatform.ios,
       createdAt: at,
       updatedAt: at,
     });

--- a/tests/services/activation-backfill-service.test.ts
+++ b/tests/services/activation-backfill-service.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
 import { ObjectId } from "mongodb";
-import { BridgeStatus } from "../../src/models/bridge.js";
+import { BridgePlatform, BridgeStatus } from "../../src/models/bridge.js";
 import { DevicePlatform } from "../../src/models/device.js";
 import type { ActivationState, Bridge, DailyUsage, DeviceToken } from "../../src/models/documents.js";
 import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
@@ -64,7 +64,7 @@ describe("ActivationBackfillService", () => {
       bridgeId: `br_${userId}`,
       userId: new ObjectId(userId),
       name: "Historical bridge",
-      platform: "macos",
+      platform: BridgePlatform.macos,
       status: BridgeStatus.inactive,
       addedAt,
       lastSeenAt: null,

--- a/tests/services/activation-backfill-service.test.ts
+++ b/tests/services/activation-backfill-service.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
 import { ObjectId } from "mongodb";
 import { BridgeStatus } from "../../src/models/bridge.js";
+import { DevicePlatform } from "../../src/models/device.js";
 import type { ActivationState, Bridge, DailyUsage, DeviceToken } from "../../src/models/documents.js";
 import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
 import { BridgeRepository } from "../../src/repositories/bridge-repo.js";
@@ -42,12 +43,16 @@ describe("ActivationBackfillService", () => {
     await ctx.cleanup();
   });
 
-  async function seedToken(userId: string, createdAt: Date): Promise<void> {
+  async function seedToken(
+    userId: string,
+    createdAt: Date,
+    platform: DevicePlatform = DevicePlatform.ios,
+  ): Promise<void> {
     await ctx.dbAccessor.getCollection<DeviceToken>(MongoDbDatabase.Auth, AuthDbCollection.DeviceTokens).insertOne({
       _id: new ObjectId(),
       userId: new ObjectId(userId),
       token: `backfill-token-${userId}`,
-      platform: "ios",
+      platform,
       createdAt,
       updatedAt: createdAt,
     });
@@ -206,6 +211,25 @@ describe("ActivationBackfillService", () => {
     );
   });
 
+  it("does not use a desktop-only token as mobile activation evidence", async () => {
+    const user = await ctx.createUser();
+    await seedToken(user.userId, new Date("2026-06-01T08:00:00.000Z"), DevicePlatform.windows);
+
+    const report = await service.run({
+      apply: true,
+      backfillAt: BACKFILL_AT,
+      batchLimit: 10,
+      jitterWindowMs: 0,
+    });
+    const state = await activationStateRepo.findByUserId(user.userId);
+
+    assert.equal(report.usersApplied, 1);
+    assert.equal(report.byStage[ActivationBackfillStage.MobileIncomplete].applied, 1);
+    assert.equal(report.byReminder[ActivationBackfillReminder.None].applied, 1);
+    assert.equal(state?.mobileSetupAt, null);
+    assert.equal(state?.bridgeReminderBaseAt, null);
+  });
+
   it("produces stable bounded jitter", () => {
     const userId = new ObjectId().toHexString();
     const first = deterministicActivationJitterMs(userId, JITTER_WINDOW_MS);
@@ -240,7 +264,7 @@ describe("ActivationBackfillService", () => {
     const failedUser = await ctx.createUser();
     const successfulUser = await ctx.createUser();
     const deviceTokenRepo = new DeviceTokenRepository(ctx.dbAccessor);
-    t.mock.method(deviceTokenRepo, "findEarliestCreatedAt", async (userId: string) => {
+    t.mock.method(deviceTokenRepo, "findEarliestMobileCreatedAt", async (userId: string) => {
       if (userId === failedUser.userId) {
         throw new Error("token lookup failed");
       }

--- a/tests/services/activation-backfill-service.test.ts
+++ b/tests/services/activation-backfill-service.test.ts
@@ -211,9 +211,10 @@ describe("ActivationBackfillService", () => {
     );
   });
 
-  it("does not use a desktop-only token as mobile activation evidence", async () => {
+  it("uses a desktop-only token as app activation evidence", async () => {
     const user = await ctx.createUser();
-    await seedToken(user.userId, new Date("2026-06-01T08:00:00.000Z"), DevicePlatform.windows);
+    const appSetupAt = new Date("2026-06-01T08:00:00.000Z");
+    await seedToken(user.userId, appSetupAt, DevicePlatform.windows);
 
     const report = await service.run({
       apply: true,
@@ -224,10 +225,10 @@ describe("ActivationBackfillService", () => {
     const state = await activationStateRepo.findByUserId(user.userId);
 
     assert.equal(report.usersApplied, 1);
-    assert.equal(report.byStage[ActivationBackfillStage.MobileIncomplete].applied, 1);
-    assert.equal(report.byReminder[ActivationBackfillReminder.None].applied, 1);
-    assert.equal(state?.mobileSetupAt, null);
-    assert.equal(state?.bridgeReminderBaseAt, null);
+    assert.equal(report.byStage[ActivationBackfillStage.BridgeIncomplete].applied, 1);
+    assert.equal(report.byReminder[ActivationBackfillReminder.Bridge1].applied, 1);
+    assert.equal(state?.mobileSetupAt?.toISOString(), appSetupAt.toISOString());
+    assert.equal(state?.bridgeReminderBaseAt?.toISOString(), BACKFILL_AT.toISOString());
   });
 
   it("produces stable bounded jitter", () => {
@@ -264,7 +265,7 @@ describe("ActivationBackfillService", () => {
     const failedUser = await ctx.createUser();
     const successfulUser = await ctx.createUser();
     const deviceTokenRepo = new DeviceTokenRepository(ctx.dbAccessor);
-    t.mock.method(deviceTokenRepo, "findEarliestMobileCreatedAt", async (userId: string) => {
+    t.mock.method(deviceTokenRepo, "findEarliestCreatedAt", async (userId: string) => {
       if (userId === failedUser.userId) {
         throw new Error("token lookup failed");
       }

--- a/tests/services/activation-reminder-service.test.ts
+++ b/tests/services/activation-reminder-service.test.ts
@@ -173,6 +173,10 @@ describe("ActivationReminderService", () => {
     assert.ok(repo.findCalls.every((call) => call.batchLimit === DEFAULT_OPTIONS.batchLimit));
     assert.equal(result.reminders[ActivationReminderKind.Session].sent, 1);
     assert.equal(result.reminders[ActivationReminderKind.Session].noDevices, 1);
+    assert.equal(
+      notification.sendCalls.find((call) => call.payload.collapseKey === "activation_bridge_1")?.payload.body,
+      "Install the Sesori bridge on your computer to connect your coding agents.",
+    );
     assert.ok(logCalls.some((args) => args[0] === "[ActivationReminderService] Reminder sent"));
     assert.ok(logCalls.some((args) => args[0] === "[ActivationReminderService] Sweep completed"));
   });

--- a/tests/services/activation-service.test.ts
+++ b/tests/services/activation-service.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { after, afterEach, before, beforeEach, describe, it, mock } from "node:test";
 import { ObjectId } from "mongodb";
-import { DevicePlatform } from "../../src/models/device.js";
 import type { Bridge, DailyUsage, DeviceToken } from "../../src/models/documents.js";
 import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
 import { BridgeRepository } from "../../src/repositories/bridge-repo.js";
@@ -72,9 +71,8 @@ describe("ActivationService", () => {
       updatedAt: sessionAt,
     });
 
-    const state = await service.recordDeviceTokenRegistration(user.userId, DevicePlatform.ios, observedAt);
+    const state = await service.recordAppSetup(user.userId, observedAt);
 
-    assert.ok(state);
     assert.equal(state.mobileSetupAt?.toISOString(), mobileAt.toISOString());
     assert.equal(state.bridgeSetupAt?.toISOString(), bridgeAt.toISOString());
     assert.equal(state.firstSessionAt?.toISOString(), sessionAt.toISOString());
@@ -86,15 +84,18 @@ describe("ActivationService", () => {
     );
   });
 
-  it("ignores desktop device-token registrations", async () => {
+  it("records app setup for a device-token registration", async () => {
     const user = await ctx.createUser();
+    const observedAt = new Date("2026-07-12T10:00:00.000Z");
 
-    for (const platform of [DevicePlatform.macos, DevicePlatform.windows, DevicePlatform.linux]) {
-      assert.equal(await service.recordDeviceTokenRegistration(user.userId, platform), null);
-    }
+    const state = await service.recordAppSetup(user.userId, observedAt);
 
-    assert.equal(await activationStateRepo.findByUserId(user.userId), null);
-    assert.deepEqual(logCalls, []);
+    assert.equal(state.mobileSetupAt?.toISOString(), observedAt.toISOString());
+    assert.equal(state.bridgeReminderBaseAt?.toISOString(), observedAt.toISOString());
+    assert.deepEqual(
+      logCalls.map((args) => (args[1] as { milestone: string }).milestone),
+      ["mobile_setup"],
+    );
   });
 
   it("records bridge and session milestones before mobile setup without creating reminder baselines", async () => {
@@ -144,7 +145,7 @@ describe("ActivationService", () => {
   it("repairs mobile setup from token history when recording bridge setup", async () => {
     const user = await ctx.createUser();
     await deviceTokenRepo.upsertToken(user.userId, `bridge-repair-token-${user.userId}`, "ios");
-    const mobileAt = await deviceTokenRepo.findEarliestMobileCreatedAt(user.userId);
+    const mobileAt = await deviceTokenRepo.findEarliestCreatedAt(user.userId);
     const bridge = await bridgeRepo.register({ userId: user.userId, name: "Repair", platform: "macos" });
 
     const state = await service.recordBridgeSetup(user.userId, bridge.addedAt);
@@ -155,17 +156,18 @@ describe("ActivationService", () => {
     assert.equal(state.sessionReminderBaseAt?.toISOString(), bridge.addedAt.toISOString());
   });
 
-  it("does not infer mobile setup from a persisted desktop token", async () => {
+  it("reconciles app setup from a persisted desktop token", async () => {
     const user = await ctx.createUser();
-    await deviceTokenRepo.upsertToken(user.userId, `desktop-only-token-${user.userId}`, DevicePlatform.windows);
+    await deviceTokenRepo.upsertToken(user.userId, `desktop-only-token-${user.userId}`, "windows");
+    const appSetupAt = await deviceTokenRepo.findEarliestCreatedAt(user.userId);
     const bridge = await bridgeRepo.register({ userId: user.userId, name: "Desktop only", platform: "windows" });
 
     const state = await service.recordBridgeSetup(user.userId, bridge.addedAt);
 
-    assert.equal(state.mobileSetupAt, null);
+    assert.equal(state.mobileSetupAt?.toISOString(), appSetupAt?.toISOString());
     assert.equal(state.bridgeSetupAt?.toISOString(), bridge.addedAt.toISOString());
-    assert.equal(state.bridgeReminderBaseAt, null);
-    assert.equal(state.sessionReminderBaseAt, null);
+    assert.equal(state.bridgeReminderBaseAt?.toISOString(), appSetupAt?.toISOString());
+    assert.equal(state.sessionReminderBaseAt?.toISOString(), bridge.addedAt.toISOString());
   });
 
   it("uses historical metadata evidence when recording a later session request", async () => {
@@ -226,7 +228,7 @@ describe("ActivationService", () => {
       createdAt: mobileAt,
       updatedAt: mobileAt,
     });
-    await service.recordDeviceTokenRegistration(user.userId, DevicePlatform.ios, mobileAt);
+    await service.recordAppSetup(user.userId, mobileAt);
 
     const bridge = await bridgeRepo.register({ userId: user.userId, name: "Later", platform: "macos" });
     await ctx.dbAccessor
@@ -242,13 +244,8 @@ describe("ActivationService", () => {
       updatedAt: sessionAt,
     });
 
-    const state = await service.recordDeviceTokenRegistration(
-      user.userId,
-      DevicePlatform.ios,
-      new Date("2026-07-15T10:00:00.000Z"),
-    );
+    const state = await service.recordAppSetup(user.userId, new Date("2026-07-15T10:00:00.000Z"));
 
-    assert.ok(state);
     assert.equal(state.mobileSetupAt?.toISOString(), mobileAt.toISOString());
     assert.equal(state.bridgeSetupAt?.toISOString(), bridgeAt.toISOString());
     assert.equal(state.firstSessionAt?.toISOString(), sessionAt.toISOString());
@@ -259,9 +256,8 @@ describe("ActivationService", () => {
     const user = await ctx.createUser();
     const observedAt = new Date("2026-07-12T10:00:00.000Z");
 
-    const state = await service.recordDeviceTokenRegistration(user.userId, DevicePlatform.android, observedAt);
+    const state = await service.recordAppSetup(user.userId, observedAt);
 
-    assert.ok(state);
     assert.equal(state.mobileSetupAt?.toISOString(), observedAt.toISOString());
     assert.equal(state.bridgeReminderBaseAt?.toISOString(), observedAt.toISOString());
   });

--- a/tests/services/activation-service.test.ts
+++ b/tests/services/activation-service.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { after, afterEach, before, beforeEach, describe, it, mock } from "node:test";
 import { ObjectId } from "mongodb";
+import { DevicePlatform } from "../../src/models/device.js";
 import type { Bridge, DailyUsage, DeviceToken } from "../../src/models/documents.js";
 import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
 import { BridgeRepository } from "../../src/repositories/bridge-repo.js";
@@ -71,8 +72,9 @@ describe("ActivationService", () => {
       updatedAt: sessionAt,
     });
 
-    const state = await service.recordMobileSetup(user.userId, observedAt);
+    const state = await service.recordDeviceTokenRegistration(user.userId, DevicePlatform.ios, observedAt);
 
+    assert.ok(state);
     assert.equal(state.mobileSetupAt?.toISOString(), mobileAt.toISOString());
     assert.equal(state.bridgeSetupAt?.toISOString(), bridgeAt.toISOString());
     assert.equal(state.firstSessionAt?.toISOString(), sessionAt.toISOString());
@@ -82,6 +84,17 @@ describe("ActivationService", () => {
       logCalls.map((args) => (args[1] as { milestone: string }).milestone),
       ["mobile_setup", "bridge_setup", "first_session"],
     );
+  });
+
+  it("ignores desktop device-token registrations", async () => {
+    const user = await ctx.createUser();
+
+    for (const platform of [DevicePlatform.macos, DevicePlatform.windows, DevicePlatform.linux]) {
+      assert.equal(await service.recordDeviceTokenRegistration(user.userId, platform), null);
+    }
+
+    assert.equal(await activationStateRepo.findByUserId(user.userId), null);
+    assert.deepEqual(logCalls, []);
   });
 
   it("records bridge and session milestones before mobile setup without creating reminder baselines", async () => {
@@ -131,7 +144,7 @@ describe("ActivationService", () => {
   it("repairs mobile setup from token history when recording bridge setup", async () => {
     const user = await ctx.createUser();
     await deviceTokenRepo.upsertToken(user.userId, `bridge-repair-token-${user.userId}`, "ios");
-    const mobileAt = await deviceTokenRepo.findEarliestCreatedAt(user.userId);
+    const mobileAt = await deviceTokenRepo.findEarliestMobileCreatedAt(user.userId);
     const bridge = await bridgeRepo.register({ userId: user.userId, name: "Repair", platform: "macos" });
 
     const state = await service.recordBridgeSetup(user.userId, bridge.addedAt);
@@ -140,6 +153,19 @@ describe("ActivationService", () => {
     assert.equal(state.bridgeSetupAt?.toISOString(), bridge.addedAt.toISOString());
     assert.equal(state.bridgeReminderBaseAt?.toISOString(), mobileAt?.toISOString());
     assert.equal(state.sessionReminderBaseAt?.toISOString(), bridge.addedAt.toISOString());
+  });
+
+  it("does not infer mobile setup from a persisted desktop token", async () => {
+    const user = await ctx.createUser();
+    await deviceTokenRepo.upsertToken(user.userId, `desktop-only-token-${user.userId}`, DevicePlatform.windows);
+    const bridge = await bridgeRepo.register({ userId: user.userId, name: "Desktop only", platform: "windows" });
+
+    const state = await service.recordBridgeSetup(user.userId, bridge.addedAt);
+
+    assert.equal(state.mobileSetupAt, null);
+    assert.equal(state.bridgeSetupAt?.toISOString(), bridge.addedAt.toISOString());
+    assert.equal(state.bridgeReminderBaseAt, null);
+    assert.equal(state.sessionReminderBaseAt, null);
   });
 
   it("uses historical metadata evidence when recording a later session request", async () => {
@@ -200,7 +226,7 @@ describe("ActivationService", () => {
       createdAt: mobileAt,
       updatedAt: mobileAt,
     });
-    await service.recordMobileSetup(user.userId, mobileAt);
+    await service.recordDeviceTokenRegistration(user.userId, DevicePlatform.ios, mobileAt);
 
     const bridge = await bridgeRepo.register({ userId: user.userId, name: "Later", platform: "macos" });
     await ctx.dbAccessor
@@ -216,8 +242,13 @@ describe("ActivationService", () => {
       updatedAt: sessionAt,
     });
 
-    const state = await service.recordMobileSetup(user.userId, new Date("2026-07-15T10:00:00.000Z"));
+    const state = await service.recordDeviceTokenRegistration(
+      user.userId,
+      DevicePlatform.ios,
+      new Date("2026-07-15T10:00:00.000Z"),
+    );
 
+    assert.ok(state);
     assert.equal(state.mobileSetupAt?.toISOString(), mobileAt.toISOString());
     assert.equal(state.bridgeSetupAt?.toISOString(), bridgeAt.toISOString());
     assert.equal(state.firstSessionAt?.toISOString(), sessionAt.toISOString());
@@ -228,8 +259,9 @@ describe("ActivationService", () => {
     const user = await ctx.createUser();
     const observedAt = new Date("2026-07-12T10:00:00.000Z");
 
-    const state = await service.recordMobileSetup(user.userId, observedAt);
+    const state = await service.recordDeviceTokenRegistration(user.userId, DevicePlatform.android, observedAt);
 
+    assert.ok(state);
     assert.equal(state.mobileSetupAt?.toISOString(), observedAt.toISOString());
     assert.equal(state.bridgeReminderBaseAt?.toISOString(), observedAt.toISOString());
   });

--- a/tests/services/activation-service.test.ts
+++ b/tests/services/activation-service.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { after, afterEach, before, beforeEach, describe, it, mock } from "node:test";
 import { ObjectId } from "mongodb";
+import { BridgePlatform } from "../../src/models/bridge.js";
+import { DevicePlatform } from "../../src/models/device.js";
 import type { Bridge, DailyUsage, DeviceToken } from "../../src/models/documents.js";
 import { ActivationStateRepository } from "../../src/repositories/activation-state-repo.js";
 import { BridgeRepository } from "../../src/repositories/bridge-repo.js";
@@ -53,11 +55,15 @@ describe("ActivationService", () => {
       _id: new ObjectId(),
       userId: new ObjectId(user.userId),
       token: `activation-token-${user.userId}`,
-      platform: "ios",
+      platform: DevicePlatform.ios,
       createdAt: mobileAt,
       updatedAt: mobileAt,
     });
-    const bridge = await bridgeRepo.register({ userId: user.userId, name: "Historical", platform: "macos" });
+    const bridge = await bridgeRepo.register({
+      userId: user.userId,
+      name: "Historical",
+      platform: BridgePlatform.macos,
+    });
     await ctx.dbAccessor
       .getCollection<Bridge>(MongoDbDatabase.Auth, AuthDbCollection.Bridges)
       .updateOne({ bridgeId: bridge.bridgeId }, { $set: { addedAt: bridgeAt, revokedAt: observedAt } });
@@ -129,13 +135,17 @@ describe("ActivationService", () => {
     const user = await ctx.createUser();
     const historicalAt = new Date("2026-07-10T10:00:00.000Z");
     const observedAt = new Date("2026-07-15T10:00:00.000Z");
-    const historical = await bridgeRepo.register({ userId: user.userId, name: "Historical", platform: "macos" });
+    const historical = await bridgeRepo.register({
+      userId: user.userId,
+      name: "Historical",
+      platform: BridgePlatform.macos,
+    });
     const collection = ctx.dbAccessor.getCollection<Bridge>(MongoDbDatabase.Auth, AuthDbCollection.Bridges);
     await collection.updateOne(
       { bridgeId: historical.bridgeId },
       { $set: { addedAt: historicalAt, revokedAt: observedAt } },
     );
-    await bridgeRepo.register({ userId: user.userId, name: "Current", platform: "linux" });
+    await bridgeRepo.register({ userId: user.userId, name: "Current", platform: BridgePlatform.linux });
 
     const state = await service.recordBridgeSetup(user.userId, observedAt);
 
@@ -144,9 +154,13 @@ describe("ActivationService", () => {
 
   it("repairs mobile setup from token history when recording bridge setup", async () => {
     const user = await ctx.createUser();
-    await deviceTokenRepo.upsertToken(user.userId, `bridge-repair-token-${user.userId}`, "ios");
+    await deviceTokenRepo.upsertToken(user.userId, `bridge-repair-token-${user.userId}`, DevicePlatform.ios);
     const mobileAt = await deviceTokenRepo.findEarliestCreatedAt(user.userId);
-    const bridge = await bridgeRepo.register({ userId: user.userId, name: "Repair", platform: "macos" });
+    const bridge = await bridgeRepo.register({
+      userId: user.userId,
+      name: "Repair",
+      platform: BridgePlatform.macos,
+    });
 
     const state = await service.recordBridgeSetup(user.userId, bridge.addedAt);
 
@@ -158,9 +172,13 @@ describe("ActivationService", () => {
 
   it("reconciles app setup from a persisted desktop token", async () => {
     const user = await ctx.createUser();
-    await deviceTokenRepo.upsertToken(user.userId, `desktop-only-token-${user.userId}`, "windows");
+    await deviceTokenRepo.upsertToken(user.userId, `desktop-only-token-${user.userId}`, DevicePlatform.windows);
     const appSetupAt = await deviceTokenRepo.findEarliestCreatedAt(user.userId);
-    const bridge = await bridgeRepo.register({ userId: user.userId, name: "Desktop only", platform: "windows" });
+    const bridge = await bridgeRepo.register({
+      userId: user.userId,
+      name: "Desktop only",
+      platform: BridgePlatform.windows,
+    });
 
     const state = await service.recordBridgeSetup(user.userId, bridge.addedAt);
 
@@ -194,7 +212,7 @@ describe("ActivationService", () => {
     const mobileAt = new Date("2026-07-10T10:00:00.000Z");
     const sessionAt = new Date("2026-07-12T10:00:00.000Z");
     await activationStateRepo.recordMilestones(user.userId, { mobileSetupAt: mobileAt }, mobileAt);
-    const bridge = await bridgeRepo.register({ userId: user.userId, name: "Repair", platform: "linux" });
+    const bridge = await bridgeRepo.register({ userId: user.userId, name: "Repair", platform: BridgePlatform.linux });
 
     const state = await service.recordFirstSession(user.userId, sessionAt);
 
@@ -224,13 +242,13 @@ describe("ActivationService", () => {
       _id: new ObjectId(),
       userId: new ObjectId(user.userId),
       token: `retry-token-${user.userId}`,
-      platform: "ios",
+      platform: DevicePlatform.ios,
       createdAt: mobileAt,
       updatedAt: mobileAt,
     });
     await service.recordAppSetup(user.userId, mobileAt);
 
-    const bridge = await bridgeRepo.register({ userId: user.userId, name: "Later", platform: "macos" });
+    const bridge = await bridgeRepo.register({ userId: user.userId, name: "Later", platform: BridgePlatform.macos });
     await ctx.dbAccessor
       .getCollection<Bridge>(MongoDbDatabase.Auth, AuthDbCollection.Bridges)
       .updateOne({ bridgeId: bridge.bridgeId }, { $set: { addedAt: bridgeAt } });


### PR DESCRIPTION
## Summary
- centralize the device-token platform contract in a shared enum-backed Zod schema
- accept `ios`, `android`, `macos`, `windows`, and `linux` token registrations while continuing to reject `web`
- verify every supported platform is authenticated, accepted, and persisted with activation behavior preserved

## Testing
- `MONGOMS_VERSION=7.0.24 node --import tsx --test --test-concurrency=1 tests/notifications/routes.test.ts`
- `MONGOMS_VERSION=7.0.24 npm test` (393 passed, 1 skipped)
- `npx tsc --noEmit`
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run circular-dependencies`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add desktop device-token support across macOS, Windows, and Linux, and treat any app token as activation evidence. Keeps the persisted name `mobileSetupAt` but records it from the first app registration across platforms.

- **New Features**
  - Accept and persist `macos`, `windows`, and `linux` tokens in `/notifications/register-token`; `web` remains rejected.
  - Shared `DevicePlatform` Zod enum used in API validation and document schemas.

- **Bug Fixes**
  - Count all app registrations (mobile or desktop) for activation and backfill; set/reconcile `mobileSetupAt` and reminder baselines from the earliest token.
  - Preserve `createdAt` for same-owner platform changes; reset only when the owner changes; concurrent updates serialize atomically.
  - Update Bridge 1 reminder body to "Install the Sesori bridge on your computer to connect your coding agents." and align tests to use `DevicePlatform` enums at typed boundaries.

<sup>Written for commit 2301282b4d5e6f78b5fea3511aa4903bcc04680b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

