### PR TITLE
feat(auth): add app-client presence status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ src/
 ## SCALING CONSTRAINTS
 
 - **Pending OAuth sessions are in-process only.** `PendingAuthStore` is an in-memory LRU with a 5-minute TTL. The store is NOT shared between instances. Horizontal scaling of this service requires either sticky sessions (`X-Sesori-Session-Token` → consistent instance) OR migrating the store to Redis. Until then: **single-instance deploys only**.
+- **App-client presence waiters are in-process only.** `AppClientPresenceService` wakes long polls on the instance that commits a device-token registration. Keep auth single-instance until app-presence signaling is distributed.
 - Tunable via `PENDING_AUTH_MAX_SESSIONS` (default 10k entries ≈ 10 MB) and `PENDING_AUTH_POLL_TIMEOUT_MS` (default 30s long-poll cap).
 - **Bridge notification debounce is in-process only.** `BridgeStateTracker` keeps per-(userId, bridgeId) debounce timers and last-notified state in a process-local Map: pending notifications are lost on restart, the map is unbounded for the process lifetime (acceptable under the 50-bridges-per-user registration cap), and multiple instances would double-notify. Same single-instance constraint as above.
 - **Activation reminder polling is in-process only.** `ActivationReminderService` has a process-local interval and single-flight guard. Multiple enabled instances can send the same reminder before either writes its MongoDB marker. Keep `ACTIVATION_REMINDERS_ENABLED=false` on all but one instance unless a distributed lease or claim is added.

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { PendingAuthStore } from "./services/pending-auth-store.js";
 import { SessionMetadataService } from "./services/session-metadata-service.js";
 import { TokenService } from "./services/token-service.js";
 import { VoiceService } from "./services/voice-service.js";
+import { AppClientPresenceService } from "./services/app-client-presence-service.js";
 
 async function main() {
   const config = loadConfig();
@@ -99,6 +100,7 @@ async function main() {
     dailyUsageRepo,
     deviceTokenRepo,
   });
