### PR TITLE
[real-time-transcription] Add glossary migration tooling [step 1/13]

### DIFF
--- a/.plans/real-time-transcription/PLAN.md
+++ b/.plans/real-time-transcription/PLAN.md
@@ -693,7 +693,7 @@ schemas cover the collection metadata, each list-indexes record, and the bounded
 duplicate-count aggregation result; all counters must be nonnegative safe
 integers. Unknown/malformed persistence metadata is a closed redacted failure.
 The collection must be absent or be a normal collection with no default
-collation (binary/simple); dry-run/apply fail before mutation when a non-simple
+collation or an explicit `{ locale: "simple" }` default; dry-run/apply fail before mutation when a non-simple
 default collation could be inherited by a newly created index. Same-spec sparse,
 partial, collated, hidden, non-unique, or otherwise semantically mismatched old/
 target indexes also fail closed.
@@ -728,7 +728,7 @@ closed recovery outcomes:
 
 | Observed state after failure/re-audit                                                                            | Outcome           | Required action                                                                                                       |
 | ---------------------------------------------------------------------------------------------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------- |
-| Valid data/simple collation and only absent/exact old/target indexes, including exact-both interruption          | `safe_to_rerun`   | Keep auth stopped and rerun the same mode; missing required indexes may be recreated.                                 |
+| Valid data/simple collation and only absent/exact old/target indexes, including exact-both interruption; rollback additionally requires zero documents | `safe_to_rerun`   | Keep auth stopped and rerun the same mode; missing required indexes may be recreated.                                 |
 | Requested final state passes the complete audit despite a same-mode `IndexNotFound`/create race                  | `completed`       | Treat as success only while the maintenance/DDL exclusion remains held through command exit.                          |
 | Any invalid/unscoped/nonempty-for-rollback data, duplicate target key, non-simple collation, or mismatched index | `repair_required` | Keep auth stopped; do not rerun blindly or start either binary. Design and review a separate data/index repair first. |
 | Fresh audit itself cannot complete, so current state is unknown                                                  | `repair_required` | Keep auth stopped and restore database observability; inspect with a reviewed read-only audit before further DDL.     |
@@ -1684,7 +1684,7 @@ each PR; `actual` includes authored additions plus deletions):
 
 | Slice | Status  | Reviewed base SHA | Forecast authored lines | Actual authored/generated lines | Verification | Next slice |
 | ----- | ------- | ----------------- | ----------------------- | ------------------------------- | ------------ | ---------- |
-| PR1   | Ready   | `8fc4fcf`         | 1,480                   | 1,256 / 0                       | MongoDB 7 focused/full; all checks; production dry-run zero | PR2        |
+| PR1   | Ready   | `8fc4fcf`         | 1,480                   | 1,402 / 0                       | MongoDB 7 focused/full; all checks; production dry-run zero | PR2        |
 | PR2   | Pending | -                 | TBD before coding       | -                               | -            | PR3        |
 | PR3   | Pending | -                 | TBD before coding       | -                               | -            | PR4        |
 | PR4   | Pending | -                 | TBD before coding       | -                               | -            | PR5        |

--- a/.plans/real-time-transcription/PLAN.md
+++ b/.plans/real-time-transcription/PLAN.md
@@ -688,23 +688,55 @@ duplicate-key findings, and exact old/target index state without logging words,
 user IDs, or project keys. Operations identify indexes by ordered key spec and
 options, not by an assumed generated name.
 
+The migration validates every consumed MongoDB result before use: strict Zod
+schemas cover the collection metadata, each list-indexes record, and the bounded
+duplicate-count aggregation result; all counters must be nonnegative safe
+integers. Unknown/malformed persistence metadata is a closed redacted failure.
+The collection must be absent or be a normal collection with no default
+collation (binary/simple); dry-run/apply fail before mutation when a non-simple
+default collation could be inherited by a newly created index. Same-spec sparse,
+partial, collated, hidden, non-unique, or otherwise semantically mismatched old/
+target indexes also fail closed.
+
 - Dry-run succeeds only when applying is safe: the collection is empty, or all
   rows already contain a valid `projectKey` and have no duplicate target key. It
   fails on any unscoped/invalid row. The expected first production result is
   zero documents.
 - `--apply` repeats the audit, creates the unique
   `{ userId: 1, projectKey: 1, word: 1 }` index, reloads index metadata and
-  confirms its exact key order and `unique: true`, then drops the old index and
-  verifies the final state. It never mutates documents or invents a project key.
+  confirms its exact key order/options and collection collation, repeats the
+  complete document/duplicate/index audit, then drops the old index and repeats
+  that complete audit again before reporting the final target-only state. It
+  never mutates documents or invents a project key.
 - `--verify` is read-only and succeeds only when all rows are scoped, the exact
   target unique index exists, and the old index is absent.
 - `--rollback` is intentionally narrower: it refuses unless the collection is
   empty, creates and verifies the old unique index first, then drops the target
-  index and verifies the old-only state. Once any project-scoped term exists,
-  rollback is forbidden and recovery must roll forward.
+  index and repeats the complete audit before reporting the old-only state. Once
+  any project-scoped term exists, rollback is forbidden and recovery must roll
+  forward.
 - `--apply` and `--rollback` are idempotent. An interruption after creating the
   replacement but before dropping the old index leaves both indexes and can be
   resumed safely.
+
+Mutating modes are supported only while all auth glossary writers are stopped
+and no other migration or manual index DDL runs, from the initial audit through
+command exit and capture of its report. Under that maintained exclusion, the
+final complete audit is the success boundary; the tool makes no claim against
+DDL or writes performed after it exits. Mutation failures return one of these
+closed recovery outcomes:
+
+| Observed state after failure/re-audit                                                                            | Outcome           | Required action                                                                                                       |
+| ---------------------------------------------------------------------------------------------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Valid data/simple collation and only absent/exact old/target indexes, including exact-both interruption          | `safe_to_rerun`   | Keep auth stopped and rerun the same mode; missing required indexes may be recreated.                                 |
+| Requested final state passes the complete audit despite a same-mode `IndexNotFound`/create race                  | `completed`       | Treat as success only while the maintenance/DDL exclusion remains held through command exit.                          |
+| Any invalid/unscoped/nonempty-for-rollback data, duplicate target key, non-simple collation, or mismatched index | `repair_required` | Keep auth stopped; do not rerun blindly or start either binary. Design and review a separate data/index repair first. |
+| Fresh audit itself cannot complete, so current state is unknown                                                  | `repair_required` | Keep auth stopped and restore database observability; inspect with a reviewed read-only audit before further DDL.     |
+
+Tests deterministically inject a legacy row and conflicting index operation
+between verification and each drop. Post-drop invalid data/mismatched DDL must
+return `repair_required`; separate valid missing-index fixtures return
+`safe_to_rerun` and prove an ordinary rerun converges.
 
 `DATABASE_CONFIG` changes to the target index. `MongoDbAccessor.ensureIndexes()`
 may create a missing target index but must never drop the old glossary index;
@@ -725,7 +757,8 @@ Production sequence for this single-instance service:
 2. Require a zero-document report. If any row exists, stop this rollout and
    design a product-approved assignment/deletion migration; do not apply PR2.
 3. Stop the old auth instance or otherwise enter a maintenance window that
