### PR TITLE
chore(auth): app-client presence follow-ups from post-merge review of #44

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,8 @@ src/
 ## SCALING CONSTRAINTS
 
 - **Pending OAuth sessions are in-process only.** `PendingAuthStore` is an in-memory LRU with a 5-minute TTL. The store is NOT shared between instances. Horizontal scaling of this service requires either sticky sessions (`X-Sesori-Session-Token` → consistent instance) OR migrating the store to Redis. Until then: **single-instance deploys only**.
-- **App-client presence waiters are in-process only.** `AppClientPresenceService` wakes long polls on the instance that commits a device-token registration. Keep auth single-instance until app-presence signaling is distributed.
 - Tunable via `PENDING_AUTH_MAX_SESSIONS` (default 10k entries ≈ 10 MB) and `PENDING_AUTH_POLL_TIMEOUT_MS` (default 30s long-poll cap).
+- **App-client presence waiters are in-process only.** `AppClientPresenceService` wakes long polls on the instance that commits a device-token registration. Keep auth single-instance until app-presence signaling is distributed.
 - **Bridge notification debounce is in-process only.** `BridgeStateTracker` keeps per-(userId, bridgeId) debounce timers and last-notified state in a process-local Map: pending notifications are lost on restart, the map is unbounded for the process lifetime (acceptable under the 50-bridges-per-user registration cap), and multiple instances would double-notify. Same single-instance constraint as above.
 - **Activation reminder polling is in-process only.** `ActivationReminderService` has a process-local interval and single-flight guard. Multiple enabled instances can send the same reminder before either writes its MongoDB marker. Keep `ACTIVATION_REMINDERS_ENABLED=false` on all but one instance unless a distributed lease or claim is added.
 

--- a/src/lib/request-close-signal.ts
+++ b/src/lib/request-close-signal.ts
@@ -1,5 +1,15 @@
 import type { FastifyReply, FastifyRequest } from "fastify";
 