+  const appClientPresenceService = new AppClientPresenceService({ deviceTokenRepo });
   const activationReminderService = new ActivationReminderService({
     activationStateRepo,
     notificationService,
@@ -159,6 +161,7 @@ async function main() {
     installScriptService,
     legalDocumentService,
     deviceTokenRepo,
+    appClientPresenceService,
     notificationService,
     bridgeStateTracker,
     activationService,

--- a/src/lib/request-close-signal.ts
+++ b/src/lib/request-close-signal.ts
@@ -1,0 +1,32 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+export function createRequestCloseSignal(params: { request: FastifyRequest; reply: FastifyReply }): AbortSignal {
+  const controller = new AbortController();
+
+  if (params.request.raw.destroyed || params.request.socket.destroyed || params.reply.raw.writableEnded) {
+    controller.abort();
+    return controller.signal;
+  }
+
+  const removeListeners = () => {
+    params.request.socket.off("close", abortIfUndelivered);
+    params.reply.raw.off("close", abortIfUndelivered);
+    params.reply.raw.off("finish", removeListeners);
+    params.reply.raw.off("close", removeListeners);
+  };
+  const abortIfUndelivered = () => {
+    if (!params.reply.raw.writableEnded) {
+      controller.abort();
+    }
+    removeListeners();
+  };
+
+  // A request stream can close normally on a healthy keep-alive connection.
+  // Socket/response events identify whether a reply can still be delivered.
+  params.request.socket.once("close", abortIfUndelivered);
+  params.reply.raw.once("close", abortIfUndelivered);
+  params.reply.raw.once("finish", removeListeners);
+  params.reply.raw.once("close", removeListeners);
+
+  return controller.signal;
+}

--- a/src/lib/request-close-signal.ts
+++ b/src/lib/request-close-signal.ts
@@ -3,7 +3,7 @@ import type { FastifyReply, FastifyRequest } from "fastify";
 export function createRequestCloseSignal(params: { request: FastifyRequest; reply: FastifyReply }): AbortSignal {
   const controller = new AbortController();
 
-  if (params.request.raw.destroyed || params.request.socket.destroyed || params.reply.raw.writableEnded) {
+  if (!isClientConnectionOpen(params)) {
     controller.abort();
     return controller.signal;
   }
@@ -29,4 +29,13 @@ export function createRequestCloseSignal(params: { request: FastifyRequest; repl
   params.reply.raw.once("close", removeListeners);
 
   return controller.signal;
+}
+
+export function isClientConnectionOpen(params: { request: FastifyRequest; reply: FastifyReply }): boolean {
+  return (
+    !params.request.raw.destroyed &&
+    !params.request.socket.destroyed &&
+    !params.reply.raw.destroyed &&
+    !params.reply.raw.writableEnded
+  );
 }

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -189,6 +189,20 @@ export const registerTokenBodySchema = z.object({
 });
 export type RegisterTokenBody = z.infer<typeof registerTokenBodySchema>;
 
+export const appClientStatusQuerySchema = z
+  .object({
+    wait: z.literal("true").optional(),
+  })
+  .strict();
+export type AppClientStatusQuery = z.infer<typeof appClientStatusQuerySchema>;
+
+export const appClientStatusReplySchema = z
+  .object({
+    registered: z.boolean(),
+  })
+  .strict();
+export type AppClientStatusReply = z.infer<typeof appClientStatusReplySchema>;
+
 export const notificationDataSchema = z.object({
   category: z.string(),
   eventType: z.string().nullable().optional(),

--- a/src/repositories/device-token-repo.ts
+++ b/src/repositories/device-token-repo.ts
@@ -44,6 +44,14 @@ export class DeviceTokenRepository {
     return this.#collection.find({ userId: new ObjectId(userId) }).toArray();
   }
 
+  async hasAnyForUser(userId: string): Promise<boolean> {
+    if (!ObjectId.isValid(userId)) {
+      throw new InternalServerError({ debugMessage: "Invalid device token userId" });
+    }
+
+    return (await this.#collection.findOne({ userId: new ObjectId(userId) }, { projection: { _id: 1 } })) !== null;
+  }
+
   async findEarliestCreatedAt(userId: string): Promise<Date | null> {
     if (!ObjectId.isValid(userId)) {
       return null;

--- a/src/routes/app-clients.ts
+++ b/src/routes/app-clients.ts
@@ -1,0 +1,79 @@
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+import { BadRequestError, InternalServerError, UnauthenticatedError } from "../lib/errors.js";
+import { createRequestCloseSignal } from "../lib/request-close-signal.js";
+import {
+  appClientStatusQuerySchema,
+  appClientStatusReplySchema,
+  type AppClientStatusQuery,
+  type AppClientStatusReply,
+} from "../models/api.js";
+import {
+  AppClientPresenceInitialReadTimeout,
+  type AppClientPresenceService,
+} from "../services/app-client-presence-service.js";
+
+const APP_CLIENT_STATUS_WAIT_TIMEOUT_MS = 30_000;
+
+export type AppClientRouteOptions = {
+  appClientPresenceService: AppClientPresenceService;
+  requireAuth: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+};
+
+export const appClientRoutes: FastifyPluginAsync<AppClientRouteOptions> = async (fastify, opts) => {
+  fastify.get<{ Querystring: AppClientStatusQuery; Reply: AppClientStatusReply }>(
+    "/auth/app-clients/status",
+    { preHandler: opts.requireAuth },
+    async (request, reply) => {
+      const queryResult = appClientStatusQuerySchema.safeParse(request.query);
+      if (!queryResult.success) {
+        throw new BadRequestError({
+          debugMessage: "Invalid app-client status query",
+          nestedError: queryResult.error.issues,
+        });
+      }
+
+      const userId = getUserId(request);
+      let registered: boolean | null;
+      try {
+        registered = queryResult.data.wait
+          ? await opts.appClientPresenceService.waitForRegistration({
+              userId,
+              timeoutMs: APP_CLIENT_STATUS_WAIT_TIMEOUT_MS,
+              abortSignal: createRequestCloseSignal({ request, reply }),
+            })
+          : await opts.appClientPresenceService.hasRegisteredClient({ userId });
+      } catch (error) {
+        if (error instanceof AppClientPresenceInitialReadTimeout) {
+          throw new InternalServerError({ debugMessage: error.message });
+        }
+        throw error;
+      }
+
+      if (registered === null || !isClientConnectionOpen({ request, reply })) {
+        return reply.hijack();
+      }
+
+      const candidateReply = { registered };
+      const replyResult = appClientStatusReplySchema.safeParse(candidateReply);
+      if (!replyResult.success) {
+        throw new InternalServerError({
+          debugMessage: "Invalid app-client status reply",
+          nestedError: replyResult.error.issues,
+        });
+      }
+
+      return replyResult.data;
+    },
+  );
+};
+
+function getUserId(request: FastifyRequest): string {
+  if (!request.user) {
+    throw new UnauthenticatedError();
+  }
+  return request.user.userId;
+}
+
+function isClientConnectionOpen(params: { request: FastifyRequest; reply: FastifyReply }): boolean {
+  return !params.request.raw.destroyed && !params.request.socket.destroyed && !params.reply.raw.writableEnded;
+}

--- a/src/routes/app-clients.ts
+++ b/src/routes/app-clients.ts
@@ -1,6 +1,6 @@
 import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
 import { BadRequestError, InternalServerError, UnauthenticatedError } from "../lib/errors.js";
-import { createRequestCloseSignal } from "../lib/request-close-signal.js";
+import { createRequestCloseSignal, isClientConnectionOpen } from "../lib/request-close-signal.js";
 import {
   appClientStatusQuerySchema,
   appClientStatusReplySchema,
@@ -72,8 +72,4 @@ function getUserId(request: FastifyRequest): string {
     throw new UnauthenticatedError();
   }
   return request.user.userId;
-}
-
-function isClientConnectionOpen(params: { request: FastifyRequest; reply: FastifyReply }): boolean {
-  return !params.request.raw.destroyed && !params.request.socket.destroyed && !params.reply.raw.writableEnded;
 }

--- a/src/routes/auth/session-status.ts
+++ b/src/routes/auth/session-status.ts
@@ -27,6 +27,7 @@
 
 import { FastifyPluginAsync, type FastifyReply, type FastifyRequest } from "fastify";
 import { NotFoundError } from "../../lib/errors.js";
+import { createRequestCloseSignal } from "../../lib/request-close-signal.js";
 import type {
   AuthSessionStatusCompleteReply,
   AuthSessionStatusDeniedReply,
@@ -154,39 +155,6 @@ async function waitForTerminalOrTimeout(params: {
   }
 
   return session;
-}
-
-function createRequestCloseSignal(params: { request: FastifyRequest; reply: FastifyReply }): AbortSignal {
-  const controller = new AbortController();
-
-  // If the connection is already gone, abort immediately without registering
-  // listeners that will never fire.
-  if (params.request.raw.destroyed || params.request.socket.destroyed || params.reply.raw.writableEnded) {
-    controller.abort();
-    return controller.signal;
-  }
-
-  const abortIfUndelivered = () => {
-    if (!params.reply.raw.writableEnded) {
-      controller.abort();
-    }
-  };
-  const removeAbortListener = () => {
-    params.request.socket.off("close", abortIfUndelivered);
-    params.reply.raw.off("close", abortIfUndelivered);
-    params.reply.raw.off("finish", removeAbortListener);
-    params.reply.raw.off("close", removeAbortListener);
-  };
-
-  // Use the underlying socket close and response close events rather than
-  // request.raw 'close', which can also fire when the request stream ends on a
-  // healthy keep-alive connection.
-  params.request.socket.once("close", abortIfUndelivered);
-  params.reply.raw.once("close", abortIfUndelivered);
-  params.reply.raw.once("finish", removeAbortListener);
-  params.reply.raw.once("close", removeAbortListener);
-
-  return controller.signal;
 }
 
 function isClientConnectionOpen(params: { request: FastifyRequest; reply: FastifyReply }): boolean {

--- a/src/routes/auth/session-status.ts
+++ b/src/routes/auth/session-status.ts
@@ -25,9 +25,9 @@
  * reset their flow.
  */
 
-import { FastifyPluginAsync, type FastifyReply, type FastifyRequest } from "fastify";
+import { FastifyPluginAsync } from "fastify";
 import { NotFoundError } from "../../lib/errors.js";
-import { createRequestCloseSignal } from "../../lib/request-close-signal.js";
+import { createRequestCloseSignal, isClientConnectionOpen } from "../../lib/request-close-signal.js";
 import type {
   AuthSessionStatusCompleteReply,
   AuthSessionStatusDeniedReply,
@@ -155,10 +155,6 @@ async function waitForTerminalOrTimeout(params: {
   }
 
   return session;
-}
-
-function isClientConnectionOpen(params: { request: FastifyRequest; reply: FastifyReply }): boolean {
-  return !params.request.raw.destroyed && !params.request.socket.destroyed && !params.reply.raw.writableEnded;
 }
 
 function createPendingReply(): AuthSessionStatusPendingReply {

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -14,6 +14,7 @@ import type { BridgeService } from "../services/bridge-service.js";
 import type { BridgeStateTracker } from "../services/bridge-state-tracker.js";
 import type { NotificationService } from "../services/notification-service.js";
 import type { ActivationService } from "../services/activation-service.js";
+import type { AppClientPresenceService } from "../services/app-client-presence-service.js";
 import type { Config } from "../config.js";
 
 // Allow up to 5 minutes of NTP clock skew between the relay and this server
@@ -27,6 +28,7 @@ function isTooFarInFuture(at: Date, now: Date = new Date()): boolean {
 export type NotificationRouteOptions = {
   config: Config;
   deviceTokenRepo: DeviceTokenRepository;
+  appClientPresenceService: AppClientPresenceService;
   notificationService: NotificationService;
   bridgeService: BridgeService;
   bridgeStateTracker: BridgeStateTracker;
@@ -44,6 +46,7 @@ export const notificationRoutes: FastifyPluginAsync<NotificationRouteOptions> = 
   const {
     config,
     deviceTokenRepo,
+    appClientPresenceService,
     notificationService,
     bridgeService,
     bridgeStateTracker,
@@ -62,7 +65,11 @@ export const notificationRoutes: FastifyPluginAsync<NotificationRouteOptions> = 
       }
 
       const userId = getUserId(request);
-      await deviceTokenRepo.upsertToken(userId, bodyResult.data.token, bodyResult.data.platform);
+      await appClientPresenceService.registerToken({
+        userId,
+        token: bodyResult.data.token,
+        platform: bodyResult.data.platform,
+      });
       try {
         await activationService.recordAppSetup(userId);
       } catch (error) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import type { InstallScriptService } from "./services/install-script-service.js"
 import type { LegalDocumentService } from "./services/legal-document-service.js";
 import type { AppleNativeVerifier } from "./services/apple-native-verifier.js";
 import type { PendingAuthStore } from "./services/pending-auth-store.js";
+import type { AppClientPresenceService } from "./services/app-client-presence-service.js";
 import { installRoutes } from "./routes/install.js";
 import { legalRoutes } from "./routes/legal.js";
 import { tokenRoutes } from "./routes/token.js";
@@ -34,6 +35,7 @@ import { notificationRoutes } from "./routes/notifications.js";
 import { bridgeRoutes } from "./routes/bridges.js";
 import { sessionRoutes } from "./routes/sessions.js";
 import { sessionStatusRoutes } from "./routes/auth/session-status.js";
+import { appClientRoutes } from "./routes/app-clients.js";
 
 export type AppServices = {
   config: Config;
@@ -45,6 +47,7 @@ export type AppServices = {
   installScriptService: InstallScriptService;
   legalDocumentService: LegalDocumentService;
   deviceTokenRepo: DeviceTokenRepository;
+  appClientPresenceService: AppClientPresenceService;
   notificationService: NotificationService;
   bridgeStateTracker: BridgeStateTracker;
   activationService: ActivationService;
@@ -147,6 +150,10 @@ export async function buildApp(services: AppServices): Promise<FastifyInstance> 
     pendingAuthStore: services.pendingAuthStore,
     statusPollTimeoutMs: services.config.PENDING_AUTH_POLL_TIMEOUT_MS,
   });
+  await app.register(appClientRoutes, {
+    appClientPresenceService: services.appClientPresenceService,
+    requireAuth,
+  });
   await app.register(voiceRoutes, {
     voiceService: services.voiceService,
     requireAuth,
@@ -154,6 +161,7 @@ export async function buildApp(services: AppServices): Promise<FastifyInstance> 
   await app.register(notificationRoutes, {
     config: services.config,
     deviceTokenRepo: services.deviceTokenRepo,
+    appClientPresenceService: services.appClientPresenceService,
     notificationService: services.notificationService,
     bridgeService: services.bridgeService,
     bridgeStateTracker: services.bridgeStateTracker,

--- a/src/services/app-client-presence-service.ts
+++ b/src/services/app-client-presence-service.ts
@@ -1,0 +1,220 @@
+import type { DevicePlatform } from "../models/device.js";
+import type { DeviceTokenRepository } from "../repositories/device-token-repo.js";
+
+type RegistrationWaiter = {
+  userId: string;
+  promise: Promise<boolean | null>;
+  resolve: (registered: boolean | null) => void;
+  timeout: ReturnType<typeof setTimeout>;
+  abortSignal: AbortSignal;
+  abortListener: () => void;
+  settled: boolean;
+};
+
+type ReadOutcome =
+  | { kind: "registered"; registered: boolean }
+  | { kind: "aborted" }
+  | { kind: "deadline" }
+  | { kind: "error"; error: unknown };
+type WaitOutcome = Exclude<ReadOutcome, { kind: "deadline" }>;
+
+export class AppClientPresenceInitialReadTimeout extends Error {
+  constructor() {
+    super("App-client presence initial read exceeded its deadline");
+    this.name = "AppClientPresenceInitialReadTimeout";
+  }
+}
+
+export class AppClientPresenceService {
+  readonly #deviceTokenRepo: DeviceTokenRepository;
+  readonly #waitersByUserId = new Map<string, Set<RegistrationWaiter>>();
+
+  constructor(params: { deviceTokenRepo: DeviceTokenRepository }) {
+    this.#deviceTokenRepo = params.deviceTokenRepo;
+  }
+
+  async registerToken(params: { userId: string; token: string; platform: DevicePlatform }): Promise<void> {
+    await this.#deviceTokenRepo.upsertToken(params.userId, params.token, params.platform);
+
+    const waiters = this.#waitersByUserId.get(params.userId);
+    if (!waiters) {
+      return;
+    }
+
+    for (const waiter of Array.from(waiters)) {
+      this.#completeWaiter(waiter, true);
+    }
+  }
+
+  async hasRegisteredClient(params: { userId: string }): Promise<boolean> {
+    return this.#deviceTokenRepo.hasAnyForUser(params.userId);
+  }
+
+  async waitForRegistration(params: {
+    userId: string;
+    timeoutMs: number;
+    abortSignal: AbortSignal;
+  }): Promise<boolean | null> {
+    if (params.abortSignal.aborted) {
+      return null;
+    }
+
+    if (params.timeoutMs <= 0) {
+      return this.#deviceTokenRepo.hasAnyForUser(params.userId);
+    }
+
+    const deadline = Date.now() + params.timeoutMs;
+    const initialRead = await this.#readUntilDeadline({
+      userId: params.userId,
+      deadline,
+      abortSignal: params.abortSignal,
+    });
+
+    switch (initialRead.kind) {
+      case "registered":
+        if (initialRead.registered) {
+          return true;
+        }
+        break;
+      case "aborted":
+        return null;
+      case "deadline":
+        throw new AppClientPresenceInitialReadTimeout();
+      case "error":
+        throw initialRead.error;
+    }
+
+    if (params.abortSignal.aborted) {
+      return null;
+    }
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      return false;
+    }
+
+    const waiter = this.#createWaiter({
+      userId: params.userId,
+      timeoutMs: remainingMs,
+      abortSignal: params.abortSignal,
+    });
+    const recheck = this.#deviceTokenRepo.hasAnyForUser(params.userId).then<WaitOutcome, WaitOutcome>(
+      (registered) => ({ kind: "registered", registered }),
+      (error: unknown) => ({ kind: "error", error }),
+    );
+    const outcome = await Promise.race([
+      waiter.promise.then<WaitOutcome>((registered) =>
+        registered === null ? { kind: "aborted" } : { kind: "registered", registered },
+      ),
+      recheck,
+    ]);
+
+    if (outcome.kind === "error") {
+      this.#completeWaiter(waiter, null);
+      throw outcome.error;
+    }
+    if (outcome.kind === "aborted") {
+      return null;
+    }
+    if (outcome.registered) {
+      this.#completeWaiter(waiter, true);
+      return true;
+    }
+
+    return waiter.promise;
+  }
+
+  async #readUntilDeadline(params: {
+    userId: string;
+    deadline: number;
+    abortSignal: AbortSignal;
+  }): Promise<ReadOutcome> {
+    const remainingMs = Math.max(0, params.deadline - Date.now());
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let abortListener: (() => void) | undefined;
+
+    const repositoryRead = this.#deviceTokenRepo.hasAnyForUser(params.userId).then<ReadOutcome, ReadOutcome>(
+      (registered) => ({ kind: "registered", registered }),
+      (error: unknown) => ({ kind: "error", error }),
+    );
+    const deadline = new Promise<ReadOutcome>((resolve) => {
+      timeout = setTimeout(() => resolve({ kind: "deadline" }), remainingMs);
+      timeout.unref?.();
+    });
+    const abort = new Promise<ReadOutcome>((resolve) => {
+      abortListener = () => resolve({ kind: "aborted" });
+      params.abortSignal.addEventListener("abort", abortListener, { once: true });
+      if (params.abortSignal.aborted) {
+        resolve({ kind: "aborted" });
+      }
+    });
+
+    try {
+      return await Promise.race([repositoryRead, deadline, abort]);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      if (abortListener) {
+        params.abortSignal.removeEventListener("abort", abortListener);
+      }
+    }
+  }
+
+  #createWaiter(params: { userId: string; timeoutMs: number; abortSignal: AbortSignal }): RegistrationWaiter {
+    let resolvePromise!: (registered: boolean | null) => void;
+    const promise = new Promise<boolean | null>((resolve) => {
+      resolvePromise = resolve;
+    });
+    const waiterRef: { value?: RegistrationWaiter } = {};
+    const abortListener = () => {
+      if (waiterRef.value) {
+        this.#completeWaiter(waiterRef.value, null);
+      }
+    };
+    const timeout = setTimeout(() => {
+      if (waiterRef.value) {
+        this.#completeWaiter(waiterRef.value, false);
+      }
+    }, params.timeoutMs);
+    timeout.unref?.();
+
+    const waiter: RegistrationWaiter = {
+      userId: params.userId,
+      promise,
+      resolve: resolvePromise,
+      timeout,
+      abortSignal: params.abortSignal,
+      abortListener,
+      settled: false,
+    };
+    waiterRef.value = waiter;
+
+    params.abortSignal.addEventListener("abort", abortListener, { once: true });
+    const waiters = this.#waitersByUserId.get(params.userId) ?? new Set<RegistrationWaiter>();
+    waiters.add(waiter);
+    this.#waitersByUserId.set(params.userId, waiters);
+
+    if (params.abortSignal.aborted) {
+      this.#completeWaiter(waiter, null);
+    }
+
+    return waiter;
+  }
+
+  #completeWaiter(waiter: RegistrationWaiter, registered: boolean | null): void {
+    if (waiter.settled) {
+      return;
+    }
+    waiter.settled = true;
+
+    clearTimeout(waiter.timeout);
+    waiter.abortSignal.removeEventListener("abort", waiter.abortListener);
+    const waiters = this.#waitersByUserId.get(waiter.userId);
+    waiters?.delete(waiter);
+    if (waiters?.size === 0) {
+      this.#waitersByUserId.delete(waiter.userId);
+    }
+    waiter.resolve(registered);
+  }
+}

--- a/tests/auth/app-clients.test.ts
+++ b/tests/auth/app-clients.test.ts
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { after, afterEach, before, describe, it } from "node:test";
+import Fastify, { type FastifyInstance } from "fastify";
+import { ApiError } from "../../src/lib/errors.js";
+import { appClientRoutes } from "../../src/routes/app-clients.js";
+import {
+  AppClientPresenceInitialReadTimeout,
+  type AppClientPresenceService,
+} from "../../src/services/app-client-presence-service.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+describe("GET /auth/app-clients/status", () => {
+  let ctx: TestContext;
+
+  before(async () => {
+    ctx = await createTestApp();
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("returns immediate false and then true after an existing token registration", async () => {
+    const user = await ctx.createUser();
+
+    const absent = await ctx.app.inject({
+      method: "GET",
+      url: "/auth/app-clients/status",
+      headers: { authorization: `Bearer ${user.accessToken}` },
+    });
+    const registration = await ctx.app.inject({
+      method: "POST",
+      url: "/notifications/register-token",
+      headers: { authorization: `Bearer ${user.accessToken}`, "content-type": "application/json" },
+      payload: JSON.stringify({ token: `presence-${user.userId}`, platform: "macos" }),
+    });
+    const present = await ctx.app.inject({
+      method: "GET",
+      url: "/auth/app-clients/status",
+      headers: { authorization: `Bearer ${user.accessToken}` },
+    });
+
+    assert.equal(absent.statusCode, 200);
+    assert.deepEqual(absent.json(), { registered: false });
+    assert.equal(registration.statusCode, 200);
+    assert.deepEqual(registration.json(), { ok: true });
+    assert.equal(present.statusCode, 200);
+    assert.deepEqual(present.json(), { registered: true });
+  });
+
+  it("wakes a long poll after the same user durably registers a token", async () => {
+    const user = await ctx.createUser();
+    const waiting = keepProcessAlive(
+      ctx.app.inject({
+        method: "GET",
+        url: "/auth/app-clients/status?wait=true",
+        headers: { authorization: `Bearer ${user.accessToken}` },
+      }),
+    );
+    await delay(10);
+
+    const registration = await ctx.app.inject({
+      method: "POST",
+      url: "/notifications/register-token",
+      headers: { authorization: `Bearer ${user.accessToken}`, "content-type": "application/json" },
+      payload: JSON.stringify({ token: `wake-${user.userId}`, platform: "android" }),
+    });
+    const response = await waiting;
+
+    assert.equal(registration.statusCode, 200);
+    assert.deepEqual(registration.json(), { ok: true });
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json(), { registered: true });
+  });
+
+  it("requires auth and rejects unsupported or unknown query values", async () => {
+    const user = await ctx.createUser();
+    const missingAuth = await ctx.app.inject({ method: "GET", url: "/auth/app-clients/status" });
+    const falseWait = await ctx.app.inject({
+      method: "GET",
+      url: "/auth/app-clients/status?wait=false",
+      headers: { authorization: `Bearer ${user.accessToken}` },
+    });
+    const unknown = await ctx.app.inject({
+      method: "GET",
+      url: "/auth/app-clients/status?other=true",
+      headers: { authorization: `Bearer ${user.accessToken}` },
+    });
+
+    assert.equal(missingAuth.statusCode, 401);
+    assert.deepEqual(missingAuth.json(), { error: "unauthenticated" });
+    assert.equal(falseWait.statusCode, 400);
+    assert.deepEqual(falseWait.json(), { error: "bad_request" });
+    assert.equal(unknown.statusCode, 400);
+    assert.deepEqual(unknown.json(), { error: "bad_request" });
+  });
+});
+
+describe("app-client status route failure and disconnect mapping", () => {
+  let apps: FastifyInstance[];
+
+  afterEach(async () => {
+    await Promise.all(apps.map((app) => app.close()));
+  });
+
+  before(() => {
+    apps = [];
+  });
+
+  it("maps only the typed initial-read deadline to the existing 500 response", async () => {
+    const app = await buildRouteApp({
+      hasRegisteredClient: async () => false,
+      waitForRegistration: async () => {
+        throw new AppClientPresenceInitialReadTimeout();
+      },
+    });
+
+    const response = await app.inject({ method: "GET", url: "/auth/app-clients/status?wait=true" });
+
+    assert.equal(response.statusCode, 500);
+    assert.deepEqual(response.json(), { error: "internal_server_error" });
+  });
+
+  it("rejects an invalid service reply through the strict reply schema", async () => {
+    const app = await buildRouteApp({
+      hasRegisteredClient: async () => "not-a-boolean",
+      waitForRegistration: async () => false,
+    });
+
+    const response = await app.inject({ method: "GET", url: "/auth/app-clients/status" });
+
+    assert.equal(response.statusCode, 500);
+    assert.deepEqual(response.json(), { error: "internal_server_error" });
+  });
+
+  it("aborts the service wait and sends no late payload after client disconnect", async () => {
+    let receivedSignal: AbortSignal | undefined;
+    const app = await buildRouteApp({
+      hasRegisteredClient: async () => false,
+      waitForRegistration: async (params: { abortSignal: AbortSignal }) => {
+        receivedSignal = params.abortSignal;
+        if (params.abortSignal.aborted) {
+          return null;
+        }
+        return new Promise<null>((resolve) => {
+          params.abortSignal.addEventListener("abort", () => resolve(null), { once: true });
+        });
+      },
+    });
+    const origin = await app.listen({ host: "127.0.0.1", port: 0 });
+    const pending = openRequest(new URL("/auth/app-clients/status?wait=true", origin));
+    await waitFor(() => receivedSignal !== undefined);
+
+    pending.destroy();
+    await pending.closed;
+    await waitFor(() => receivedSignal?.aborted === true);
+
+    assert.equal(receivedSignal?.aborted, true);
+  });
+
+  async function buildRouteApp(service: object): Promise<FastifyInstance> {
+    const app = Fastify({ disableRequestLogging: true });
+    apps.push(app);
+    app.decorateRequest("user", null);
+    app.setErrorHandler((error, _request, reply) => {
+      if (error instanceof ApiError) {
+        return reply.status(error.errorCode).send({ error: error.message });
+      }
+      return reply.status(500).send({ error: "internal_server_error" });
+    });
+    await app.register(appClientRoutes, {
+      appClientPresenceService: service as AppClientPresenceService,
+      requireAuth: async (request) => {
+        request.user = {
+          tokenType: "access",
+          userId: "507f1f77bcf86cd799439011",
+          provider: "github",
+          providerUserId: "provider-user",
+          iss: "auth-backend",
+          aud: "mobile",
+          iat: 1,
+          exp: 2,
+        };
+      },
+    });
+    await app.ready();
+    return app;
+  }
+});
+
+function openRequest(url: URL): { destroy: () => void; closed: Promise<void> } {
+  const request = http.request(url);
+  const closed = new Promise<void>((resolve) => {
+    request.once("close", resolve);
+    request.once("error", () => resolve());
+  });
+  request.end();
+  return { destroy: () => request.destroy(), closed };
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error("Condition was not reached before deadline");
+    }
+    await delay(1);
+  }
+}
+
+async function keepProcessAlive<T>(promise: Promise<T>): Promise<T> {
+  const keepAlive = setInterval(() => undefined, 1_000);
+  try {
+    return await promise;
+  } finally {
+    clearInterval(keepAlive);
+  }
+}

--- a/tests/auth/oauth-callback-confirmation.test.ts
+++ b/tests/auth/oauth-callback-confirmation.test.ts
@@ -121,6 +121,11 @@ function createTestServices(params: {
     installScriptService: {} as AppServices["installScriptService"],
     legalDocumentService: {} as AppServices["legalDocumentService"],
     deviceTokenRepo: {} as AppServices["deviceTokenRepo"],
+    appClientPresenceService: {
+      registerToken: async () => {},
+      hasRegisteredClient: async () => false,
+      waitForRegistration: async () => false,
+    } as AppServices["appClientPresenceService"],
     notificationService: {} as AppServices["notificationService"],
     bridgeStateTracker: {} as AppServices["bridgeStateTracker"],
     activationService: {} as AppServices["activationService"],

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -34,6 +34,7 @@ import { InstallScriptService } from "../../src/services/install-script-service.
 import { LegalDocumentService } from "../../src/services/legal-document-service.js";
 import { TokenService } from "../../src/services/token-service.js";
 import { VoiceService } from "../../src/services/voice-service.js";
+import { AppClientPresenceService } from "../../src/services/app-client-presence-service.js";
 import { loadConfig } from "../../src/config.js";
 
 export type TestUser = {
@@ -54,6 +55,7 @@ export type TestContext = {
   dbAccessor: MongoDbAccessor;
   tokenService: TokenService;
   pendingAuthStore: PendingAuthStore;
+  appClientPresenceService: AppClientPresenceService;
   cleanup: () => Promise<void>;
   createUser: (opts?: { provider?: string; providerUserId?: string }) => Promise<TestUser>;
   createExpiredRefreshToken: (userId: string) => string;
@@ -73,6 +75,7 @@ export type TestAppOverrides = {
   installScriptService?: InstallScriptService;
   legalDocumentService?: LegalDocumentService;
   activationService?: ActivationService;
+  appClientPresenceService?: AppClientPresenceService;
 };
 
 export type { OAuthClient };
@@ -176,6 +179,8 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
   const activationService =
     overrides?.activationService ??
     new ActivationService({ activationStateRepo, bridgeRepo, dailyUsageRepo, deviceTokenRepo });
+  const appClientPresenceService =
+    overrides?.appClientPresenceService ?? new AppClientPresenceService({ deviceTokenRepo });
   const authService = new AuthService({ tokenService, userRepo, oauthAccountRepo, passwordAccountRepo, bridgeService });
   const voiceService = new VoiceService({ openai, glossaryRepo, dailyUsageRepo });
   const sessionMetadataService =
@@ -194,6 +199,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
     installScriptService,
     legalDocumentService,
     deviceTokenRepo,
+    appClientPresenceService,
     notificationService,
     bridgeStateTracker,
     activationService,
@@ -298,6 +304,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
     dbAccessor,
     tokenService,
     pendingAuthStore,
+    appClientPresenceService,
     cleanup,
     createUser,
     createExpiredRefreshToken,

--- a/tests/lib/request-close-signal.test.ts
+++ b/tests/lib/request-close-signal.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { EventEmitter, getEventListeners } from "node:events";
+import { describe, it } from "node:test";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { createRequestCloseSignal } from "../../src/lib/request-close-signal.js";
+
+describe("createRequestCloseSignal", () => {
+  it("aborts on an undelivered socket close and removes every listener", () => {
+    const fixture = createFixture();
+    const signal = createRequestCloseSignal(fixture.params);
+
+    fixture.socket.emit("close");
+
+    assert.equal(signal.aborted, true);
+    assertNoListeners(fixture);
+  });
+
+  it("does not abort a delivered response and removes every listener on finish", () => {
+    const fixture = createFixture();
+    const signal = createRequestCloseSignal(fixture.params);
+    fixture.replyRaw.writableEnded = true;
+
+    fixture.replyRaw.emit("finish");
+
+    assert.equal(signal.aborted, false);
+    assertNoListeners(fixture);
+  });
+
+  it("returns an already-aborted signal without listeners for a closed request", () => {
+    const fixture = createFixture();
+    fixture.requestRaw.destroyed = true;
+
+    const signal = createRequestCloseSignal(fixture.params);
+
+    assert.equal(signal.aborted, true);
+    assertNoListeners(fixture);
+  });
+});
+
+function createFixture(): {
+  params: { request: FastifyRequest; reply: FastifyReply };
+  socket: EventEmitter & { destroyed: boolean };
+  requestRaw: { destroyed: boolean };
+  replyRaw: EventEmitter & { writableEnded: boolean };
+} {
+  const socket = Object.assign(new EventEmitter(), { destroyed: false });
+  const requestRaw = { destroyed: false };
+  const replyRaw = Object.assign(new EventEmitter(), { writableEnded: false });
+  return {
+    params: {
+      request: { raw: requestRaw, socket } as unknown as FastifyRequest,
+      reply: { raw: replyRaw } as unknown as FastifyReply,
+    },
+    socket,
+    requestRaw,
+    replyRaw,
+  };
+}
+
+function assertNoListeners(fixture: ReturnType<typeof createFixture>): void {
+  assert.equal(getEventListeners(fixture.socket, "close").length, 0);
+  assert.equal(getEventListeners(fixture.replyRaw, "close").length, 0);
+  assert.equal(getEventListeners(fixture.replyRaw, "finish").length, 0);
+}

--- a/tests/lib/request-close-signal.test.ts
+++ b/tests/lib/request-close-signal.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { EventEmitter, getEventListeners } from "node:events";
 import { describe, it } from "node:test";
 import type { FastifyReply, FastifyRequest } from "fastify";
-import { createRequestCloseSignal } from "../../src/lib/request-close-signal.js";
+import { createRequestCloseSignal, isClientConnectionOpen } from "../../src/lib/request-close-signal.js";
 
 describe("createRequestCloseSignal", () => {
   it("aborts on an undelivered socket close and removes every listener", () => {
@@ -35,17 +35,38 @@ describe("createRequestCloseSignal", () => {
     assert.equal(signal.aborted, true);
     assertNoListeners(fixture);
   });
+
+  it("returns an already-aborted signal when the response was destroyed before listener registration", () => {
+    const fixture = createFixture();
+    fixture.replyRaw.destroyed = true;
+
+    const signal = createRequestCloseSignal(fixture.params);
+
+    assert.equal(signal.aborted, true);
+    assertNoListeners(fixture);
+  });
+
+  it("reports connection liveness consistently for destroyed and completed responses", () => {
+    const fixture = createFixture();
+    assert.equal(isClientConnectionOpen(fixture.params), true);
+
+    fixture.replyRaw.destroyed = true;
+    assert.equal(isClientConnectionOpen(fixture.params), false);
+    fixture.replyRaw.destroyed = false;
+    fixture.replyRaw.writableEnded = true;
+    assert.equal(isClientConnectionOpen(fixture.params), false);
+  });
 });
 
 function createFixture(): {
   params: { request: FastifyRequest; reply: FastifyReply };
   socket: EventEmitter & { destroyed: boolean };
   requestRaw: { destroyed: boolean };
-  replyRaw: EventEmitter & { writableEnded: boolean };
+  replyRaw: EventEmitter & { writableEnded: boolean; destroyed: boolean };
 } {
   const socket = Object.assign(new EventEmitter(), { destroyed: false });
   const requestRaw = { destroyed: false };
-  const replyRaw = Object.assign(new EventEmitter(), { writableEnded: false });
+  const replyRaw = Object.assign(new EventEmitter(), { writableEnded: false, destroyed: false });
   return {
     params: {
       request: { raw: requestRaw, socket } as unknown as FastifyRequest,

--- a/tests/notifications/device-token-repo.test.ts
+++ b/tests/notifications/device-token-repo.test.ts
@@ -169,6 +169,19 @@ describe("DeviceTokenRepository", () => {
     assert.deepEqual(new Set(tokens.map((token) => token.token)), new Set(["token-list-1", "token-list-2"]));
   });
 
+  it("hasAnyForUser uses current tokens across every supported platform", async () => {
+    const emptyUser = await ctx.createUser();
+    assert.equal(await repo.hasAnyForUser(emptyUser.userId), false);
+
+    for (const platform of Object.values(DevicePlatform)) {
+      const user = await ctx.createUser();
+      await repo.upsertToken(user.userId, `presence-${platform}`, platform);
+      assert.equal(await repo.hasAnyForUser(user.userId), true, platform);
+    }
+
+    await assert.rejects(() => repo.hasAnyForUser("invalid-id"), InternalServerError);
+  });
+
   it("findEarliestCreatedAt returns the first app registration on any platform", async () => {
     const user = await ctx.createUser();
     const desktopAt = new Date("2026-07-09T10:00:00.000Z");

--- a/tests/notifications/routes.test.ts
+++ b/tests/notifications/routes.test.ts
@@ -216,6 +216,9 @@ describe("Notification routes", () => {
     const user = await ctx.createUser();
     const token = "token/with:special?chars";
     await deviceTokenRepo.upsertToken(user.userId, token, DevicePlatform.android);
+    const registerMock = mock.method(ctx.appClientPresenceService, "registerToken", async () => {
+      throw new Error("deletion must not delegate through presence service");
+    });
 
     const res = await ctx.app.inject({
       method: "DELETE",
@@ -227,6 +230,7 @@ describe("Notification routes", () => {
 
     assert.equal(res.statusCode, 200);
     assert.deepEqual(res.json(), { ok: true });
+    assert.equal(registerMock.mock.callCount(), 0);
     const tokens = await deviceTokenRepo.findByUserId(user.userId);
     assert.equal(tokens.length, 0);
   });

--- a/tests/services/app-client-presence-service.test.ts
+++ b/tests/services/app-client-presence-service.test.ts
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { getEventListeners } from "node:events";
+import { describe, it } from "node:test";
+import { DevicePlatform } from "../../src/models/device.js";
+import type { DeviceTokenRepository } from "../../src/repositories/device-token-repo.js";
+import {
+  AppClientPresenceInitialReadTimeout,
+  AppClientPresenceService,
+} from "../../src/services/app-client-presence-service.js";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+};
+
+class FakeDeviceTokenRepository {
+  readonly reads: Array<boolean | Promise<boolean>> = [];
+  upsert: () => Promise<void> = async () => {};
+  readCount = 0;
+
+  async hasAnyForUser(): Promise<boolean> {
+    const result = this.reads[this.readCount++];
+    if (result === undefined) {
+      throw new Error("Unexpected presence read");
+    }
+    return result;
+  }
+
+  async upsertToken(): Promise<void> {
+    await this.upsert();
+  }
+}
+
+describe("AppClientPresenceService", () => {
+  it("returns immediate current presence without storing a waiter", async () => {
+    const repo = new FakeDeviceTokenRepository();
+    repo.reads.push(false, true);
+    const service = createService(repo);
+
+    assert.equal(await service.hasRegisteredClient({ userId: "user-a" }), false);
+    assert.equal(await service.hasRegisteredClient({ userId: "user-a" }), true);
+    assert.equal(repo.readCount, 2);
+  });
+
+  it("returns false at the absolute timeout and removes its abort listener", async () => {
+    const repo = new FakeDeviceTokenRepository();
+    repo.reads.push(false, false);
+    const service = createService(repo);
+    const controller = new AbortController();
+
+    const result = await keepProcessAlive(
+      service.waitForRegistration({ userId: "user-timeout", timeoutMs: 20, abortSignal: controller.signal }),
+    );
+
+    assert.equal(result, false);
+    assert.equal(getEventListeners(controller.signal, "abort").length, 0);
+  });
+
+  it("counts the initial read against the same absolute timeout", async () => {
+    const repo = new FakeDeviceTokenRepository();
+    repo.reads.push(delayResult(false, 20), false);
+    const service = createService(repo);
+    const startedAt = Date.now();
+
+    const result = await keepProcessAlive(
+      service.waitForRegistration({ userId: "user-budget", timeoutMs: 35, abortSignal: new AbortController().signal }),
+    );
+
+    const elapsedMs = Date.now() - startedAt;
+    assert.equal(result, false);
+    assert.ok(elapsedMs >= 30, `elapsed ${elapsedMs}ms`);
+    assert.ok(elapsedMs < 70, `elapsed ${elapsedMs}ms`);
+  });
+
+  it("throws a typed failure when the initial read misses the deadline", async () => {
+    const repo = new FakeDeviceTokenRepository();
+    const lateRead = deferred<boolean>();
+    repo.reads.push(lateRead.promise);
+    const service = createService(repo);
+    const controller = new AbortController();
+
+    await assert.rejects(
+      keepProcessAlive(
+        service.waitForRegistration({ userId: "user-slow", timeoutMs: 15, abortSignal: controller.signal }),
+      ),
+      AppClientPresenceInitialReadTimeout,
+    );
+    assert.equal(getEventListeners(controller.signal, "abort").length, 0);
+
+    lateRead.resolve(true);
+    await delay(0);
+  });
+
+  it("returns cancellation without reading when the signal is already aborted", async () => {
+    const repo = new FakeDeviceTokenRepository();
+    const service = createService(repo);
+    const controller = new AbortController();
+    controller.abort();
+
+    assert.equal(
+      await service.waitForRegistration({ userId: "user-aborted", timeoutMs: 50, abortSignal: controller.signal }),
+      null,
+    );
+    assert.equal(repo.readCount, 0);
+  });
+
+  it("aborts an active waiter and removes its listener", async () => {
+    const repo = new FakeDeviceTokenRepository();
+    repo.reads.push(false, false);
+    const service = createService(repo);
+    const controller = new AbortController();
+    const result = service.waitForRegistration({
+      userId: "user-abort",
+      timeoutMs: 1_000,
+      abortSignal: controller.signal,
+    });
+    await waitFor(() => repo.readCount === 2);
+
+    controller.abort();
+
+    assert.equal(await result, null);
+    assert.equal(getEventListeners(controller.signal, "abort").length, 0);
+  });
+
+  it("wakes every waiter for the registered user and leaves other users waiting", async () => {
+    const repo = new FakeDeviceTokenRepository();
+    repo.reads.push(false, false, false, false, false, false);
+    const service = createService(repo);
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const otherController = new AbortController();
+    const first = service.waitForRegistration({
+      userId: "user-a",
+      timeoutMs: 1_000,
+      abortSignal: firstController.signal,
+    });
+    const second = service.waitForRegistration({
+      userId: "user-a",
+      timeoutMs: 1_000,
+      abortSignal: secondController.signal,
+    });
+    const other = service.waitForRegistration({
+      userId: "user-b",
+      timeoutMs: 1_000,
+      abortSignal: otherController.signal,
+    });
+    await waitFor(() => repo.readCount === 6);
+
+    await service.registerToken({ userId: "user-a", token: "token-a", platform: DevicePlatform.ios });
+
+    assert.deepEqual(await Promise.all([first, second]), [true, true]);
+    const otherState = await Promise.race([other.then(() => "settled"), delayResult("waiting", 10)]);
+    assert.equal(otherState, "waiting");
+    otherController.abort();
+    assert.equal(await other, null);
+  });
+
+  it("does not wake a waiter until the token upsert succeeds", async () => {
+    const repo = new FakeDeviceTokenRepository();
+    repo.reads.push(false, false);
+    const upsert = deferred<void>();
+    repo.upsert = () => upsert.promise;
+    const service = createService(repo);
+    const controller = new AbortController();
+    const waiting = service.waitForRegistration({
+      userId: "user-durable",
+      timeoutMs: 1_000,
+      abortSignal: controller.signal,
+    });
+    await waitFor(() => repo.readCount === 2);
+    const registration = service.registerToken({
+      userId: "user-durable",
+      token: "token-durable",
+      platform: DevicePlatform.android,
+    });
+
+    assert.equal(await Promise.race([waiting.then(() => "settled"), delayResult("waiting", 10)]), "waiting");
+    upsert.resolve();
+    await registration;
+    assert.equal(await waiting, true);
+  });
+
+  it("does not wake a waiter when the token upsert fails", async () => {
+    const repo = new FakeDeviceTokenRepository();
+    repo.reads.push(false, false);
+    repo.upsert = async () => {
+      throw new Error("write failed");
+    };
+    const service = createService(repo);
+    const controller = new AbortController();
+    const waiting = service.waitForRegistration({
+      userId: "user-failed",
+      timeoutMs: 1_000,
+      abortSignal: controller.signal,
+    });
+    await waitFor(() => repo.readCount === 2);
+
+    await assert.rejects(
+      service.registerToken({ userId: "user-failed", token: "token-failed", platform: DevicePlatform.linux }),
+      /write failed/,
+    );
+    assert.equal(await Promise.race([waiting.then(() => "settled"), delayResult("waiting", 10)]), "waiting");
+    controller.abort();
+    assert.equal(await waiting, null);
+  });
+
+  it("closes the query-to-wait race with a post-registration recheck", async () => {
+    const repo = new FakeDeviceTokenRepository();
+    repo.reads.push(false, true);
+    const service = createService(repo);
+
+    assert.equal(
+      await service.waitForRegistration({
+        userId: "user-race",
+        timeoutMs: 1_000,
+        abortSignal: new AbortController().signal,
+      }),
+      true,
+    );
+  });
+
+  it("cleans the waiter and listener when the post-registration recheck fails", async () => {
+    const repo = new FakeDeviceTokenRepository();
+    repo.reads.push(false, Promise.reject(new Error("recheck failed")));
+    const service = createService(repo);
+    const controller = new AbortController();
+
+    await assert.rejects(
+      service.waitForRegistration({ userId: "user-error", timeoutMs: 1_000, abortSignal: controller.signal }),
+      /recheck failed/,
+    );
+    assert.equal(getEventListeners(controller.signal, "abort").length, 0);
+  });
+});
+
+function createService(repo: FakeDeviceTokenRepository): AppClientPresenceService {
+  return new AppClientPresenceService({ deviceTokenRepo: repo as unknown as DeviceTokenRepository });
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function delayResult<T>(value: T, ms: number): Promise<T> {
+  await delay(ms);
+  return value;
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error("Condition was not reached before deadline");
+    }
+    await delay(1);
+  }
+}
+
+async function keepProcessAlive<T>(promise: Promise<T>): Promise<T> {
+  const keepAlive = setInterval(() => undefined, 1_000);
+  try {
+    return await promise;
+  } finally {
+    clearInterval(keepAlive);
+  }
+}


### PR DESCRIPTION
## Summary
- add authenticated immediate and 30-second long-poll app-client presence status
- wake same-user waiters only after durable token registration while preserving activation and deletion behavior
- extract request-close cancellation and cover timeout, race, disconnect, and cleanup paths

## Plan tracking
- https://github.com/sesori-ai/sesori_apps_monorepo/commit/d732a24e828f0d8649b385991f499745d781ddeb

## Verification
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm test` (422 passed, 1 skipped)
- `npm run circular-dependencies`
- architecture implementation review: approved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an authenticated app‑client presence endpoint with instant and 30s long‑poll to detect if a user has a registered app client. Also hardens long‑poll connection checks to avoid late replies on disconnect.

- **New Features**
  - GET `/auth/app-clients/status` (auth) returns `{ registered: boolean }`; supports `wait=true` for up to 30s and aborts on client disconnect.
  - `AppClientPresenceService` tracks per‑user waiters and wakes them after a durable device‑token upsert via `DeviceTokenRepository.hasAnyForUser`.
  - `/notifications/register-token` now delegates to the presence service so waits wake only after durable registration; delete path unchanged.
  - Strict schemas added for query and reply; scaling note: presence waiters are in‑process only—keep auth single‑instance.

- **Bug Fixes**
  - Hardened long‑poll connection detection with `createRequestCloseSignal` and `isClientConnectionOpen`; prevents late writes on keep‑alive closes and destroyed responses, and reused in session‑status.

<sup>Written for commit 785d55043873c7e245877c232bd6c0f0be6333ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