-   prevents glossary writes. Do not run old and new binaries concurrently.
+   prevents glossary writes. Do not run old and new binaries concurrently, and
+   allow exactly one migration command with no manual glossary index DDL.
 4. From the reviewed PR2 artifact, apply and verify with the PR1 command:
 
    ```bash
@@ -741,11 +774,13 @@ Production sequence for this single-instance service:
 There is deliberately no mixed-version window. An old binary omits
 `projectKey` on writes and reads every term for the user, so it is semantically
 unsafe after project-scoped data exists even though MongoDB could accept some
-of its writes. If apply fails before the old index is dropped, resume the old
-binary and rerun the idempotent command. If the old index was dropped but no new
-term was written, stop the failed new binary, run `--rollback`, verify, and then
-restore the old binary. If any scoped term was written, do not run `--rollback`
-or an old binary; repair or redeploy PR2 forward.
+of its writes. On `safe_to_rerun`, keep auth stopped and rerun the same command.
+On `repair_required`, keep both binaries stopped and obtain a separately reviewed
+data/index repair; this migration never deletes or assigns terms. After a
+successful apply, if PR2 fails before any scoped term is written, keep it stopped,
+run `--rollback`, verify, and only then restore the old binary. If any scoped term
+was written, do not run `--rollback` or an old binary; repair or redeploy PR2
+forward.
 
 `dailyUsage` remains the durable quota source. Repository methods accept a
 captured strict `YYYY-MM-DD` UTC date key so a request crossing midnight reads
@@ -1649,7 +1684,7 @@ each PR; `actual` includes authored additions plus deletions):
 
 | Slice | Status  | Reviewed base SHA | Forecast authored lines | Actual authored/generated lines | Verification | Next slice |
 | ----- | ------- | ----------------- | ----------------------- | ------------------------------- | ------------ | ---------- |
-| PR1   | Pending | -                 | TBD before coding       | -                               | -            | PR2        |
+| PR1   | Ready   | `8fc4fcf`         | 1,480                   | 1,256 / 0                       | MongoDB 7 focused/full; all checks; production dry-run zero | PR2        |
 | PR2   | Pending | -                 | TBD before coding       | -                               | -            | PR3        |
 | PR3   | Pending | -                 | TBD before coding       | -                               | -            | PR4        |
 | PR4   | Pending | -                 | TBD before coding       | -                               | -            | PR5        |
@@ -1675,34 +1710,58 @@ File map:
 
 - `src/models/voice.ts` (new): define and export the strict reusable
   `projectKey` schema without changing a live request contract.
+- `src/models/documents.ts`: add exported strict legacy and project-scoped
+  glossary migration document schemas while leaving the live
+  `glossaryEntrySchema`/`GlossaryEntry` contract unchanged until PR2.
+- `src/config.ts`: add a narrow `MONGODB_URI`-only migration config loader using
+  `safeParse`; normal web config remains unchanged and no other app secret is
+  required by the CLI.
 - `src/db/glossary-index-migration.ts` (new): own old/target index specs,
-  old/target document-shape audit, exact verification, apply ordering, rollback
-  ordering, and redacted reports; it is not called by application startup.
+  binary/simple collection-collation invariant, strict collection/index/
+  aggregation metadata validation, old/target document-shape audit, exact
+  verification, apply ordering, rollback ordering, and redacted reports; it is
+  not called by application startup.
 - `src/scripts/migrate-project-glossary-index.ts` (new): expose dry-run,
   `--apply`, `--verify`, and `--rollback` modes using only `MONGODB_URI` and
   always close MongoDB.
 - `package.json`: add `migrate-project-glossary-index`; no new dependency.
 - `README.md`: document the derivation contract and complete dry-run/apply/
-  verify/interruption/rollback runbook, prominently stating that production
-  `--apply` waits for the PR2 maintenance-window cutover.
+  verify/interruption/rollback/`repair_required` runbook, prominently stating
+  that production `--apply` waits for the PR2 maintenance-window cutover and
+  auth stays stopped for every non-rerunnable partial state.
 - `tests/models/voice.test.ts` (new): cover exact opaque-key length/alphabet and
-  malformed variants.
+  malformed variants plus strict legacy/target migration document shapes.
+- `tests/config.test.ts` (new): cover isolated valid/missing/malformed migration
+  URI configuration without loading normal web configuration.
 - `tests/scripts/project-glossary-index-migration.test.ts` (new): cover dry-run,
   apply, verify, interruption/idempotency, unsafe legacy/target rows, exact index
-  mismatch, redacted output, and empty-only rollback against MongoDB 7.
+  mismatch, non-simple collection collation, malformed MongoDB metadata/counts,
+  redacted output, post-drop race detection, concurrent/conflicting DDL outcomes,
+  and empty-only rollback against MongoDB 7.
 
 Acceptance criteria:
 
-- [ ] Add the strict opaque `projectKey` schema and document the v1 client
+- [x] Add the strict opaque `projectKey` schema and document the v1 client
       derivation formula without importing client code.
-- [ ] Make migration dry-run the default; require explicit, mutually exclusive
+- [x] Make migration dry-run the default; require explicit, mutually exclusive
       flags for mutation and fail closed on malformed data/indexes.
-- [ ] Prove apply creates/verifies the target unique index before dropping the
+- [x] Validate complete persisted document and every consumed collection/index/
+      aggregation result through strict Zod `safeParse`, including nonnegative
+      safe-integer counts; require absent or binary/simple collection collation
+      before any index mutation.
+- [x] Prove apply creates/verifies the target unique index before dropping the
       legacy index, rollback does the inverse only while data is empty, and every
       mode is resumable and content-redacted.
-- [ ] Run the production dry-run and record its counts, but do not run production
+- [x] Require the mutating-mode maintenance boundary to exclude glossary writers
+      and concurrent migration/index DDL; run the complete data, duplicate,
+      collation, and index audit after every destructive drop and never report
+      success when an intervening write or conflicting DDL invalidates it.
+- [x] Return `safe_to_rerun` only for valid absent/exact-index interruption states
+      and `repair_required` for post-drop invalid data, mismatched DDL, or unknown
+      state; keep auth stopped and require separate review for every repair.
+- [x] Run the production dry-run and record its counts, but do not run production
       `--apply` until the PR2 binary/artifact and maintenance window are ready.
-- [ ] Record the actual authored/generated line count and the reviewed
+- [x] Record the actual authored/generated line count and the reviewed
       `origin/master` SHA in this plan before opening the PR.
 
 Focused verification:
@@ -1710,6 +1769,7 @@ Focused verification:
 ```bash
 MONGODB_URI_TEST=mongodb://localhost:27017/auth-backend-test \
   node --import tsx --test --test-concurrency=1 \
+  tests/config.test.ts \
   tests/models/voice.test.ts \
   tests/scripts/project-glossary-index-migration.test.ts
 ```

--- a/README.md
+++ b/README.md
@@ -166,6 +166,85 @@ Relay reports to `POST /internal/bridge-status` must include the registered `bri
 
 Activation reminder timers and single-flight state are process-local. Keep `ACTIVATION_REMINDERS_ENABLED=false` on every instance except the single designated sender; multiple enabled instances can duplicate notifications.
 
+## Project-scoped glossary migration
+
+Glossary ownership uses an opaque, stable client-derived project key rather than
+a filesystem path or raw bridge project ID:
+
+```text
+digestInput = "sesori-project-glossary-v1\0" + bridgeId + "\0" + projectId
+projectKey = "prj_v1_" + base64url(sha256(utf8(digestInput)))
+```
+
+The result is exactly `prj_v1_` plus a 43-character unpadded base64url digest.
+Including the bridge ID separates bridge-local project namespaces; using stable
+`Project.id` keeps the key unchanged when a directory moves. The server validates
+only this opaque shape and scopes it to the authenticated user. It never accepts
+or persists a raw path for glossary ownership.
+
+PR1 adds a migration command but does not change live glossary behavior or the
+startup index configuration. The command defaults to a read-only dry-run and
+reports only counts and closed state enums, never words, user IDs, project keys,
+documents, or index names:
+
+```bash
+sops exec-env env/app/prod.env \
+  'npm run migrate-project-glossary-index'
+```
+
+The expected production preview is `documentCount: 0`, no invalid/duplicate
+counts, `legacyIndexState: "exact"`, `targetIndexState: "absent"`, and
+`outcome: "completed"`. Any document, malformed metadata, non-simple collection
+collation, index mismatch, or `repair_required` outcome stops the rollout and
+requires a separately reviewed data/index plan. Do not infer a project key or
+delete production terms ad hoc.
+
+Do **not** run `--apply` from the PR1 deployment. Mutation waits until the reviewed
+PR2 artifact is ready and auth is in a maintenance window. For that cutover:
+
+1. Remove the single auth instance from ingress, stop it, and confirm no glossary
+   writer remains. Permit exactly one migration command and no manual index DDL.
+2. Run `--apply` from the reviewed PR2 artifact:
+
+   ```bash
+   sops exec-env env/app/prod.env \
+     'npm run migrate-project-glossary-index -- --apply'
+   ```
+
+3. Keep auth stopped while handling the closed outcome:
+   - `completed`: proceed to read-only `--verify`.
+   - `safe_to_rerun`: rerun the same mode; this is limited to valid data with
+     absent/exact indexes, such as interruption before the destructive drop.
+   - `repair_required`: do not rerun blindly or start either binary. Restore DB
+     observability if needed and obtain a separately reviewed repair.
+4. Run `--verify` and require target `exact`, legacy `absent`, every invalid/
+   duplicate count zero, and `completed` before starting PR2:
+
+   ```bash
+   sops exec-env env/app/prod.env \
+     'npm run migrate-project-glossary-index -- --verify'
+   ```
+
+The maintenance/no-DDL exclusion remains held through each command's exit and
+capture of its report. Apply creates and reload-verifies the target unique index,
+re-audits all data/index metadata, drops the old index, and performs the complete
+audit again. An exact-both interruption is resumable. Post-drop invalid data,
+mismatched DDL, or unknown state is `repair_required`, not automatically
+recoverable.
+
+Rollback is allowed only while the glossary collection is empty. If PR2 fails
+before any project-scoped term is written, keep it stopped and run:
+
+```bash
+sops exec-env env/app/prod.env \
+  'npm run migrate-project-glossary-index -- --rollback'
+```
+
+Require the rollback report itself to show legacy `exact`, target `absent`, zero
+documents, and `completed` before restoring the old binary. Do not use forward
+`--verify` after rollback. Once any scoped term exists, rollback is forbidden;
+repair or roll forward with PR2.
+
 ## Activation backfill
 
 Deploy the activation-state schema and indexes before running the existing-user backfill. The command requires `MONGODB_URI`, defaults to dry-run, and does not create indexes or write documents unless `--apply` is present.
@@ -342,6 +421,7 @@ the restricted target dataset/table and deletion identity exist.
 | `npm run backfill-product-analytics-preference` | Validate preference migration; pass `-- --apply` to persist bounded batches |
 | `npm run export-product-analytics` | Run one isolated auth-private export using ADC (unscheduled until analytics IAM exists) |
 | `npm run suppress-product-analytics-export` | Read one protected suppression request from stdin and hand off a restricted deletion target |
+| `npm run migrate-project-glossary-index` | Dry-run glossary index migration; mutation flags require the documented PR2 maintenance window |
 
 ## Project structure
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "backfill-product-analytics-preference": "tsx src/scripts/backfill-product-analytics-preference.ts",
     "export-product-analytics": "tsx src/scripts/export-product-analytics.ts",
     "suppress-product-analytics-export": "tsx src/scripts/suppress-product-analytics-export.ts",
+    "migrate-project-glossary-index": "tsx src/scripts/migrate-project-glossary-index.ts",
     "circular-dependencies": "madge --circular --ts-config ./tsconfig.json ./src/index.ts"
   },
   "dependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,6 +80,19 @@ const configSchema = z.object({
 
 export type Config = z.infer<typeof configSchema>;
 