+/**
+ * Returns an AbortSignal that fires if and only if the client goes away
+ * before the response is delivered. If the connection is already gone on
+ * entry, an already-aborted signal is returned without registering listeners.
+ *
+ * All listeners are removed on the first terminal event: a delivered response
+ * (`finish`), or a socket/response `close` (which also aborts when the reply
+ * was still undelivered). `abortIfUndelivered` performs that cleanup itself,
+ * so the standalone `removeListeners` registrations are no-ops on that path.
+ */
 export function createRequestCloseSignal(params: { request: FastifyRequest; reply: FastifyReply }): AbortSignal {
   const controller = new AbortController();
 
@@ -31,6 +41,13 @@ export function createRequestCloseSignal(params: { request: FastifyRequest; repl
   return controller.signal;
 }
 
+/**
+ * Returns true while the underlying transport is still open and the response
+ * has not been committed. Used as a post-await guard before writing a
+ * long-poll reply. `reply.raw.destroyed` is checked separately from
+ * `writableEnded` because the server can destroy a response object without it
+ * ever having ended cleanly.
+ */
 export function isClientConnectionOpen(params: { request: FastifyRequest; reply: FastifyReply }): boolean {
   return (
     !params.request.raw.destroyed &&

--- a/src/routes/app-clients.ts
+++ b/src/routes/app-clients.ts
@@ -1,3 +1,19 @@
+/**
+ * GET /auth/app-clients/status — authenticated endpoint reporting whether the
+ * user has at least one registered app-client device token.
+ *
+ * Query:
+ *   wait=true — hold the connection open (up to 30 s) and return as soon as a
+ *   token registration commits. Omitted means an immediate read; any other
+ *   value or unknown key is rejected by the strict query schema.
+ *
+ * Responses:
+ *   200 { registered: boolean }
+ *   400 { error: "bad_request" }           — invalid query
+ *   401 { error: "unauthenticated" }
+ *   500 { error: "internal_server_error" } — the initial read missed the 30 s
+ *       deadline; unconfirmed absence is never reported as `false`
+ */
 import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
 import { BadRequestError, InternalServerError, UnauthenticatedError } from "../lib/errors.js";
 import { createRequestCloseSignal, isClientConnectionOpen } from "../lib/request-close-signal.js";
@@ -43,12 +59,17 @@ export const appClientRoutes: FastifyPluginAsync<AppClientRouteOptions> = async 
             })
           : await opts.appClientPresenceService.hasRegisteredClient({ userId });
       } catch (error) {
+        // The initial read never confirmed presence or absence — surface 500
+        // rather than letting a false negative reach the app client.
         if (error instanceof AppClientPresenceInitialReadTimeout) {
           throw new InternalServerError({ debugMessage: error.message });
         }
+
         throw error;
       }
 
+      // null means the client disconnected (abort fired before resolution).
+      // Hijack so no late payload is written to a closed socket.
       if (registered === null || !isClientConnectionOpen({ request, reply })) {
         return reply.hijack();
       }
@@ -71,5 +92,6 @@ function getUserId(request: FastifyRequest): string {
   if (!request.user) {
     throw new UnauthenticatedError();
   }
+
   return request.user.userId;
 }

--- a/src/services/app-client-presence-service.ts
+++ b/src/services/app-client-presence-service.ts
@@ -11,13 +11,27 @@ type RegistrationWaiter = {
   settled: boolean;
 };
 
-type ReadOutcome =
-  | { kind: "registered"; registered: boolean }
-  | { kind: "aborted" }
-  | { kind: "deadline" }
-  | { kind: "error"; error: unknown };
-type WaitOutcome = Exclude<ReadOutcome, { kind: "deadline" }>;
+enum OutcomeKind {
+  Registered = "registered",
+  Aborted = "aborted",
+  Deadline = "deadline",
+  Error = "error",
+}
 
+type ReadOutcome =
+  | { kind: OutcomeKind.Registered; registered: boolean }
+  | { kind: OutcomeKind.Aborted }
+  | { kind: OutcomeKind.Deadline }
+  | { kind: OutcomeKind.Error; error: unknown };
+type WaitOutcome = Exclude<ReadOutcome, { kind: OutcomeKind.Deadline }>;
+
+/**
+ * Thrown by `waitForRegistration` when the initial repository read does not
+ * complete before the absolute deadline. Deliberately distinct from a normal
+ * wait timeout (which resolves `false`): a deadline hit before the first read
+ * settles means absence was never confirmed, and the route surfaces it as a
+ * 500 instead of serializing a false `{ registered: false }`.
+ */
 export class AppClientPresenceInitialReadTimeout extends Error {
   constructor() {
     super("App-client presence initial read exceeded its deadline");
@@ -25,6 +39,28 @@ export class AppClientPresenceInitialReadTimeout extends Error {
   }
 }
 
+/**
+ * Tracks whether a user has at least one registered app-client device token
+ * and lets in-flight HTTP long polls wait for the first registration.
+ *
+ * `#waitersByUserId` is entirely process-local: waiters are only woken on the
+ * instance that commits the token upsert, and they do not survive restarts
+ * (an open long poll ends with its connection; no wake is delivered).
+ * Horizontal scaling requires distributing the wake signal — see
+ * AGENTS.md SCALING CONSTRAINTS. State is bounded by concurrent open
+ * requests: every completion path funnels through `#completeWaiter`, which
+ * removes the waiter and deletes drained per-user entries.
+ *
+ * Waiter lifecycle (per `waitForRegistration` call):
+ *   1. The initial repository read races the absolute deadline and the
+ *      caller's abort signal.
+ *   2. On a false read, a waiter is stored and a recheck fires immediately to
+ *      close the registration-between-read-and-storage race window.
+ *   3. `registerToken` resolves all waiters for the user as `true` — but only
+ *      after the durable upsert succeeds; a failed upsert wakes no one.
+ *   4. The remaining-budget timer resolves `false`; the abort signal resolves
+ *      `null` (client gone — the route must not serialize a reply).
+ */
 export class AppClientPresenceService {
   readonly #deviceTokenRepo: DeviceTokenRepository;
   readonly #waitersByUserId = new Map<string, Set<RegistrationWaiter>>();
@@ -33,6 +69,11 @@ export class AppClientPresenceService {
     this.#deviceTokenRepo = params.deviceTokenRepo;
   }
 
+  /**
+   * Durably upserts the device token, then wakes every in-flight waiter for
+   * `userId` with `true`. If the upsert throws, no waiter is notified — the
+   * database write must succeed before presence is asserted.
+   */
   async registerToken(params: { userId: string; token: string; platform: DevicePlatform }): Promise<void> {
     await this.#deviceTokenRepo.upsertToken(params.userId, params.token, params.platform);
 
@@ -50,6 +91,21 @@ export class AppClientPresenceService {
     return this.#deviceTokenRepo.hasAnyForUser(params.userId);
   }
 
+  /**
+   * Waits up to `timeoutMs` for the user to have at least one registered
+   * device token, using a single absolute deadline that starts before the
+   * initial read.
+   *
+   * Returns:
+   *   - `true`  — a token exists or was registered during the wait
+   *   - `false` — the deadline elapsed after a confirmed absent read
+   *   - `null`  — `abortSignal` fired (client disconnected); the caller must
+   *               hijack the reply rather than serialize a response
+   *
+   * Throws `AppClientPresenceInitialReadTimeout` when the deadline elapses
+   * before the initial read settles, so unconfirmed absence is never reported
+   * as `false`.
+   */
   async waitForRegistration(params: {
     userId: string;
     timeoutMs: number;
@@ -60,6 +116,9 @@ export class AppClientPresenceService {
     }
 
     if (params.timeoutMs <= 0) {
+      // No wait budget: degrade to an immediate read (no waiter, no deadline
+      // race). The route always passes a positive timeout; this is a
+      // defensive fallback only.
       return this.#deviceTokenRepo.hasAnyForUser(params.userId);
     }
 
@@ -71,16 +130,16 @@ export class AppClientPresenceService {
     });
 
     switch (initialRead.kind) {
-      case "registered":
+      case OutcomeKind.Registered:
         if (initialRead.registered) {
           return true;
         }
         break;
-      case "aborted":
+      case OutcomeKind.Aborted:
         return null;
-      case "deadline":
+      case OutcomeKind.Deadline:
         throw new AppClientPresenceInitialReadTimeout();
-      case "error":
+      case OutcomeKind.Error:
         throw initialRead.error;
     }
 
@@ -98,24 +157,28 @@ export class AppClientPresenceService {
       timeoutMs: remainingMs,
       abortSignal: params.abortSignal,
     });
+    // A registration that committed between the initial false read and waiter
+    // storage would never wake this waiter; the recheck observes it.
     const recheck = this.#deviceTokenRepo.hasAnyForUser(params.userId).then<WaitOutcome, WaitOutcome>(
-      (registered) => ({ kind: "registered", registered }),
-      (error: unknown) => ({ kind: "error", error }),
+      (registered) => ({ kind: OutcomeKind.Registered, registered }),
+      (error: unknown) => ({ kind: OutcomeKind.Error, error }),
     );
     const outcome = await Promise.race([
       waiter.promise.then<WaitOutcome>((registered) =>
-        registered === null ? { kind: "aborted" } : { kind: "registered", registered },
+        registered === null ? { kind: OutcomeKind.Aborted } : { kind: OutcomeKind.Registered, registered },
       ),
       recheck,
     ]);
 
-    if (outcome.kind === "error") {
+    if (outcome.kind === OutcomeKind.Error) {
       this.#completeWaiter(waiter, null);
       throw outcome.error;
     }
-    if (outcome.kind === "aborted") {
+
+    if (outcome.kind === OutcomeKind.Aborted) {
       return null;
     }
+
     if (outcome.registered) {
       this.#completeWaiter(waiter, true);
       return true;
@@ -134,18 +197,18 @@ export class AppClientPresenceService {
     let abortListener: (() => void) | undefined;
 
     const repositoryRead = this.#deviceTokenRepo.hasAnyForUser(params.userId).then<ReadOutcome, ReadOutcome>(
-      (registered) => ({ kind: "registered", registered }),
-      (error: unknown) => ({ kind: "error", error }),
+      (registered) => ({ kind: OutcomeKind.Registered, registered }),
+      (error: unknown) => ({ kind: OutcomeKind.Error, error }),
     );
     const deadline = new Promise<ReadOutcome>((resolve) => {
-      timeout = setTimeout(() => resolve({ kind: "deadline" }), remainingMs);
+      timeout = setTimeout(() => resolve({ kind: OutcomeKind.Deadline }), remainingMs);
       timeout.unref?.();
     });
     const abort = new Promise<ReadOutcome>((resolve) => {
-      abortListener = () => resolve({ kind: "aborted" });
+      abortListener = () => resolve({ kind: OutcomeKind.Aborted });
       params.abortSignal.addEventListener("abort", abortListener, { once: true });
       if (params.abortSignal.aborted) {
-        resolve({ kind: "aborted" });
+        resolve({ kind: OutcomeKind.Aborted });
       }
     });
 
@@ -155,6 +218,7 @@ export class AppClientPresenceService {
       if (timeout) {
         clearTimeout(timeout);
       }
+
       if (abortListener) {
         params.abortSignal.removeEventListener("abort", abortListener);
       }
@@ -166,6 +230,9 @@ export class AppClientPresenceService {
     const promise = new Promise<boolean | null>((resolve) => {
       resolvePromise = resolve;
     });
+    // waiterRef breaks the forward reference: the abort listener and timeout
+    // callback need the waiter object, but both are created before it can be
+    // assembled. The ref is populated below before any event can fire.
     const waiterRef: { value?: RegistrationWaiter } = {};
     const abortListener = () => {
       if (waiterRef.value) {
@@ -202,12 +269,18 @@ export class AppClientPresenceService {
     return waiter;
   }
 
+  /**
+   * Single-completion gate: clears the timer, removes the abort listener,
+   * removes the waiter from the per-user set (deleting a drained entry), and
+   * resolves its promise. The `settled` flag makes completion idempotent when
+   * registration, recheck, timeout, and abort race for the same waiter.
+   */
   #completeWaiter(waiter: RegistrationWaiter, registered: boolean | null): void {
     if (waiter.settled) {
       return;
     }
-    waiter.settled = true;
 
+    waiter.settled = true;
     clearTimeout(waiter.timeout);
     waiter.abortSignal.removeEventListener("abort", waiter.abortListener);
     const waiters = this.#waitersByUserId.get(waiter.userId);
@@ -215,6 +288,7 @@ export class AppClientPresenceService {
     if (waiters?.size === 0) {
       this.#waitersByUserId.delete(waiter.userId);
     }
+
     waiter.resolve(registered);
   }
 }

--- a/tests/auth/app-clients.test.ts
+++ b/tests/auth/app-clients.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
 import http from "node:http";
-import { after, afterEach, before, describe, it } from "node:test";
+import { after, afterEach, before, describe, it, mock } from "node:test";
 import Fastify, { type FastifyInstance } from "fastify";
 import { ApiError } from "../../src/lib/errors.js";
+import { DeviceTokenRepository } from "../../src/repositories/device-token-repo.js";
 import { appClientRoutes } from "../../src/routes/app-clients.js";
 import {
   AppClientPresenceInitialReadTimeout,
@@ -51,27 +52,36 @@ describe("GET /auth/app-clients/status", () => {
 
   it("wakes a long poll after the same user durably registers a token", async () => {
     const user = await ctx.createUser();
-    const waiting = keepProcessAlive(
-      ctx.app.inject({
-        method: "GET",
-        url: "/auth/app-clients/status?wait=true",
-        headers: { authorization: `Bearer ${user.accessToken}` },
-      }),
-    );
-    await delay(10);
+    const readSpy = mock.method(DeviceTokenRepository.prototype, "hasAnyForUser");
+    try {
+      const waiting = keepProcessAlive(
+        ctx.app.inject({
+          method: "GET",
+          url: "/auth/app-clients/status?wait=true",
+          headers: { authorization: `Bearer ${user.accessToken}` },
+        }),
+      );
+      // The recheck read starts only after the waiter is stored. Once it has
+      // RESOLVED false, the recheck path can no longer complete the poll, so
+      // the response below can only come from the registration wake.
+      await waitFor(() => readSpy.mock.callCount() >= 2);
+      assert.equal(await readSpy.mock.calls[1]?.result, false);
 
-    const registration = await ctx.app.inject({
-      method: "POST",
-      url: "/notifications/register-token",
-      headers: { authorization: `Bearer ${user.accessToken}`, "content-type": "application/json" },
-      payload: JSON.stringify({ token: `wake-${user.userId}`, platform: "android" }),
-    });
-    const response = await waiting;
+      const registration = await ctx.app.inject({
+        method: "POST",
+        url: "/notifications/register-token",
+        headers: { authorization: `Bearer ${user.accessToken}`, "content-type": "application/json" },
+        payload: JSON.stringify({ token: `wake-${user.userId}`, platform: "android" }),
+      });
+      const response = await waiting;
 
-    assert.equal(registration.statusCode, 200);
-    assert.deepEqual(registration.json(), { ok: true });
-    assert.equal(response.statusCode, 200);
-    assert.deepEqual(response.json(), { registered: true });
+      assert.equal(registration.statusCode, 200);
+      assert.deepEqual(registration.json(), { ok: true });
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(response.json(), { registered: true });
+    } finally {
+      readSpy.mock.restore();
+    }
   });
 
   it("requires auth and rejects unsupported or unknown query values", async () => {
@@ -120,6 +130,18 @@ describe("app-client status route failure and disconnect mapping", () => {
 
     assert.equal(response.statusCode, 500);
     assert.deepEqual(response.json(), { error: "internal_server_error" });
+  });
+
+  it("returns { registered: false } when the wait times out without a registration", async () => {
+    const app = await buildRouteApp({
+      hasRegisteredClient: async () => false,
+      waitForRegistration: async () => false,
+    });
+
+    const response = await app.inject({ method: "GET", url: "/auth/app-clients/status?wait=true" });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json(), { registered: false });
   });
 
   it("rejects an invalid service reply through the strict reply schema", async () => {

--- a/tests/services/app-client-presence-service.test.ts
+++ b/tests/services/app-client-presence-service.test.ts
@@ -105,6 +105,21 @@ describe("AppClientPresenceService", () => {
     assert.equal(repo.readCount, 0);
   });
 
+  it("bypasses waiter machinery and reads immediately when timeoutMs is not positive", async () => {
+    const repo = new FakeDeviceTokenRepository();
+    repo.reads.push(true);
+    const service = createService(repo);
+
+    const result = await service.waitForRegistration({
+      userId: "user-zero",
+      timeoutMs: 0,
+      abortSignal: new AbortController().signal,
+    });
+
+    assert.equal(result, true);
+    assert.equal(repo.readCount, 1);
+  });
+
   it("aborts an active waiter and removes its listener", async () => {
     const repo = new FakeDeviceTokenRepository();
     repo.reads.push(false, false);


### PR DESCRIPTION
## Summary
Follow-up to #44, addressing the findings of a five-domain post-merge review (code quality, architecture, performance, testing, documentation) run against the VESPR reviewer protocol. No behavioral change to production code paths.

### Tests (QA findings)
- **QA-1 (MAJOR)**: add the plan-required route-level test — `wait=true` with no registration returns `200 { registered: false }` (this was the only plan §8 test behavior missing from #44)
- **QA-2**: make the long-poll wake test deterministic — gate on the recheck read having **resolved** `false` (prototype spy, restored in `finally`) instead of a 10 ms sleep, so the asserted response can only be produced by the registration wake
- **QA-3**: cover the `timeoutMs <= 0` immediate-read branch of `waitForRegistration`
- QA-4's suggested stale-waiter probe was evaluated and **rejected as vacuous** during implementation review (`registerToken` performs no presence read, so the probe could not detect stale state); map cleanup remains transitively proven by the abort-listener-removal assertion, which shares the atomic `#completeWaiter` path

### Documentation (DC findings)
- **DC-1 (MAJOR)**: class-level and method JSDoc on `AppClientPresenceService` (waiter lifecycle, process-local constraint, durable-upsert-before-wake), matching the `PendingAuthStore` documentation baseline
- **DC-2**: document why `AppClientPresenceInitialReadTimeout` is a typed error (unconfirmed absence must never serialize as `registered: false`)
- **DC-3**: route file-header contract + inline comments on the 500-mapping and null→hijack decisions
- **DC-4**: contracts for `createRequestCloseSignal` / `isClientConnectionOpen`, including why `reply.raw.destroyed` is checked separately from `writableEnded`

### Conventions (CQ findings) + AGENTS.md
- **CQ-3**: string-valued `OutcomeKind` enum replaces the string-literal `kind` discriminator (runtime values unchanged; exhaustive switch narrowing preserved)
- **CQ-1/2/4**: blank lines between adjacent guard blocks per the repo convention
- AGENTS.md: reattach the `PENDING_AUTH_*` tunables line to the PendingAuthStore bullet it describes (the #44 insertion had orphaned it under the presence bullet)

## Verification
- `npm run format:check` ✅
- `npm run lint` ✅
- `npm run build` ✅
- `npm run circular-dependencies` ✅ (no circular deps)
- `npm test` ✅ — 426 passed, 0 failed, 1 pre-existing skip (hermetic mongodb-memory-server); includes the corrected Mongo-backed wake test and both new tests
- architecture implementation review (aristotle-impl-review): **APPROVED** after two rounds — its findings (wake-test synchronization must gate on the recheck *resolving* false; stale-waiter probe vacuous) are incorporated above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Follow-up to #44 that tightens the app-client presence flow with clearer contracts, docs, and deterministic tests. No production behavior changes.

- **Refactors**
  - Replace string-literal outcome kinds with an `OutcomeKind` enum (values unchanged).
  - Document the presence waiter lifecycle, typed `AppClientPresenceInitialReadTimeout`, route’s 500 mapping for unconfirmed absence, disconnect hijack, and request-close-signal helpers.
  - Style: separate adjacent guard blocks per repo convention; fix `AGENTS.md` scaling note placement.
  - Tests: add the missing route check for wait timeout → 200 { registered: false }, make the long-poll wake test deterministic (gate on recheck resolved false), and cover the `timeoutMs <= 0` immediate-read path.

<sup>Written for commit 8abd8e0f7e968f3e9a9f118bd70bfbf1aee959c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