+const glossaryMigrationConfigSchema = z.object({
+  MONGODB_URI: z.string().regex(/^mongodb(?:\+srv)?:\/\/\S+$/),
+});
+
+export function loadGlossaryMigrationConfig(env: NodeJS.ProcessEnv): { mongodbUri: string } {
+  const result = glossaryMigrationConfigSchema.safeParse(env);
+  if (!result.success) {
+    throw new Error("GlossaryMigrationConfigError");
+  }
+
+  return { mongodbUri: result.data.MONGODB_URI };
+}
+
 let cached: Config | null = null;
 
 export function loadConfig(): Config {

--- a/src/db/glossary-index-migration.ts
+++ b/src/db/glossary-index-migration.ts
@@ -48,6 +48,7 @@ export type GlossaryIndexMigrationReport = {
 };
 
 type ParsedIndex = z.infer<typeof indexMetadataSchema>;
+type ParsedCollation = z.infer<typeof collationSchema>;
 type Audit = Omit<GlossaryIndexMigrationReport, "mode" | "outcome"> & {
   legacyIndexName: string | null;
   targetIndexName: string | null;
@@ -111,18 +112,84 @@ const indexMetadataListSchema = z.array(indexMetadataSchema).min(1);
 const duplicateCountResultSchema = z
   .array(z.object({ duplicateTargetKeyCount: nonnegativeSafeIntegerSchema }).strict())
   .max(1);
+const glossaryIndexMigrationMaxTimeMs = 5 * 60 * 1_000;
+const maxPersistenceDiagnosticIssues = 10;
+const maxPersistenceDiagnosticPathSegments = 8;
+const persistenceDiagnosticStaticPathSegments = new Set([
+  "2dsphereIndexVersion",
+  "alternate",
+  "backwards",
+  "bits",
+  "bucketSize",
+  "caseFirst",
+  "caseLevel",
+  "collation",
+  "default_language",
+  "duplicateTargetKeyCount",
+  "expireAfterSeconds",
+  "hidden",
+  "idIndex",
+  "info",
+  "key",
+  "language_override",
+  "locale",
+  "max",
+  "maxVariable",
+  "min",
+  "name",
+  "normalization",
+  "ns",
+  "numericOrdering",
+  "options",
+  "partialFilterExpression",
+  "prepareUnique",
+  "readOnly",
+  "sparse",
+  "storageEngine",
+  "strength",
+  "textIndexVersion",
+  "unique",
+  "uuid",
+  "v",
+  "version",
+  "weights",
+  "wildcardProjection",
+]);
 
-class GlossaryIndexMigrationPersistenceError extends Error {
-  constructor() {
-    super("GlossaryIndexMigrationPersistenceError");
+function safePersistenceDiagnosticPath(path: PropertyKey[]): string {
+  if (path.length === 0) {
+    return "<root>";
+  }
+
+  return path
+    .slice(0, maxPersistenceDiagnosticPathSegments)
+    .map((segment) =>
+      typeof segment === "string" && persistenceDiagnosticStaticPathSegments.has(segment) ? segment : "<field>",
+    )
+    .join(".");
+}
+
+export class GlossaryIndexMigrationPersistenceError extends Error {
+  readonly diagnostic: string;
+
+  constructor(error: z.ZodError) {
+    const diagnostic = JSON.stringify({
+      issues: error.issues.slice(0, maxPersistenceDiagnosticIssues).map((issue) => ({
+        path: safePersistenceDiagnosticPath(issue.path),
+        code: issue.code,
+      })),
+      truncated: error.issues.length > maxPersistenceDiagnosticIssues,
+    });
+    super(diagnostic);
     this.name = "GlossaryIndexMigrationPersistenceError";
+    this.diagnostic = diagnostic;
   }
 }
 
 function parsePersistence<T>(schema: z.ZodType<T>, value: unknown): T {
   const result = schema.safeParse(value);
   if (!result.success) {
-    throw new GlossaryIndexMigrationPersistenceError();
+    throw new GlossaryIndexMigrationPersistenceError(result.error);
   }
 
   return result.data;
@@ -152,7 +219,7 @@ function isExactUniqueIndex(index: ParsedIndex): boolean {
     index.hidden !== true &&
     index.prepareUnique !== true &&
     index.partialFilterExpression === undefined &&
-    index.collation === undefined &&
+    isSimpleCollation(index.collation) &&
     index.expireAfterSeconds === undefined &&
     index.storageEngine === undefined &&
     index.weights === undefined &&
@@ -166,6 +233,10 @@ function isExactUniqueIndex(index: ParsedIndex): boolean {
     index.bucketSize === undefined &&
     index.wildcardProjection === undefined
   );
+}
+
+function isSimpleCollation(collation: ParsedCollation | undefined): boolean {
+  return collation === undefined || collation.locale === "simple";
 }
 
 function classifyIndex(
@@ -198,7 +269,7 @@ async function auditDocuments(collection: Collection<Document>): Promise<{
   let missingProjectKeyCount = 0;
   let invalidProjectKeyCount = 0;
   let invalidDocumentCount = 0;
-  const cursor = collection.find({});
+  const cursor = collection.find({}, { batchSize: 1_000, maxTimeMS: glossaryIndexMigrationMaxTimeMs });
 
   try {
     for await (const document of cursor) {
@@ -238,7 +309,7 @@ async function countDuplicateTargetKeys(collection: Collection<Document>): Promi
         { $match: { count: { $gt: 1 } } },
         { $count: "duplicateTargetKeyCount" },
       ],
-      { allowDiskUse: true },
+      { allowDiskUse: true, maxTimeMS: glossaryIndexMigrationMaxTimeMs },
     )
     .toArray();
   const result = parsePersistence(duplicateCountResultSchema, rawResult);
@@ -266,9 +337,9 @@ async function audit(db: Db): Promise<Audit> {
   }
 
   const collectionMetadata = collections[0];
-  const collectionState = collectionMetadata.options.collation
-    ? GlossaryCollectionState.NonSimpleCollation
-    : GlossaryCollectionState.Simple;
+  const collectionState = isSimpleCollation(collectionMetadata.options.collation)
+    ? GlossaryCollectionState.Simple
+    : GlossaryCollectionState.NonSimpleCollation;
   const collection = db.collection(AuthDbCollection.GlossaryEntries);
   const documents = await auditDocuments(collection);
   const duplicateTargetKeyCount = await countDuplicateTargetKeys(collection);

--- a/src/db/glossary-index-migration.ts
+++ b/src/db/glossary-index-migration.ts
@@ -1,0 +1,469 @@
+import { UUID, type Collection, type Db, type Document } from "mongodb";
+import { z } from "zod";
+import { legacyGlossaryEntryMigrationSchema, projectScopedGlossaryEntryMigrationSchema } from "../models/documents.js";
+import { projectKeySchema } from "../models/voice.js";
+import { AuthDbCollection } from "../types/mongo.js";
+
+export const legacyGlossaryIndexSpec = { userId: 1, word: 1 } as const;
+export const projectScopedGlossaryIndexSpec = { userId: 1, projectKey: 1, word: 1 } as const;
+export const legacyGlossaryIndexName = "userId_1_word_1";
+export const projectScopedGlossaryIndexName = "userId_1_projectKey_1_word_1";
+
+export enum GlossaryIndexMigrationMode {
+  DryRun = "dry-run",
+  Apply = "apply",
+  Verify = "verify",
+  Rollback = "rollback",
+}
+
+export enum GlossaryIndexMigrationOutcome {
+  Completed = "completed",
+  SafeToRerun = "safe_to_rerun",
+  RepairRequired = "repair_required",
+}
+
+export enum GlossaryIndexState {
+  Absent = "absent",
+  Exact = "exact",
+  Mismatch = "mismatch",
+}
+
+export enum GlossaryCollectionState {
+  Absent = "absent",
+  Simple = "simple",
+  NonSimpleCollation = "non_simple_collation",
+}
+
+export type GlossaryIndexMigrationReport = {
+  mode: GlossaryIndexMigrationMode;
+  outcome: GlossaryIndexMigrationOutcome;
+  collectionState: GlossaryCollectionState;
+  documentCount: number;
+  missingProjectKeyCount: number;
+  invalidProjectKeyCount: number;
+  invalidDocumentCount: number;
+  duplicateTargetKeyCount: number;
+  legacyIndexState: GlossaryIndexState;
+  targetIndexState: GlossaryIndexState;
+};
+
+type ParsedIndex = z.infer<typeof indexMetadataSchema>;
+type Audit = Omit<GlossaryIndexMigrationReport, "mode" | "outcome"> & {
+  legacyIndexName: string | null;
+  targetIndexName: string | null;
+};
+
+const nonnegativeSafeIntegerSchema = z.number().int().nonnegative().safe();
+const indexDirectionSchema = z.union([z.number().finite(), z.string().min(1)]);
+const indexKeySchema = z.record(z.string(), indexDirectionSchema);
+const collationSchema = z
+  .object({
+    locale: z.string().min(1),
+    caseLevel: z.boolean().optional(),
+    caseFirst: z.enum(["upper", "lower", "off"]).optional(),
+    strength: z.number().int().min(1).max(5).optional(),
+    numericOrdering: z.boolean().optional(),
+    alternate: z.enum(["non-ignorable", "shifted"]).optional(),
+    maxVariable: z.enum(["punct", "space"]).optional(),
+    normalization: z.boolean().optional(),
+    backwards: z.boolean().optional(),
+    version: z.string().min(1).optional(),
+  })
+  .strict();
+const unknownRecordSchema = z.record(z.string(), z.unknown());
+const indexMetadataSchema = z
+  .object({
+    v: nonnegativeSafeIntegerSchema,
+    key: indexKeySchema,
+    name: z.string().min(1),
+    ns: z.string().min(1).optional(),
+    unique: z.boolean().optional(),
+    sparse: z.boolean().optional(),
+    hidden: z.boolean().optional(),
+    prepareUnique: z.boolean().optional(),
+    partialFilterExpression: unknownRecordSchema.optional(),
+    collation: collationSchema.optional(),
+    expireAfterSeconds: z.number().finite().optional(),
+    storageEngine: unknownRecordSchema.optional(),
+    weights: unknownRecordSchema.optional(),
+    default_language: z.string().optional(),
+    language_override: z.string().optional(),
+    textIndexVersion: nonnegativeSafeIntegerSchema.optional(),
+    "2dsphereIndexVersion": nonnegativeSafeIntegerSchema.optional(),
+    bits: nonnegativeSafeIntegerSchema.optional(),
+    min: z.number().finite().optional(),
+    max: z.number().finite().optional(),
+    bucketSize: z.number().finite().optional(),
+    wildcardProjection: unknownRecordSchema.optional(),
+  })
+  .strict();
+const collectionMetadataSchema = z
+  .object({
+    name: z.literal(AuthDbCollection.GlossaryEntries),
+    type: z.literal("collection"),
+    options: z.object({ collation: collationSchema.optional() }).strict(),
+    info: z.object({ readOnly: z.literal(false), uuid: z.instanceof(UUID) }).strict(),
+    idIndex: indexMetadataSchema,
+  })
+  .strict();
+const collectionMetadataListSchema = z.array(collectionMetadataSchema).max(1);
+const indexMetadataListSchema = z.array(indexMetadataSchema).min(1);
+const duplicateCountResultSchema = z
+  .array(z.object({ duplicateTargetKeyCount: nonnegativeSafeIntegerSchema }).strict())
+  .max(1);
+
+class GlossaryIndexMigrationPersistenceError extends Error {
+  constructor() {
+    super("GlossaryIndexMigrationPersistenceError");
+    this.name = "GlossaryIndexMigrationPersistenceError";
+  }
+}
+
+function parsePersistence<T>(schema: z.ZodType<T>, value: unknown): T {
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    throw new GlossaryIndexMigrationPersistenceError();
+  }
+
+  return result.data;
+}
+
+function incrementCount(value: number): number {
+  return parsePersistence(nonnegativeSafeIntegerSchema, value + 1);
+}
+
+function indexKeyMatches(index: ParsedIndex, expected: Readonly<Record<string, number>>): boolean {
+  const actualEntries = Object.entries(index.key);
+  const expectedEntries = Object.entries(expected);
+  return (
+    actualEntries.length === expectedEntries.length &&
+    actualEntries.every(([key, value], indexPosition) => {
+      const expectedEntry = expectedEntries[indexPosition];
+      return expectedEntry?.[0] === key && expectedEntry[1] === value;
+    })
+  );
+}
+
+function isExactUniqueIndex(index: ParsedIndex): boolean {
+  return (
+    index.v === 2 &&
+    index.unique === true &&
+    index.sparse !== true &&
+    index.hidden !== true &&
+    index.prepareUnique !== true &&
+    index.partialFilterExpression === undefined &&
+    index.collation === undefined &&
+    index.expireAfterSeconds === undefined &&
+    index.storageEngine === undefined &&
+    index.weights === undefined &&
+    index.default_language === undefined &&
+    index.language_override === undefined &&
+    index.textIndexVersion === undefined &&
+    index["2dsphereIndexVersion"] === undefined &&
+    index.bits === undefined &&
+    index.min === undefined &&
+    index.max === undefined &&
+    index.bucketSize === undefined &&
+    index.wildcardProjection === undefined
+  );
+}
+
+function classifyIndex(
+  indexes: ParsedIndex[],
+  expected: Readonly<Record<string, number>>,
+  canonicalName: string,
+): { state: GlossaryIndexState; name: string | null } {
+  const matching = indexes.filter((index) => indexKeyMatches(index, expected));
+  if (matching.length === 0) {
+    if (indexes.some((index) => index.name === canonicalName)) {
+      return { state: GlossaryIndexState.Mismatch, name: null };
+    }
+    return { state: GlossaryIndexState.Absent, name: null };
+  }
+
+  if (matching.length !== 1 || !isExactUniqueIndex(matching[0])) {
+    return { state: GlossaryIndexState.Mismatch, name: null };
+  }
+
+  return { state: GlossaryIndexState.Exact, name: matching[0].name };
+}
+
+async function auditDocuments(collection: Collection<Document>): Promise<{
+  documentCount: number;
+  missingProjectKeyCount: number;
+  invalidProjectKeyCount: number;
+  invalidDocumentCount: number;
+}> {
+  let documentCount = 0;
+  let missingProjectKeyCount = 0;
+  let invalidProjectKeyCount = 0;
+  let invalidDocumentCount = 0;
+  const cursor = collection.find({});
+
+  try {
+    for await (const document of cursor) {
+      documentCount = incrementCount(documentCount);
+      if (!Object.hasOwn(document, "projectKey")) {
+        missingProjectKeyCount = incrementCount(missingProjectKeyCount);
+        if (!legacyGlossaryEntryMigrationSchema.safeParse(document).success) {
+          invalidDocumentCount = incrementCount(invalidDocumentCount);
+        }
+        continue;
+      }
+
+      if (!projectKeySchema.safeParse(document.projectKey).success) {
+        invalidProjectKeyCount = incrementCount(invalidProjectKeyCount);
+      }
+      if (!projectScopedGlossaryEntryMigrationSchema.safeParse(document).success) {
+        invalidDocumentCount = incrementCount(invalidDocumentCount);
+      }
+    }
+  } finally {
+    await cursor.close();
+  }
+
+  return { documentCount, missingProjectKeyCount, invalidProjectKeyCount, invalidDocumentCount };
+}
+
+async function countDuplicateTargetKeys(collection: Collection<Document>): Promise<number> {
+  const rawResult = await collection
+    .aggregate(
+      [
+        {
+          $group: {
+            _id: { userId: "$userId", projectKey: "$projectKey", word: "$word" },
+            count: { $sum: 1 },
+          },
+        },
+        { $match: { count: { $gt: 1 } } },
+        { $count: "duplicateTargetKeyCount" },
+      ],
+      { allowDiskUse: true },
+    )
+    .toArray();
+  const result = parsePersistence(duplicateCountResultSchema, rawResult);
+  return result[0]?.duplicateTargetKeyCount ?? 0;
+}
+
+async function audit(db: Db): Promise<Audit> {
+  const rawCollections = await db
+    .listCollections({ name: AuthDbCollection.GlossaryEntries }, { nameOnly: false })
+    .toArray();
+  const collections = parsePersistence(collectionMetadataListSchema, rawCollections);
+  if (collections.length === 0) {
+    return {
+      collectionState: GlossaryCollectionState.Absent,
+      documentCount: 0,
+      missingProjectKeyCount: 0,
+      invalidProjectKeyCount: 0,
+      invalidDocumentCount: 0,
+      duplicateTargetKeyCount: 0,
+      legacyIndexState: GlossaryIndexState.Absent,
+      targetIndexState: GlossaryIndexState.Absent,
+      legacyIndexName: null,
+      targetIndexName: null,
+    };
+  }
+
+  const collectionMetadata = collections[0];
+  const collectionState = collectionMetadata.options.collation
+    ? GlossaryCollectionState.NonSimpleCollation
+    : GlossaryCollectionState.Simple;
+  const collection = db.collection(AuthDbCollection.GlossaryEntries);
+  const documents = await auditDocuments(collection);
+  const duplicateTargetKeyCount = await countDuplicateTargetKeys(collection);
+  const indexes = parsePersistence(indexMetadataListSchema, await collection.listIndexes().toArray());
+  const legacyIndex = classifyIndex(indexes, legacyGlossaryIndexSpec, legacyGlossaryIndexName);
+  const targetIndex = classifyIndex(indexes, projectScopedGlossaryIndexSpec, projectScopedGlossaryIndexName);
+
+  return {
+    collectionState,
+    ...documents,
+    duplicateTargetKeyCount,
+    legacyIndexState: legacyIndex.state,
+    targetIndexState: targetIndex.state,
+    legacyIndexName: legacyIndex.name,
+    targetIndexName: targetIndex.name,
+  };
+}
+
+function toReport(
+  mode: GlossaryIndexMigrationMode,
+  outcome: GlossaryIndexMigrationOutcome,
+  state: Audit,
+): GlossaryIndexMigrationReport {
+  return {
+    mode,
+    outcome,
+    collectionState: state.collectionState,
+    documentCount: state.documentCount,
+    missingProjectKeyCount: state.missingProjectKeyCount,
+    invalidProjectKeyCount: state.invalidProjectKeyCount,
+    invalidDocumentCount: state.invalidDocumentCount,
+    duplicateTargetKeyCount: state.duplicateTargetKeyCount,
+    legacyIndexState: state.legacyIndexState,
+    targetIndexState: state.targetIndexState,
+  };
+}
+
+function hasSafeData(state: Audit): boolean {
+  return (
+    state.missingProjectKeyCount === 0 &&
+    state.invalidProjectKeyCount === 0 &&
+    state.invalidDocumentCount === 0 &&
+    state.duplicateTargetKeyCount === 0
+  );
+}
+
+function hasSafeIndexes(state: Audit): boolean {
+  return (
+    state.legacyIndexState !== GlossaryIndexState.Mismatch && state.targetIndexState !== GlossaryIndexState.Mismatch
+  );
+}
+
+function canApply(state: Audit): boolean {
+  return (
+    state.collectionState !== GlossaryCollectionState.NonSimpleCollation && hasSafeData(state) && hasSafeIndexes(state)
+  );
+}
+
+function canRollback(state: Audit): boolean {
+  return canApply(state) && state.documentCount === 0;
+}
+
+function isApplied(state: Audit): boolean {
+  return (
+    canApply(state) &&
+    state.collectionState === GlossaryCollectionState.Simple &&
+    state.legacyIndexState === GlossaryIndexState.Absent &&
+    state.targetIndexState === GlossaryIndexState.Exact
+  );
+}
+
+function isRolledBack(state: Audit): boolean {
+  return (
+    canRollback(state) &&
+    state.collectionState === GlossaryCollectionState.Simple &&
+    state.legacyIndexState === GlossaryIndexState.Exact &&
+    state.targetIndexState === GlossaryIndexState.Absent
+  );
+}
+
+function classifyRecovery(mode: GlossaryIndexMigrationMode, state: Audit): GlossaryIndexMigrationOutcome {
+  if (mode === GlossaryIndexMigrationMode.Apply && isApplied(state)) {
+    return GlossaryIndexMigrationOutcome.Completed;
+  }
+  if (mode === GlossaryIndexMigrationMode.Rollback && isRolledBack(state)) {
+    return GlossaryIndexMigrationOutcome.Completed;
+  }
+  if (mode === GlossaryIndexMigrationMode.Apply ? canApply(state) : canRollback(state)) {
+    return GlossaryIndexMigrationOutcome.SafeToRerun;
+  }
+  return GlossaryIndexMigrationOutcome.RepairRequired;
+}
+
+async function recoverAfterMutationFailure(
+  db: Db,
+  mode: GlossaryIndexMigrationMode.Apply | GlossaryIndexMigrationMode.Rollback,
+): Promise<GlossaryIndexMigrationReport> {
+  const state = await audit(db);
+  return toReport(mode, classifyRecovery(mode, state), state);
+}
+
+async function applyMigration(db: Db, initialState: Audit): Promise<GlossaryIndexMigrationReport> {
+  if (!canApply(initialState)) {
+    return toReport(GlossaryIndexMigrationMode.Apply, GlossaryIndexMigrationOutcome.RepairRequired, initialState);
+  }
+
+  const collection = db.collection(AuthDbCollection.GlossaryEntries);
+  try {
+    if (initialState.targetIndexState === GlossaryIndexState.Absent) {
+      await collection.createIndex(projectScopedGlossaryIndexSpec, {
+        name: projectScopedGlossaryIndexName,
+        unique: true,
+      });
+    }
+
+    const beforeDrop = await audit(db);
+    if (!canApply(beforeDrop) || beforeDrop.targetIndexState !== GlossaryIndexState.Exact) {
+      return toReport(
+        GlossaryIndexMigrationMode.Apply,
+        classifyRecovery(GlossaryIndexMigrationMode.Apply, beforeDrop),
+        beforeDrop,
+      );
+    }
+
+    if (beforeDrop.legacyIndexState === GlossaryIndexState.Exact && beforeDrop.legacyIndexName) {
+      await collection.dropIndex(beforeDrop.legacyIndexName);
+    }
+
+    const finalState = await audit(db);
+    return toReport(
+      GlossaryIndexMigrationMode.Apply,
+      classifyRecovery(GlossaryIndexMigrationMode.Apply, finalState),
+      finalState,
+    );
+  } catch {
+    return recoverAfterMutationFailure(db, GlossaryIndexMigrationMode.Apply);
+  }
+}
+
+async function rollbackMigration(db: Db, initialState: Audit): Promise<GlossaryIndexMigrationReport> {
+  if (!canRollback(initialState)) {
+    return toReport(GlossaryIndexMigrationMode.Rollback, GlossaryIndexMigrationOutcome.RepairRequired, initialState);
+  }
+
+  const collection = db.collection(AuthDbCollection.GlossaryEntries);
+  try {
+    if (initialState.legacyIndexState === GlossaryIndexState.Absent) {
+      await collection.createIndex(legacyGlossaryIndexSpec, { name: legacyGlossaryIndexName, unique: true });
+    }
+
+    const beforeDrop = await audit(db);
+    if (!canRollback(beforeDrop) || beforeDrop.legacyIndexState !== GlossaryIndexState.Exact) {
+      return toReport(
+        GlossaryIndexMigrationMode.Rollback,
+        classifyRecovery(GlossaryIndexMigrationMode.Rollback, beforeDrop),
+        beforeDrop,
+      );
+    }
+
+    if (beforeDrop.targetIndexState === GlossaryIndexState.Exact && beforeDrop.targetIndexName) {
+      await collection.dropIndex(beforeDrop.targetIndexName);
+    }
+
+    const finalState = await audit(db);
+    return toReport(
+      GlossaryIndexMigrationMode.Rollback,
+      classifyRecovery(GlossaryIndexMigrationMode.Rollback, finalState),
+      finalState,
+    );
+  } catch {
+    return recoverAfterMutationFailure(db, GlossaryIndexMigrationMode.Rollback);
+  }
+}
+
+export async function runGlossaryIndexMigration(input: {
+  db: Db;
+  mode: GlossaryIndexMigrationMode;
+}): Promise<GlossaryIndexMigrationReport> {
+  const state = await audit(input.db);
+  if (input.mode === GlossaryIndexMigrationMode.DryRun) {
+    return toReport(
+      input.mode,
+      canApply(state) ? GlossaryIndexMigrationOutcome.Completed : GlossaryIndexMigrationOutcome.RepairRequired,
+      state,
+    );
+  }
+  if (input.mode === GlossaryIndexMigrationMode.Verify) {
+    return toReport(
+      input.mode,
+      isApplied(state) ? GlossaryIndexMigrationOutcome.Completed : GlossaryIndexMigrationOutcome.RepairRequired,
+      state,
+    );
+  }
+  if (input.mode === GlossaryIndexMigrationMode.Apply) {
+    return applyMigration(input.db, state);
+  }
+  return rollbackMigration(input.db, state);
+}

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -7,6 +7,7 @@ import {
   productAnalyticsPreferenceRevisionSchema,
   productAnalyticsPreferenceSchema,
 } from "../types/product-analytics.js";
+import { projectKeySchema } from "./voice.js";
 
 export const userSchema = z.object({
   _id: z.instanceof(ObjectId),
@@ -64,6 +65,12 @@ export const glossaryEntrySchema = z.object({
 });
 
 export type GlossaryEntry = z.infer<typeof glossaryEntrySchema>;
+
+// COMPATIBILITY 2026-08-02 (v0.1.0): Supports auditing pre-PR2 unscoped glossary documents during project-scope cutover and rollback. After PR2 is verified in production, its rollback window closes, and no pre-PR2 binary can be deployed, remove this schema; the legacy document audit, index constants/classification, apply-drop, and rollback paths in glossary-index-migration.ts; the CLI rollback mode/runbook if no longer operationally needed; and their model/migration tests.
+export const legacyGlossaryEntryMigrationSchema = glossaryEntrySchema.strict();
+export const projectScopedGlossaryEntryMigrationSchema = glossaryEntrySchema
+  .extend({ projectKey: projectKeySchema })
+  .strict();
 
 export const dailyUsageSchema = z.object({
   _id: z.instanceof(ObjectId),

--- a/src/models/voice.ts
+++ b/src/models/voice.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const projectKeySchema = z.string().regex(/^prj_v1_[A-Za-z0-9_-]{43}$/);
+
+export type ProjectKey = z.infer<typeof projectKeySchema>;

--- a/src/models/voice.ts
+++ b/src/models/voice.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
-export const projectKeySchema = z.string().regex(/^prj_v1_[A-Za-z0-9_-]{43}$/);
+export const projectKeySchema = z
+  .string()
+  .regex(/^prj_v1_[A-Za-z0-9_-]{43}$/)
+  .brand<"ProjectKey">();
 
 export type ProjectKey = z.infer<typeof projectKeySchema>;

--- a/src/scripts/migrate-project-glossary-index.ts
+++ b/src/scripts/migrate-project-glossary-index.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import { pathToFileURL } from "node:url";
+import { loadGlossaryMigrationConfig } from "../config.js";
+import {
+  GlossaryIndexMigrationMode,
+  GlossaryIndexMigrationOutcome,
+  runGlossaryIndexMigration,
+} from "../db/glossary-index-migration.js";
+import { MongoDbConnector } from "../db/mongo-db-connector.js";
+import { safeErrorType } from "../lib/errors.js";
+import { MongoDbDatabase } from "../types/mongo.js";
+
+export type ProjectGlossaryIndexMigrationCliOptions = {
+  mode: GlossaryIndexMigrationMode;
+  help: boolean;
+};
+
+const modeByFlag = new Map<string, GlossaryIndexMigrationMode>([
+  ["--apply", GlossaryIndexMigrationMode.Apply],
+  ["--verify", GlossaryIndexMigrationMode.Verify],
+  ["--rollback", GlossaryIndexMigrationMode.Rollback],
+]);
+
+export function parseProjectGlossaryIndexMigrationArgs(argv: string[]): ProjectGlossaryIndexMigrationCliOptions {
+  let selectedMode: GlossaryIndexMigrationMode | null = null;
+  let help = false;
+
+  for (const argument of argv) {
+    if (argument === "--help" || argument === "-h") {
+      if (help || selectedMode) {
+        throw new Error("InvalidProjectGlossaryIndexMigrationArguments");
+      }
+      help = true;
+      continue;
+    }
+
+    const mode = modeByFlag.get(argument);
+    if (!mode || selectedMode || help) {
+      throw new Error("InvalidProjectGlossaryIndexMigrationArguments");
+    }
+    selectedMode = mode;
+  }
+
+  return { mode: selectedMode ?? GlossaryIndexMigrationMode.DryRun, help };
+}
+
+export function printProjectGlossaryIndexMigrationUsage(): void {
+  console.log("Usage: npm run migrate-project-glossary-index -- [--apply | --verify | --rollback]");
+  console.log();
+  console.log("No mode flag performs a read-only dry-run. Mutating modes require the documented stopped-auth window.");
+}
+
+export async function runProjectGlossaryIndexMigrationCli(input: {
+  argv: string[];
+  env?: NodeJS.ProcessEnv;
+}): Promise<number> {
+  let options: ProjectGlossaryIndexMigrationCliOptions;
+  try {
+    options = parseProjectGlossaryIndexMigrationArgs(input.argv);
+  } catch {
+    console.error("[ProjectGlossaryIndexMigration] Invalid arguments");
+    printProjectGlossaryIndexMigrationUsage();
+    return 1;
+  }
+
+  if (options.help) {
+    printProjectGlossaryIndexMigrationUsage();
+    return 0;
+  }
+
+  let connector: MongoDbConnector | null = null;
+  try {
+    const config = loadGlossaryMigrationConfig(input.env ?? process.env);
+    connector = new MongoDbConnector({
+      connectionString: config.mongodbUri,
+      clientOptions: { appName: "sesori-project-glossary-index-migration" },
+    });
+    const report = await runGlossaryIndexMigration({
+      db: connector.getDb(MongoDbDatabase.Auth),
+      mode: options.mode,
+    });
+    console.log("[ProjectGlossaryIndexMigration] Report", report);
+    return report.outcome === GlossaryIndexMigrationOutcome.Completed ? 0 : 1;
+  } catch (error) {
+    console.error("[ProjectGlossaryIndexMigration] Failed", {
+      mode: options.mode,
+      outcome: GlossaryIndexMigrationOutcome.RepairRequired,
+      errorType: safeErrorType({ error }),
+    });
+    return 1;
+  } finally {
+    await connector?.close();
+  }
+}
+
+const entrypoint = process.argv[1];
+if (entrypoint && import.meta.url === pathToFileURL(entrypoint).href) {
+  process.exitCode = await runProjectGlossaryIndexMigrationCli({ argv: process.argv.slice(2) });
+}

--- a/src/scripts/migrate-project-glossary-index.ts
+++ b/src/scripts/migrate-project-glossary-index.ts
@@ -4,6 +4,7 @@ import { loadGlossaryMigrationConfig } from "../config.js";
 import {
   GlossaryIndexMigrationMode,
   GlossaryIndexMigrationOutcome,
+  GlossaryIndexMigrationPersistenceError,
   runGlossaryIndexMigration,
 } from "../db/glossary-index-migration.js";
 import { MongoDbConnector } from "../db/mongo-db-connector.js";
@@ -86,6 +87,7 @@ export async function runProjectGlossaryIndexMigrationCli(input: {
       mode: options.mode,
       outcome: GlossaryIndexMigrationOutcome.RepairRequired,
       errorType: safeErrorType({ error }),
+      ...(error instanceof GlossaryIndexMigrationPersistenceError ? { diagnostic: error.diagnostic } : {}),
     });
     return 1;
   } finally {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { loadGlossaryMigrationConfig } from "../src/config.js";
+
+describe("loadGlossaryMigrationConfig", () => {
+  it("returns only the validated MongoDB URI", () => {
+    assert.deepEqual(
+      loadGlossaryMigrationConfig({
+        MONGODB_URI: "mongodb://localhost:27017/oauth",
+        JWT_PRIVATE_KEY: "must-not-cross-the-cli-boundary",
+      }),
+      { mongodbUri: "mongodb://localhost:27017/oauth" },
+    );
+  });
+
+  it("rejects missing and empty MongoDB URIs without loading web config", () => {
+    assert.throws(() => loadGlossaryMigrationConfig({}), /GlossaryMigrationConfigError/);
+    assert.throws(() => loadGlossaryMigrationConfig({ MONGODB_URI: "" }), /GlossaryMigrationConfigError/);
+    assert.throws(
+      () => loadGlossaryMigrationConfig({ MONGODB_URI: "not-a-mongodb-uri" }),
+      /GlossaryMigrationConfigError/,
+    );
+  });
+});

--- a/tests/models/voice.test.ts
+++ b/tests/models/voice.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { ObjectId } from "mongodb";
+import {
+  legacyGlossaryEntryMigrationSchema,
+  projectScopedGlossaryEntryMigrationSchema,
+} from "../../src/models/documents.js";
+import { projectKeySchema } from "../../src/models/voice.js";
+
+const validProjectKey = `prj_v1_${"A".repeat(43)}`;
+
+describe("projectKeySchema", () => {
+  it("accepts exactly the versioned base64url SHA-256 shape", () => {
+    assert.equal(projectKeySchema.safeParse(validProjectKey).success, true);
+    assert.equal(projectKeySchema.safeParse(`prj_v1_${"a0_-".repeat(10)}abc`).success, true);
+  });
+
+  it("rejects wrong prefixes, lengths, padding, non-base64url characters, and whitespace", () => {
+    const invalid = [
+      `prj_v2_${"A".repeat(43)}`,
+      `prj_v1_${"A".repeat(42)}`,
+      `prj_v1_${"A".repeat(44)}`,
+      `prj_v1_${"A".repeat(42)}=`,
+      `prj_v1_${"A".repeat(42)}+`,
+      `prj_v1_${"A".repeat(42)}/`,
+      `${validProjectKey}\n`,
+      ` ${validProjectKey}`,
+    ];
+
+    for (const value of invalid) {
+      assert.equal(projectKeySchema.safeParse(value).success, false, value);
+    }
+  });
+});
+
+describe("glossary migration document schemas", () => {
+  const legacyDocument = {
+    _id: new ObjectId(),
+    userId: new ObjectId(),
+    word: "Sesori",
+    createdAt: new Date("2026-08-02T00:00:00.000Z"),
+  };
+
+  it("keeps strict legacy and project-scoped shapes separate", () => {
+    assert.equal(legacyGlossaryEntryMigrationSchema.safeParse(legacyDocument).success, true);
+    assert.equal(
+      projectScopedGlossaryEntryMigrationSchema.safeParse({ ...legacyDocument, projectKey: validProjectKey }).success,
+      true,
+    );
+    assert.equal(projectScopedGlossaryEntryMigrationSchema.safeParse(legacyDocument).success, false);
+    assert.equal(
+      legacyGlossaryEntryMigrationSchema.safeParse({ ...legacyDocument, projectKey: validProjectKey }).success,
+      false,
+    );
+  });
+
+  it("rejects malformed fields and unknown persisted fields", () => {
+    assert.equal(legacyGlossaryEntryMigrationSchema.safeParse({ ...legacyDocument, word: 42 }).success, false);
+    assert.equal(
+      projectScopedGlossaryEntryMigrationSchema.safeParse({
+        ...legacyDocument,
+        projectKey: validProjectKey,
+        unexpected: true,
+      }).success,
+      false,
+    );
+  });
+});

--- a/tests/scripts/project-glossary-index-migration.test.ts
+++ b/tests/scripts/project-glossary-index-migration.test.ts
@@ -1,6 +1,15 @@
 import assert from "node:assert/strict";
 import { after, afterEach, before, beforeEach, describe, it, mock } from "node:test";
-import { AggregationCursor, Collection, MongoClient, ObjectId, type Db, type Document } from "mongodb";
+import {
+  AggregationCursor,
+  Collection,
+  MongoClient,
+  ObjectId,
+  type AggregateOptions,
+  type Db,
+  type Document,
+  type FindOptions,
+} from "mongodb";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import {
   GlossaryCollectionState,
@@ -22,6 +31,7 @@ import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
 
 const validProjectKey = `prj_v1_${"A".repeat(43)}`;
 const canaryWord = "PRIVATE_GLOSSARY_CANARY";
+const metadataCanary = "PRIVATE_METADATA_CANARY";
 
 describe("project glossary index migration", () => {
   let memoryServer: MongoMemoryServer | null = null;
@@ -175,6 +185,40 @@ describe("project glossary index migration", () => {
     assert.ok((await indexKeys()).some((key) => key.projectKey === 1));
   });
 
+  it("accepts an explicit simple collection collation", async () => {
+    await db.createCollection(AuthDbCollection.GlossaryEntries, { collation: { locale: "simple" } });
+    await createLegacyIndex();
+
+    const report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.DryRun });
+
+    assert.equal(report.collectionState, GlossaryCollectionState.Simple);
+    assert.equal(report.legacyIndexState, GlossaryIndexState.Exact);
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.Completed);
+  });
+
+  it("bounds complete audit queries with the reviewed MongoDB options", async () => {
+    await createLegacyIndex();
+    const originalFind = Collection.prototype.find;
+    const originalAggregate = Collection.prototype.aggregate;
+    let findOptions: FindOptions | undefined;
+    let aggregateOptions: AggregateOptions | undefined;
+    mock.method(Collection.prototype, "find", function (this: Collection, filter, options) {
+      findOptions = options;
+      return originalFind.call(this, filter, options);
+    });
+    mock.method(Collection.prototype, "aggregate", function (this: Collection, pipeline, options) {
+      aggregateOptions = options;
+      return originalAggregate.call(this, pipeline, options);
+    });
+
+    await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.DryRun });
+
+    assert.equal(findOptions?.maxTimeMS, 300_000);
+    assert.equal(findOptions?.batchSize, 1_000);
+    assert.equal(aggregateOptions?.maxTimeMS, 300_000);
+    assert.equal(aggregateOptions?.allowDiskUse, true);
+  });
+
   it("returns repair_required for a conflicting target index name", async () => {
     await createLegacyIndex();
     await collection().createIndex({ createdAt: 1 }, { name: projectScopedGlossaryIndexName });
@@ -203,7 +247,7 @@ describe("project glossary index migration", () => {
     });
     await assert.rejects(
       runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.DryRun }),
-      /GlossaryIndexMigrationPersistenceError/,
+      /GlossaryIndexMigrationPersistenceError.*options.*unrecognized_keys/,
     );
 
     await db.dropDatabase();
@@ -356,7 +400,8 @@ describe("project glossary index migration", () => {
   it("keeps CLI output content-redacted and closes its connector", async () => {
     await createLegacyIndex();
     const document = glossaryDocument();
-    await collection().insertOne(document);
+    const scopedDocument = glossaryDocument({ projectKey: validProjectKey });
+    await collection().insertMany([document, scopedDocument]);
     const calls: unknown[][] = [];
     let closeCalls = 0;
     const originalClose = MongoDbConnector.prototype.close;
@@ -374,7 +419,32 @@ describe("project glossary index migration", () => {
     assert.equal(output.includes(canaryWord), false);
     assert.equal(output.includes(validProjectKey), false);
     assert.equal(output.includes(document._id.toHexString()), false);
+    assert.equal(output.includes(scopedDocument._id.toHexString()), false);
     assert.equal(closeCalls, 1);
+  });
+
+  it("reports bounded persistence diagnostics without logging dynamic metadata", async () => {
+    await createLegacyIndex();
+    mock.method(AggregationCursor.prototype, "toArray", async () =>
+      Array.from({ length: 20 }, (_, index) => ({
+        duplicateTargetKeyCount: -1,
+        [`${metadataCanary}_${index}`]: true,
+      })),
+    );
+    const calls: unknown[][] = [];
+    mock.method(console, "log", (...args: unknown[]) => calls.push(args));
+    mock.method(console, "error", (...args: unknown[]) => calls.push(args));
+
+    const exitCode = await runProjectGlossaryIndexMigrationCli({ argv: [], env: { MONGODB_URI: mongodbUri } });
+
+    assert.equal(exitCode, 1);
+    const output = JSON.stringify(calls);
+    assert.equal(output.includes("GlossaryIndexMigrationPersistenceError"), true);
+    assert.equal(output.includes("too_small"), true);
+    assert.equal(output.includes("unrecognized_keys"), true);
+    assert.equal(output.includes("truncated"), true);
+    assert.equal(output.includes(metadataCanary), false);
+    assert.ok(output.length < 2_000);
   });
 
   it("handles help and missing configuration without connecting", async () => {

--- a/tests/scripts/project-glossary-index-migration.test.ts
+++ b/tests/scripts/project-glossary-index-migration.test.ts
@@ -1,0 +1,386 @@
+import assert from "node:assert/strict";
+import { after, afterEach, before, beforeEach, describe, it, mock } from "node:test";
+import { AggregationCursor, Collection, MongoClient, ObjectId, type Db, type Document } from "mongodb";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import {
+  GlossaryCollectionState,
+  GlossaryIndexMigrationMode,
+  GlossaryIndexMigrationOutcome,
+  GlossaryIndexState,
+  legacyGlossaryIndexName,
+  legacyGlossaryIndexSpec,
+  projectScopedGlossaryIndexName,
+  projectScopedGlossaryIndexSpec,
+  runGlossaryIndexMigration,
+} from "../../src/db/glossary-index-migration.js";
+import { MongoDbConnector } from "../../src/db/mongo-db-connector.js";
+import {
+  parseProjectGlossaryIndexMigrationArgs,
+  runProjectGlossaryIndexMigrationCli,
+} from "../../src/scripts/migrate-project-glossary-index.js";
+import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
+
+const validProjectKey = `prj_v1_${"A".repeat(43)}`;
+const canaryWord = "PRIVATE_GLOSSARY_CANARY";
+
+describe("project glossary index migration", () => {
+  let memoryServer: MongoMemoryServer | null = null;
+  let client: MongoClient;
+  let db: Db;
+  let mongodbUri: string;
+
+  before(async () => {
+    if (process.env.MONGODB_URI_TEST) {
+      mongodbUri = process.env.MONGODB_URI_TEST;
+    } else {
+      memoryServer = await MongoMemoryServer.create({ binary: { version: "7.0.24" } });
+      mongodbUri = memoryServer.getUri();
+    }
+    client = new MongoClient(mongodbUri);
+    await client.connect();
+    db = client.db(MongoDbDatabase.Auth);
+  });
+
+  after(async () => {
+    await client.close();
+    await memoryServer?.stop();
+  });
+
+  beforeEach(async () => {
+    mock.restoreAll();
+    await db.dropDatabase();
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  function collection(): Collection<Document> {
+    return db.collection(AuthDbCollection.GlossaryEntries);
+  }
+
+  async function createLegacyIndex(): Promise<void> {
+    await collection().createIndex(legacyGlossaryIndexSpec, { unique: true });
+  }
+
+  async function createTargetIndex(options: { unique?: boolean; sparse?: boolean } = {}): Promise<void> {
+    const indexOptions: { unique: boolean; sparse?: boolean } = { unique: options.unique ?? true };
+    if (options.sparse !== undefined) {
+      indexOptions.sparse = options.sparse;
+    }
+    await collection().createIndex(projectScopedGlossaryIndexSpec, indexOptions);
+  }
+
+  function glossaryDocument(input: { projectKey?: string; word?: string; userId?: ObjectId } = {}): Document {
+    const document: Document = {
+      _id: new ObjectId(),
+      userId: input.userId ?? new ObjectId(),
+      word: input.word ?? canaryWord,
+      createdAt: new Date("2026-08-02T00:00:00.000Z"),
+    };
+    if (input.projectKey !== undefined) {
+      document.projectKey = input.projectKey;
+    }
+    return document;
+  }
+
+  async function indexKeys(): Promise<Record<string, unknown>[]> {
+    return (await collection().listIndexes().toArray()).map((index) => index.key as Record<string, unknown>);
+  }
+
+  it("parses one explicit mode and rejects duplicate, mixed, or unknown flags", () => {
+    assert.deepEqual(parseProjectGlossaryIndexMigrationArgs([]), {
+      mode: GlossaryIndexMigrationMode.DryRun,
+      help: false,
+    });
+    assert.deepEqual(parseProjectGlossaryIndexMigrationArgs(["--apply"]), {
+      mode: GlossaryIndexMigrationMode.Apply,
+      help: false,
+    });
+    assert.deepEqual(parseProjectGlossaryIndexMigrationArgs(["--verify"]), {
+      mode: GlossaryIndexMigrationMode.Verify,
+      help: false,
+    });
+    assert.deepEqual(parseProjectGlossaryIndexMigrationArgs(["--rollback"]), {
+      mode: GlossaryIndexMigrationMode.Rollback,
+      help: false,
+    });
+    assert.deepEqual(parseProjectGlossaryIndexMigrationArgs(["--help"]), {
+      mode: GlossaryIndexMigrationMode.DryRun,
+      help: true,
+    });
+    assert.throws(() => parseProjectGlossaryIndexMigrationArgs(["--apply", "--verify"]));
+    assert.throws(() => parseProjectGlossaryIndexMigrationArgs(["--apply", "--apply"]));
+    assert.throws(() => parseProjectGlossaryIndexMigrationArgs(["--unknown"]));
+  });
+
+  it("dry-runs empty legacy state without mutating indexes", async () => {
+    await createLegacyIndex();
+
+    const report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.DryRun });
+
+    assert.deepEqual(report, {
+      mode: GlossaryIndexMigrationMode.DryRun,
+      outcome: GlossaryIndexMigrationOutcome.Completed,
+      collectionState: GlossaryCollectionState.Simple,
+      documentCount: 0,
+      missingProjectKeyCount: 0,
+      invalidProjectKeyCount: 0,
+      invalidDocumentCount: 0,
+      duplicateTargetKeyCount: 0,
+      legacyIndexState: GlossaryIndexState.Exact,
+      targetIndexState: GlossaryIndexState.Absent,
+    });
+    assert.deepEqual(await indexKeys(), [{ _id: 1 }, legacyGlossaryIndexSpec]);
+  });
+
+  it("fails closed on legacy, invalid, malformed, and duplicate target documents", async () => {
+    await createLegacyIndex();
+    await collection().insertOne(glossaryDocument());
+    let report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.DryRun });
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.RepairRequired);
+    assert.equal(report.missingProjectKeyCount, 1);
+
+    await db.dropDatabase();
+    await createLegacyIndex();
+    await collection().insertOne(glossaryDocument({ projectKey: "invalid" }));
+    report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.DryRun });
+    assert.equal(report.invalidProjectKeyCount, 1);
+    assert.equal(report.invalidDocumentCount, 1);
+
+    await db.dropDatabase();
+    const duplicateUserId = new ObjectId();
+    await collection().insertMany([
+      glossaryDocument({ projectKey: validProjectKey, word: canaryWord, userId: duplicateUserId }),
+      glossaryDocument({ projectKey: validProjectKey, word: canaryWord, userId: duplicateUserId }),
+    ]);
+    report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.DryRun });
+    assert.equal(report.duplicateTargetKeyCount, 1);
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.RepairRequired);
+  });
+
+  it("fails before mutation for non-simple collection collation and mismatched indexes", async () => {
+    await db.createCollection(AuthDbCollection.GlossaryEntries, { collation: { locale: "en", strength: 2 } });
+    let report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Apply });
+    assert.equal(report.collectionState, GlossaryCollectionState.NonSimpleCollation);
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.RepairRequired);
+    assert.deepEqual(await indexKeys(), [{ _id: 1 }]);
+
+    await db.dropDatabase();
+    await createLegacyIndex();
+    await createTargetIndex({ unique: false });
+    report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Apply });
+    assert.equal(report.targetIndexState, GlossaryIndexState.Mismatch);
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.RepairRequired);
+    assert.ok((await indexKeys()).some((key) => key.projectKey === 1));
+  });
+
+  it("returns repair_required for a conflicting target index name", async () => {
+    await createLegacyIndex();
+    await collection().createIndex({ createdAt: 1 }, { name: projectScopedGlossaryIndexName });
+
+    const report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Apply });
+
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.RepairRequired);
+    assert.equal(report.targetIndexState, GlossaryIndexState.Mismatch);
+    assert.equal(report.legacyIndexState, GlossaryIndexState.Exact);
+  });
+
+  it("returns repair_required for a conflicting legacy index name", async () => {
+    await createTargetIndex();
+    await collection().createIndex({ createdAt: 1 }, { name: legacyGlossaryIndexName });
+
+    const report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Rollback });
+
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.RepairRequired);
+    assert.equal(report.legacyIndexState, GlossaryIndexState.Mismatch);
+    assert.equal(report.targetIndexState, GlossaryIndexState.Exact);
+  });
+
+  it("rejects unsupported collection metadata and malformed aggregation counts", async () => {
+    await db.createCollection(AuthDbCollection.GlossaryEntries, {
+      validator: { word: { $type: "string" } },
+    });
+    await assert.rejects(
+      runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.DryRun }),
+      /GlossaryIndexMigrationPersistenceError/,
+    );
+
+    await db.dropDatabase();
+    await createLegacyIndex();
+    mock.method(AggregationCursor.prototype, "toArray", async () => [{ duplicateTargetKeyCount: -1 }]);
+    await assert.rejects(
+      runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.DryRun }),
+      /GlossaryIndexMigrationPersistenceError/,
+    );
+  });
+
+  it("applies scoped data in create-verify-drop order and is idempotent", async () => {
+    await createLegacyIndex();
+    const document = glossaryDocument({ projectKey: validProjectKey });
+    await collection().insertOne(document);
+
+    let report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Apply });
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.Completed);
+    assert.equal(report.legacyIndexState, GlossaryIndexState.Absent);
+    assert.equal(report.targetIndexState, GlossaryIndexState.Exact);
+    assert.deepEqual(await collection().findOne({ _id: document._id }), document);
+
+    report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Apply });
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.Completed);
+    assert.deepEqual(await indexKeys(), [{ _id: 1 }, projectScopedGlossaryIndexSpec]);
+  });
+
+  it("resumes the exact-both interruption state and verifies target-only state", async () => {
+    await createLegacyIndex();
+    await createTargetIndex();
+
+    const applied = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Apply });
+    assert.equal(applied.outcome, GlossaryIndexMigrationOutcome.Completed);
+
+    const verified = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Verify });
+    assert.equal(verified.outcome, GlossaryIndexMigrationOutcome.Completed);
+    assert.equal(verified.legacyIndexState, GlossaryIndexState.Absent);
+    assert.equal(verified.targetIndexState, GlossaryIndexState.Exact);
+  });
+
+  it("rolls back only an empty collection, old-first, and idempotently", async () => {
+    await createTargetIndex();
+
+    let report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Rollback });
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.Completed);
+    assert.deepEqual(await indexKeys(), [{ _id: 1 }, legacyGlossaryIndexSpec]);
+
+    report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Rollback });
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.Completed);
+
+    await collection().insertOne(glossaryDocument());
+    report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Rollback });
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.RepairRequired);
+    assert.equal(report.documentCount, 1);
+  });
+
+  it("returns repair_required when a legacy row appears during the old-index drop", async () => {
+    await createLegacyIndex();
+    const originalDropIndex = Collection.prototype.dropIndex;
+    mock.method(Collection.prototype, "dropIndex", async function (this: Collection, indexName, options) {
+      await this.insertOne(glossaryDocument());
+      return originalDropIndex.call(this, indexName, options);
+    });
+
+    const report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Apply });
+
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.RepairRequired);
+    assert.equal(report.missingProjectKeyCount, 1);
+    assert.equal(report.legacyIndexState, GlossaryIndexState.Absent);
+    assert.equal(report.targetIndexState, GlossaryIndexState.Exact);
+  });
+
+  it("returns repair_required when conflicting DDL replaces the target after the old-index drop", async () => {
+    await createLegacyIndex();
+    const originalDropIndex = Collection.prototype.dropIndex;
+    mock.method(Collection.prototype, "dropIndex", async function (this: Collection, indexName, options) {
+      const result = await originalDropIndex.call(this, indexName, options);
+      const indexes = await this.listIndexes().toArray();
+      const target = indexes.find((index) => (index.key as Record<string, unknown>).projectKey === 1);
+      assert.ok(target?.name);
+      await originalDropIndex.call(this, target.name);
+      await this.createIndex(projectScopedGlossaryIndexSpec, { unique: false });
+      return result;
+    });
+
+    const report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Apply });
+
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.RepairRequired);
+    assert.equal(report.targetIndexState, GlossaryIndexState.Mismatch);
+  });
+
+  it("returns repair_required when a document appears during the target-index rollback drop", async () => {
+    await createTargetIndex();
+    const originalDropIndex = Collection.prototype.dropIndex;
+    mock.method(Collection.prototype, "dropIndex", async function (this: Collection, indexName, options) {
+      await this.insertOne(glossaryDocument({ projectKey: validProjectKey }));
+      return originalDropIndex.call(this, indexName, options);
+    });
+
+    const report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Rollback });
+
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.RepairRequired);
+    assert.equal(report.documentCount, 1);
+    assert.equal(report.legacyIndexState, GlossaryIndexState.Exact);
+    assert.equal(report.targetIndexState, GlossaryIndexState.Absent);
+  });
+
+  it("returns repair_required when conflicting DDL replaces the legacy index after rollback drop", async () => {
+    await createTargetIndex();
+    const originalDropIndex = Collection.prototype.dropIndex;
+    mock.method(Collection.prototype, "dropIndex", async function (this: Collection, indexName, options) {
+      const result = await originalDropIndex.call(this, indexName, options);
+      const indexes = await this.listIndexes().toArray();
+      const legacy = indexes.find((index) => {
+        const key = index.key as Record<string, unknown>;
+        return key.userId === 1 && key.word === 1 && key.projectKey === undefined;
+      });
+      assert.ok(legacy?.name);
+      await originalDropIndex.call(this, legacy.name);
+      await this.createIndex(legacyGlossaryIndexSpec, { unique: false });
+      return result;
+    });
+
+    const report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Rollback });
+
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.RepairRequired);
+    assert.equal(report.legacyIndexState, GlossaryIndexState.Mismatch);
+  });
+
+  it("uses safe_to_rerun for a valid missing-index state and converges on rerun", async () => {
+    await createLegacyIndex();
+    const originalCreateIndex = Collection.prototype.createIndex;
+    let calls = 0;
+    mock.method(Collection.prototype, "createIndex", async function (this: Collection, spec, options) {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error("simulated create interruption");
+      }
+      return originalCreateIndex.call(this, spec, options);
+    });
+
+    let report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Apply });
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.SafeToRerun);
+
+    mock.restoreAll();
+    report = await runGlossaryIndexMigration({ db, mode: GlossaryIndexMigrationMode.Apply });
+    assert.equal(report.outcome, GlossaryIndexMigrationOutcome.Completed);
+  });
+
+  it("keeps CLI output content-redacted and closes its connector", async () => {
+    await createLegacyIndex();
+    const document = glossaryDocument();
+    await collection().insertOne(document);
+    const calls: unknown[][] = [];
+    let closeCalls = 0;
+    const originalClose = MongoDbConnector.prototype.close;
+    mock.method(console, "log", (...args: unknown[]) => calls.push(args));
+    mock.method(console, "error", (...args: unknown[]) => calls.push(args));
+    mock.method(MongoDbConnector.prototype, "close", async function (this: MongoDbConnector) {
+      closeCalls += 1;
+      return originalClose.call(this);
+    });
+
+    const exitCode = await runProjectGlossaryIndexMigrationCli({ argv: [], env: { MONGODB_URI: mongodbUri } });
+
+    assert.equal(exitCode, 1);
+    const output = JSON.stringify(calls);
+    assert.equal(output.includes(canaryWord), false);
+    assert.equal(output.includes(validProjectKey), false);
+    assert.equal(output.includes(document._id.toHexString()), false);
+    assert.equal(closeCalls, 1);
+  });
+
+  it("handles help and missing configuration without connecting", async () => {
+    mock.method(console, "log", () => {});
+    mock.method(console, "error", () => {});
+    assert.equal(await runProjectGlossaryIndexMigrationCli({ argv: ["--help"], env: {} }), 0);
+    assert.equal(await runProjectGlossaryIndexMigrationCli({ argv: [], env: {} }), 1);
+  });
+});


### PR DESCRIPTION
## Summary

- add the strict opaque `projectKey` primitive and migration-only glossary document schemas
- add a read-only-by-default MongoDB glossary index migration with apply, verify, rollback, and closed recovery outcomes
- document the client derivation contract and PR2 maintenance-window cutover runbook

## Safety

- leaves live glossary routes, repositories, startup index wiring, and transcription behavior unchanged
- validates documents, collection/index metadata, counts, collation, and index-name conflicts before mutation
- creates and verifies the replacement index before dropping the legacy index, with complete post-drop audits
- never assigns or deletes glossary terms; production `--apply` remains forbidden until PR2 is ready

## Verification

- external MongoDB 7 focused suite: 23/23 passed
- external MongoDB 7 full suite: 503 passed, 1 existing skip, 0 failed
- `npx tsc --noEmit`
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run circular-dependencies`
- implementation architecture review: approved

## Production Dry-Run

Authorized read-only audit completed with no mutation:

- collection collation: simple
- documents and invalid/duplicate counts: 0
- legacy index: exact
- target index: absent
- outcome: completed

Plan checkpoint: PR1 ready, base `8fc4fcf`, 1,256 authored lines, next slice PR2.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read‑only‑by‑default MongoDB migration to move the glossary index from `{ userId, word }` to `{ userId, projectKey, word }`, plus a strict opaque `projectKey`. Hardens audits, validation, and failure handling; live behavior stays unchanged and production `--apply` waits for PR2.

- **New Features**
  - CLI `npm run migrate-project-glossary-index` with modes: dry-run (default), `--apply`, `--verify`, `--rollback`.
  - Validates collection, index, and aggregation results via Zod; requires simple/binary collation; enforces nonnegative safe‑integer counters; bounds audits with batch size and `maxTimeMS`.
  - Apply order: create and verify target unique index, full re‑audit, drop legacy, full re‑audit; rollback is the inverse and allowed only when the collection is empty.
  - Closed outcomes: `completed`, `safe_to_rerun` (only for valid absent/exact index interruption states), `repair_required`; outputs are redacted and include bounded persistence diagnostics; non‑`completed` exits non‑zero.
  - Adds strict `projectKey` schema and migration‑only document schemas; config loader limited to `MONGODB_URI`.

- **Migration**
  - Do not run `--apply` until the reviewed PR2 artifact and a maintenance window. Stop auth writers; allow exactly one command; no manual glossary index DDL.
  - Expected prod dry‑run: 0 documents; legacy index exact; target index absent.
  - After apply, run `--verify`. On `safe_to_rerun`, rerun the same mode. On `repair_required`, keep auth stopped and perform a separately reviewed repair.

<sup>Written for commit 770fc175e452dca10a680ef5e91395fde99957c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

