### PR TITLE
feat(notifications): filter push notifications by per-device settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,9 @@ Every push producer funnels through `NotificationService.sendToUser`, so that is
 
 `deviceTokens.deviceId` is the join key to `settingsConfiguration`. It is optional while clients roll it out: a token without one **fails open** and keeps delivering, because it cannot be matched to a stored preference and silently muting it would be worse than an unwanted notification. Do not invert that default until clients reliably send `deviceId`. A token that changes owner has its `deviceId` cleared so it is never filtered against the previous account's settings.
 
-Filtering applies to activation reminders too — they send `system_update`, so a user who disables that toggle stops receiving them. When every device opts out, `sendToUser` returns `devicesNotified: 0` without calling FCM, and `ActivationReminderService` treats that as a genuine zero-device result and marks the reminder complete rather than retrying forever.
+Activation reminders are the one deliberate exemption: `ActivationReminderService` calls `sendToUserIgnoringDeviceSettings`, so a user who disables `systemUpdate` still receives them. They are lifecycle nudges about finishing setup rather than the product "System Updates" the toggle names, and they only ride `system_update` on the wire because the client enum has no activation member — a dedicated category needs a client change first. Do not "fix" that call back to `sendToUser`; the reminder mock in the tests implements only the unfiltered method so such a regression fails.
+
+When every device opts out of a filtered category, `sendToUser` returns `devicesNotified: 0` without calling FCM, and `ActivationReminderService` treats a genuine zero-device result as complete rather than retrying forever.
 
 ## ANTI-PATTERNS
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,8 @@ Every push producer funnels through `NotificationService.sendToUser`, so that is
 
 `deviceTokens.deviceId` is the join key to `settingsConfiguration`. It is optional while clients roll it out: a token without one **fails open** and keeps delivering, because it cannot be matched to a stored preference and silently muting it would be worse than an unwanted notification. Do not invert that default until clients reliably send `deviceId`. A token that changes owner has its `deviceId` cleared so it is never filtered against the previous account's settings.
 
+`register-token` predates this feature and every shipped client already calls it with only `{ token, platform }`, so requiring `deviceId` outright would 400 every existing install and remove it from push entirely — a registration failure is not a degraded filter, it is no notifications at all. `AUTH_REQUIRE_DEVICE_ID_IN_TOKEN_REGISTRATION` gates that cutover: ship with it unset, ship the client that sends `deviceId`, then flip it once the install base has rolled over. Same shape as the retired `AUTH_REQUIRE_BRIDGE_ID_IN_STATUS` gate; delete it the same way once every client sends the field.
+
 Filtering applies to activation reminders too — they send `system_update`, so a user who disables that toggle stops receiving them. When every device opts out, `sendToUser` returns `devicesNotified: 0` without calling FCM, and `ActivationReminderService` treats that as a genuine zero-device result and marks the reminder complete rather than retrying forever.
 
 ## ANTI-PATTERNS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,9 +96,7 @@ Every push producer funnels through `NotificationService.sendToUser`, so that is
 
 `deviceTokens.deviceId` is the join key to `settingsConfiguration`. It is optional while clients roll it out: a token without one **fails open** and keeps delivering, because it cannot be matched to a stored preference and silently muting it would be worse than an unwanted notification. Do not invert that default until clients reliably send `deviceId`. A token that changes owner has its `deviceId` cleared so it is never filtered against the previous account's settings.
 
-Activation reminders are the one deliberate exemption: `ActivationReminderService` calls `sendToUserIgnoringDeviceSettings`, so a user who disables `systemUpdate` still receives them. They are lifecycle nudges about finishing setup rather than the product "System Updates" the toggle names, and they only ride `system_update` on the wire because the client enum has no activation member — a dedicated category needs a client change first. Do not "fix" that call back to `sendToUser`; the reminder mock in the tests implements only the unfiltered method so such a regression fails.
-
-When every device opts out of a filtered category, `sendToUser` returns `devicesNotified: 0` without calling FCM, and `ActivationReminderService` treats a genuine zero-device result as complete rather than retrying forever.
+Filtering applies to activation reminders too — they send `system_update`, so a user who disables that toggle stops receiving them. When every device opts out, `sendToUser` returns `devicesNotified: 0` without calling FCM, and `ActivationReminderService` treats that as a genuine zero-device result and marks the reminder complete rather than retrying forever.
 
 ## ANTI-PATTERNS
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ src/
 | Product analytics preference/export/deletion | `src/types/product-analytics.ts`, `src/models/{documents,api,product-analytics-export}.ts`, `src/clients/bigquery-product-analytics-*.ts`, `src/api/product-analytics-*.ts`, `src/repositories/{user-repo,product-analytics-*}.ts`, `src/services/product-analytics-*.ts`, `src/routes/product-analytics.ts`, `src/scripts/{backfill-product-analytics-preference,export-product-analytics,suppress-product-analytics-export}.ts` | Required revisioned preference, isolated auth-private export, and separately permissioned privacy-target handoff; see README rollout and IAM boundaries |
 | Activation reminders       | `.plans/activation-reminders/` + `src/services/activation-reminder-service.ts` + `src/repositories/activation-state-repo.ts`            | Read `PLAN.md` and `CONSIDERATIONS.md` before continuing the staged implementation          |
 | Per-device settings        | `src/routes/settings/settings.ts` + `src/services/settings-service.ts` + `src/repositories/settings-configuration-repo.ts` + `src/models/settings.ts` | Settings keyed by `{userId, deviceId}`; toggle registry + server-resolved defaults live in `models/settings.ts` |
+| Push notification filtering | `src/models/notification.ts` + `src/services/notification-service.ts` | `NotificationCategory` is the wire contract; `NOTIFICATION_CATEGORY_SETTING_KEYS` maps each category to the toggle that silences it |
 | Wire dependencies          | `src/index.ts`                                                                                                                          | Composition root — all instantiation happens here                                           |
 
 ## CONVENTIONS
@@ -88,6 +89,14 @@ The activation-reminder feature is intentionally split into independently deploy
 Desktop bridge instances register via `POST /auth/bridges` (idempotent: clients resend their `bridgeId`; an owned non-revoked id updates in place, anything else mints a new `br_` id). `GET /auth/me` returns `bridges[]` (id, name, platform, addedAt, lastSeenAt — no live status; clients get live connectivity from the relay). The relay reports per-bridge connect/disconnect to `POST /internal/bridge-status`, which requires `bridgeId`; missing or malformed IDs get a 400. Unknown/revoked bridgeIds get a 404, which the relay turns into a WS close 4006 so the bridge re-registers. Bridges authenticate to the relay with the **user access token** — there is no bridge-scoped token. Bridge-scoped JWTs were prototyped and dropped (`8b600dd`): they added a second credential lifecycle (24h TTL, no re-issue path) and a synchronous relay→auth call per connect without buying real revocation, since the bridge host holds the user refresh token regardless. Re-evaluate only if bridge auth must outlive user sessions.
 
 Push notifications debounce through `BridgeStateTracker` (120s), keyed per bridge by `(userId, bridgeId)`.
+
+## NOTIFICATION CATEGORY FILTERING
+
+Every push producer funnels through `NotificationService.sendToUser`, so that is the only place category filtering belongs — adding a second filter at a route or producer would double-apply it. `NotificationCategory` values are the wire contract shared with the client's own enum; changing a value breaks the bridge and the apps. `NOTIFICATION_CATEGORY_SETTING_KEYS` is typed `Record<NotificationCategory, NotificationSettingKey>` so a new category cannot compile until it is mapped to a toggle.
+
+`deviceTokens.deviceId` is the join key to `settingsConfiguration`. It is optional while clients roll it out: a token without one **fails open** and keeps delivering, because it cannot be matched to a stored preference and silently muting it would be worse than an unwanted notification. Do not invert that default until clients reliably send `deviceId`. A token that changes owner has its `deviceId` cleared so it is never filtered against the previous account's settings.
+
+Filtering applies to activation reminders too — they send `system_update`, so a user who disables that toggle stops receiving them. When every device opts out, `sendToUser` returns `devicesNotified: 0` without calling FCM, and `ActivationReminderService` treats that as a genuine zero-device result and marks the reminder complete rather than retrying forever.
 
 ## ANTI-PATTERNS
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ Push notifications are forwarded to Firebase Cloud Messaging. Every notification
 | `DELETE` | `/notifications/tokens/:token`   | Bearer | Unregister an FCM token                                                                          |
 | `POST`   | `/notifications/send`            | Bearer | Forward a notification to the user's opted-in devices. Body `{ category, title, body, collapseKey, data? }` |
 
-Filtering is applied to every producer, since they all funnel through `NotificationService.sendToUser` — including activation reminders, which a user can silence via the `systemUpdate` toggle.
+Filtering applies to every producer that goes through `NotificationService.sendToUser`, which covers bridge-sent notifications and bridge connect/disconnect.
+
+**Activation reminders are exempt.** They are lifecycle nudges about finishing setup rather than the product "System Updates" the toggle describes, so they are sent through `sendToUserIgnoringDeviceSettings` and reach the user even when that toggle is off. They currently ride the `system_update` category on the wire because the client enum has no dedicated activation member; a separate category would need a client change first.
 
 **`deviceId` rollout.** `deviceId` on `register-token` is the join key between a push token and its settings document, and it is optional while clients roll it out. A token registered without one cannot be matched to a stored preference, so it **keeps delivering unfiltered** rather than going silent. Per-device filtering only takes full effect once clients send `deviceId`; until then those devices behave exactly as before. A token that changes owner has its `deviceId` cleared, so a recycled token is never filtered against the previous account's settings.
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,29 @@ Both endpoints return the complete resolved shape:
 
 `updatedAt` is `null` until the device stores its first override, then an ISO 8601 timestamp. Missing or invalid bearer authentication returns 401. A malformed/non-v4 `deviceId`, an empty PATCH, unknown groups or toggles, and non-boolean toggle values return 400.
 
+### Notifications
+
+Push notifications are forwarded to Firebase Cloud Messaging. Every notification carries a `category`, and the server **drops it per device** when that device has switched the matching toggle off in `/auth/settings/:deviceId`.
+
+| Wire category      | Settings toggle    | Origin                                        |
+| ------------------ | ------------------ | --------------------------------------------- |
+| `ai_interaction`   | `aiInteraction`    | Bridge, via `POST /notifications/send`        |
+| `session_message`  | `sessionMessage`   | Bridge, via `POST /notifications/send`        |
+| `system_update`    | `systemUpdate`     | Bridge, plus activation reminders             |
+| `connection_status`| `connectionStatus` | Server, on bridge connect/disconnect          |
+
+`connection_status` is server-originated and is rejected on `POST /notifications/send`.
+
+| Method   | Path                            | Auth   | Description                                                                                     |
+| -------- | ------------------------------- | ------ | ----------------------------------------------------------------------------------------------- |
+| `POST`   | `/notifications/register-token`  | Bearer | Register an FCM token. Body `{ token, platform, deviceId? }`                                     |
+| `DELETE` | `/notifications/tokens/:token`   | Bearer | Unregister an FCM token                                                                          |
+| `POST`   | `/notifications/send`            | Bearer | Forward a notification to the user's opted-in devices. Body `{ category, title, body, collapseKey, data? }` |
+
+Filtering is applied to every producer, since they all funnel through `NotificationService.sendToUser` — including activation reminders, which a user can silence via the `systemUpdate` toggle.
+
+**`deviceId` rollout.** `deviceId` on `register-token` is the join key between a push token and its settings document, and it is optional while clients roll it out. A token registered without one cannot be matched to a stored preference, so it **keeps delivering unfiltered** rather than going silent. Per-device filtering only takes full effect once clients send `deviceId`; until then those devices behave exactly as before. A token that changes owner has its `deviceId` cleared, so a recycled token is never filtered against the previous account's settings.
+
 ## Environment variables
 
 Managed via SOPS-encrypted files in `env/app/`. See `.sops.yaml` for key configuration.

--- a/README.md
+++ b/README.md
@@ -175,9 +175,7 @@ Push notifications are forwarded to Firebase Cloud Messaging. Every notification
 | `DELETE` | `/notifications/tokens/:token`   | Bearer | Unregister an FCM token                                                                          |
 | `POST`   | `/notifications/send`            | Bearer | Forward a notification to the user's opted-in devices. Body `{ category, title, body, collapseKey, data? }` |
 
-Filtering applies to every producer that goes through `NotificationService.sendToUser`, which covers bridge-sent notifications and bridge connect/disconnect.
-
-**Activation reminders are exempt.** They are lifecycle nudges about finishing setup rather than the product "System Updates" the toggle describes, so they are sent through `sendToUserIgnoringDeviceSettings` and reach the user even when that toggle is off. They currently ride the `system_update` category on the wire because the client enum has no dedicated activation member; a separate category would need a client change first.
+Filtering is applied to every producer, since they all funnel through `NotificationService.sendToUser` — including activation reminders, which a user can silence via the `systemUpdate` toggle.
 
 **`deviceId` rollout.** `deviceId` on `register-token` is the join key between a push token and its settings document, and it is optional while clients roll it out. A token registered without one cannot be matched to a stored preference, so it **keeps delivering unfiltered** rather than going silent. Per-device filtering only takes full effect once clients send `deviceId`; until then those devices behave exactly as before. A token that changes owner has its `deviceId` cleared, so a recycled token is never filtered against the previous account's settings.
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,16 @@ Filtering is applied to every producer, since they all funnel through `Notificat
 
 **`deviceId` rollout.** `deviceId` on `register-token` is the join key between a push token and its settings document, and it is optional while clients roll it out. A token registered without one cannot be matched to a stored preference, so it **keeps delivering unfiltered** rather than going silent. Per-device filtering only takes full effect once clients send `deviceId`; until then those devices behave exactly as before. A token that changes owner has its `deviceId` cleared, so a recycled token is never filtered against the previous account's settings.
 
+`/notifications/register-token` is not a new endpoint — every shipped client already calls it on sign-in and on FCM token refresh, currently sending only `{ token, platform }`. That is why `deviceId` starts optional: requiring it before clients send it would return 400 on every registration and leave those users with **no push notifications at all**, which is worse than leaving them unfiltered.
+
+Sequence the cutover with `AUTH_REQUIRE_DEVICE_ID_IN_TOKEN_REGISTRATION`:
+
+1. **Deploy this version** with the flag unset. The server stores `deviceId` when a client sends one and filters only those devices.
+2. **Ship the client** that includes its existing `deviceId` in the `register-token` body, and wait for the install base to roll over. Tokens still arriving without one remain unfiltered in the meantime.
+3. **Flip the flag to `true`.** Registrations without a `deviceId` are then rejected with 400, so every push token is filterable.
+
+Do not flip it before step 2 completes. Registration failures do not degrade filtering — they remove the client from push entirely until it updates, because the token never reaches the server. Flipping back to unset restores the previous behaviour immediately; no data migration is involved either way.
+
 ## Environment variables
 
 Managed via SOPS-encrypted files in `env/app/`. See `.sops.yaml` for key configuration.
@@ -204,6 +214,7 @@ Managed via SOPS-encrypted files in `env/app/`. See `.sops.yaml` for key configu
 | `PENDING_AUTH_POLL_TIMEOUT_MS` | Max long-poll duration on `/auth/session/status`. Default `30000`.                                                                                                                          |
 | `RELAY_WEBHOOK_SECRET`         | Shared secret authenticating the relay on `/internal/*` endpoints.                                                                                                                          |
 | `PRODUCT_ANALYTICS_PSEUDONYMIZATION_KEY` | Canonical base64 for at least 32 random bytes. The web/export/suppression runtimes must use the same long-lived key to derive stable HMAC user keys. |
+| `AUTH_REQUIRE_DEVICE_ID_IN_TOKEN_REGISTRATION` | Transition gate for per-device notification filtering. When `true`, `POST /notifications/register-token` rejects a body without `deviceId` (400). Default `false`. Flip only after clients send `deviceId`; doing so earlier drops those clients from push entirely. See the Notifications section. |
 | `ACTIVATION_REMINDERS_ENABLED` | Master switch for activation reminder polling. Default `false`. Enable on only one server instance until distributed leasing exists.                                                         |
 | `ACTIVATION_SWEEP_INTERVAL_MS` | Reminder polling interval in milliseconds. Default `900000` (15 minutes).                                                                                                                    |
 | `ACTIVATION_BRIDGE_REMINDER_1_DELAY_MS` | Delay from the bridge reminder baseline to the first bridge reminder. Default `7200000` (2 hours).                                                                                           |

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,15 @@ const configSchema = z.object({
   RELAY_URL: z.string().min(1, "RELAY_URL is required"),
   RELAY_WEBHOOK_SECRET: z.string().optional(),
   PRODUCT_ANALYTICS_PSEUDONYMIZATION_KEY: productAnalyticsPseudonymizationKeySchema,
+  // Transition gate for per-device notification filtering. Default false so the
+  // shipped client, which does not send deviceId yet, keeps registering its push
+  // token. Flipping this before clients roll over returns 400 on every token
+  // registration, which removes those users from push entirely rather than
+  // merely leaving them unfiltered.
+  AUTH_REQUIRE_DEVICE_ID_IN_TOKEN_REGISTRATION: z
+    .union([z.literal("true"), z.literal("false"), z.literal("1"), z.literal("0")])
+    .optional()
+    .transform((v) => v === "true" || v === "1"),
   ACTIVATION_REMINDERS_ENABLED: z
     .union([z.literal("true"), z.literal("false"), z.literal("1"), z.literal("0")])
     .optional()

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,8 @@ async function main() {
     );
   }
 
-  const notificationService = new NotificationService(deviceTokenRepo, messaging);
+  const settingsService = new SettingsService({ settingsRepo });
+  const notificationService = new NotificationService(deviceTokenRepo, messaging, settingsService);
   const bridgeStateTracker = new BridgeStateTracker(notificationService);
   const bridgeService = new BridgeService({ bridgeRepo, bridgeStateTracker });
   const activationService = new ActivationService({
@@ -110,7 +111,6 @@ async function main() {
     userRepo,
     pseudonymizationKey: config.PRODUCT_ANALYTICS_PSEUDONYMIZATION_KEY,
   });
-  const settingsService = new SettingsService({ settingsRepo });
   const activationReminderService = new ActivationReminderService({
     activationStateRepo,
     notificationService,

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import { BridgePlatform, bridgeIdSchema, bridgePlatformSchema } from "./bridge.js";
 import { devicePlatformSchema } from "./device.js";
+import { CLIENT_SENDABLE_NOTIFICATION_CATEGORIES } from "./notification.js";
+import { deviceIdSchema } from "./settings.js";
 import {
   productAnalyticsExpectedRevisionSchema,
   productAnalyticsOperationIdSchema,
@@ -218,6 +220,9 @@ export type GlossaryRemoveReply = {
 export const registerTokenBodySchema = z.object({
   token: z.string().min(1),
   platform: devicePlatformSchema,
+  // Optional during rollout: clients that predate per-device notification
+  // settings keep registering without it and stay unfiltered.
+  deviceId: deviceIdSchema.optional(),
 });
 export type RegisterTokenBody = z.infer<typeof registerTokenBodySchema>;
 
@@ -243,7 +248,7 @@ export const notificationDataSchema = z.object({
 });
 
 export const sendNotificationBodySchema = z.object({
-  category: z.enum(["ai_interaction", "session_message", "system_update"]),
+  category: z.enum(CLIENT_SENDABLE_NOTIFICATION_CATEGORIES),
   title: z.string().min(1).max(200),
   body: z.string().min(1).max(500),
   collapseKey: z.string().nullable(),

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -90,6 +90,9 @@ export const deviceTokenSchema = z.object({
   userId: z.instanceof(ObjectId),
   token: z.string(),
   platform: devicePlatformSchema,
+  // Joins a push token to its settingsConfiguration document. Null for tokens
+  // registered before clients started sending it; those deliver unfiltered.
+  deviceId: deviceIdSchema.nullable().optional(),
   createdAt: z.date(),
   updatedAt: z.date(),
 });

--- a/src/models/notification.ts
+++ b/src/models/notification.ts
@@ -1,0 +1,26 @@
+import type { NotificationSettingKey } from "./settings.js";
+
+// Values are the wire contract shared with the client's NotificationCategory
+// enum; the bridge sends them verbatim on POST /notifications/send.
+export enum NotificationCategory {
+  AiInteraction = "ai_interaction",
+  SessionMessage = "session_message",
+  ConnectionStatus = "connection_status",
+  SystemUpdate = "system_update",
+}
+
+// Typing as Record<NotificationCategory, …> keeps this exhaustive: a new
+// category cannot compile until it is mapped to a toggle that can silence it.
+export const NOTIFICATION_CATEGORY_SETTING_KEYS: Record<NotificationCategory, NotificationSettingKey> = {
+  [NotificationCategory.AiInteraction]: "aiInteraction",
+  [NotificationCategory.SessionMessage]: "sessionMessage",
+  [NotificationCategory.ConnectionStatus]: "connectionStatus",
+  [NotificationCategory.SystemUpdate]: "systemUpdate",
+};
+
+// Only these may arrive from a client; connection_status is server-originated.
+export const CLIENT_SENDABLE_NOTIFICATION_CATEGORIES = [
+  NotificationCategory.AiInteraction,
+  NotificationCategory.SessionMessage,
+  NotificationCategory.SystemUpdate,
+] as const;

--- a/src/repositories/device-token-repo.ts
+++ b/src/repositories/device-token-repo.ts
@@ -12,7 +12,7 @@ export class DeviceTokenRepository {
     this.#collection = accessor.getCollection<DeviceToken>(MongoDbDatabase.Auth, AuthDbCollection.DeviceTokens);
   }
 
-  async upsertToken(userId: string, token: string, platform: DevicePlatform): Promise<void> {
+  async upsertToken(userId: string, token: string, platform: DevicePlatform, deviceId?: string): Promise<void> {
     if (!ObjectId.isValid(userId)) {
       throw new InternalServerError({ debugMessage: "Invalid device token userId" });
     }
@@ -29,6 +29,9 @@ export class DeviceTokenRepository {
           $set: {
             userId: objectUserId,
             platform,
+            // A client that omits deviceId must not erase a previously learned
+            // one, but a new owner must not inherit the old owner's device.
+            deviceId: deviceId ?? { $cond: [sameOwner, { $ifNull: ["$deviceId", null] }, null] },
             createdAt: {
               $cond: [sameOwner, { $ifNull: ["$createdAt", now] }, now],
             },

--- a/src/repositories/settings-configuration-repo.ts
+++ b/src/repositories/settings-configuration-repo.ts
@@ -15,6 +15,16 @@ export class SettingsConfigurationRepository {
     );
   }
 
+  // Served by the (userId, deviceId) unique index as a prefix scan, so one
+  // notification send costs a single lookup instead of one per device.
+  async findByUserId(userId: string): Promise<SettingsConfiguration[]> {
+    if (!ObjectId.isValid(userId)) {
+      return [];
+    }
+
+    return this.#collection.find({ userId: new ObjectId(userId) }).toArray();
+  }
+
   async findByUserAndDevice(userId: string, deviceId: string): Promise<SettingsConfiguration | null> {
     if (!ObjectId.isValid(userId)) {
       return null;

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -63,6 +63,7 @@ export const notificationRoutes: FastifyPluginAsync<NotificationRouteOptions> = 
         userId,
         token: bodyResult.data.token,
         platform: bodyResult.data.platform,
+        deviceId: bodyResult.data.deviceId,
       });
       try {
         await activationService.recordAppSetup(userId);

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -14,6 +14,7 @@ import type { BridgeService } from "../services/bridge-service.js";
 import type { NotificationService } from "../services/notification-service.js";
 import type { ActivationService } from "../services/activation-service.js";
 import type { AppClientPresenceService } from "../services/app-client-presence-service.js";
+import type { Config } from "../config.js";
 
 // Allow up to 5 minutes of NTP clock skew between the relay and this server
 // before rejecting a status timestamp as "from the future".
@@ -24,6 +25,7 @@ function isTooFarInFuture(at: Date, now: Date = new Date()): boolean {
 }
 
 export type NotificationRouteOptions = {
+  config: Config;
   deviceTokenRepo: DeviceTokenRepository;
   appClientPresenceService: AppClientPresenceService;
   notificationService: NotificationService;
@@ -40,6 +42,7 @@ function getUserId(request: FastifyRequest): string {
 
 export const notificationRoutes: FastifyPluginAsync<NotificationRouteOptions> = async (fastify, opts) => {
   const {
+    config,
     deviceTokenRepo,
     appClientPresenceService,
     notificationService,
@@ -56,6 +59,10 @@ export const notificationRoutes: FastifyPluginAsync<NotificationRouteOptions> = 
       const bodyResult = registerTokenBodySchema.safeParse(request.body);
       if (!bodyResult.success) {
         throw new BadRequestError({ debugMessage: "Invalid request body", nestedError: bodyResult.error.issues });
+      }
+
+      if (config.AUTH_REQUIRE_DEVICE_ID_IN_TOKEN_REGISTRATION && !bodyResult.data.deviceId) {
+        throw new BadRequestError({ debugMessage: "deviceId is required" });
       }
 
       const userId = getUserId(request);

--- a/src/server.ts
+++ b/src/server.ts
@@ -170,6 +170,7 @@ export async function buildApp(services: AppServices): Promise<FastifyInstance> 
     requireAuth,
   });
   await app.register(notificationRoutes, {
+    config: services.config,
     deviceTokenRepo: services.deviceTokenRepo,
     appClientPresenceService: services.appClientPresenceService,
     notificationService: services.notificationService,

--- a/src/services/activation-reminder-service.ts
+++ b/src/services/activation-reminder-service.ts
@@ -231,7 +231,7 @@ export class ActivationReminderService {
         return;
       }
 
-      const { devicesNotified, retryableFailures } = await this.#notificationService.sendToUser(
+      const { devicesNotified, retryableFailures } = await this.#notificationService.sendToUserIgnoringDeviceSettings(
         reminder.userId,
         REMINDER_PAYLOADS[kind],
         this.#disposalAbortController.signal,

--- a/src/services/activation-reminder-service.ts
+++ b/src/services/activation-reminder-service.ts
@@ -4,6 +4,7 @@ import {
   type DueActivationReminder,
 } from "../repositories/activation-state-repo.js";
 import type { NotificationPayload, NotificationService } from "./notification-service.js";
+import { NotificationCategory } from "../models/notification.js";
 
 export const ACTIVATION_REMINDER_DISPOSE_TIMEOUT_MS = 15_000;
 
@@ -17,19 +18,19 @@ const REMINDER_KINDS = [
 
 const REMINDER_PAYLOADS: Record<ActivationReminderKind, NotificationPayload> = {
   [ActivationReminderKind.Bridge1]: {
-    category: "system_update",
+    category: NotificationCategory.SystemUpdate,
     title: "Finish setting up Sesori",
     body: "Install the Sesori bridge on your computer to connect your coding agents.",
     collapseKey: "activation_bridge_1",
   },
   [ActivationReminderKind.Bridge2]: {
-    category: "system_update",
+    category: NotificationCategory.SystemUpdate,
     title: "Your Sesori setup is unfinished",
     body: "You haven't connected your computer yet. Install the Sesori bridge to unlock Sesori.",
     collapseKey: "activation_bridge_2",
   },
   [ActivationReminderKind.Session]: {
-    category: "system_update",
+    category: NotificationCategory.SystemUpdate,
     title: "Start your first session",
     body: "You're all set up! You haven't started a new session yet - create one to put Sesori to work.",
     collapseKey: "activation_first_session",

--- a/src/services/activation-reminder-service.ts
+++ b/src/services/activation-reminder-service.ts
@@ -231,7 +231,7 @@ export class ActivationReminderService {
         return;
       }
 
-      const { devicesNotified, retryableFailures } = await this.#notificationService.sendToUserIgnoringDeviceSettings(
+      const { devicesNotified, retryableFailures } = await this.#notificationService.sendToUser(
         reminder.userId,
         REMINDER_PAYLOADS[kind],
         this.#disposalAbortController.signal,

--- a/src/services/app-client-presence-service.ts
+++ b/src/services/app-client-presence-service.ts
@@ -74,8 +74,13 @@ export class AppClientPresenceService {
    * `userId` with `true`. If the upsert throws, no waiter is notified — the
    * database write must succeed before presence is asserted.
    */
-  async registerToken(params: { userId: string; token: string; platform: DevicePlatform }): Promise<void> {
-    await this.#deviceTokenRepo.upsertToken(params.userId, params.token, params.platform);
+  async registerToken(params: {
+    userId: string;
+    token: string;
+    platform: DevicePlatform;
+    deviceId?: string;
+  }): Promise<void> {
+    await this.#deviceTokenRepo.upsertToken(params.userId, params.token, params.platform, params.deviceId);
 
     const waiters = this.#waitersByUserId.get(params.userId);
     if (!waiters) {

--- a/src/services/bridge-state-tracker.ts
+++ b/src/services/bridge-state-tracker.ts
@@ -1,5 +1,6 @@
 import { BridgeStatus } from "../models/bridge.js";
 import type { NotificationPayload, NotificationService } from "./notification-service.js";
+import { NotificationCategory } from "../models/notification.js";
 
 /**
  * Debounces bridge online/offline push notifications so transient relay
@@ -140,7 +141,7 @@ export class BridgeStateTracker {
   #buildPayload(status: BridgeStatus): NotificationPayload {
     if (status === BridgeStatus.active) {
       return {
-        category: "connection_status",
+        category: NotificationCategory.ConnectionStatus,
         title: "Bridge Online",
         body: "Your bridge has reconnected.",
         collapseKey: "connection_status",
@@ -148,7 +149,7 @@ export class BridgeStateTracker {
     }
 
     return {
-      category: "connection_status",
+      category: NotificationCategory.ConnectionStatus,
       title: "Bridge Offline",
       body: "Your bridge has disconnected. AI sessions are paused.",
       collapseKey: "connection_status",

--- a/src/services/notification-service.ts
+++ b/src/services/notification-service.ts
@@ -48,7 +48,16 @@ export class NotificationService {
   // to a stored preference, so it keeps delivering rather than going silent.
   async #selectOptedInTokens(userId: string, tokens: DeviceToken[], category: NotificationCategory) {
     const settingKey = NOTIFICATION_CATEGORY_SETTING_KEYS[category];
-    const settingsByDevice = await this.#settingsResolver.resolveNotificationsByDevice(userId);
+
+    let settingsByDevice: Map<string, NotificationSettings>;
+    try {
+      settingsByDevice = await this.#settingsResolver.resolveNotificationsByDevice(userId);
+    } catch (error) {
+      // Same rule as an unmatched token: an unreadable preference is not proof
+      // of an opt-out, and muting every device is worse than over-delivering.
+      console.warn("Failed to read notification settings; delivering unfiltered", { userId, error });
+      return tokens;
+    }
 
     return tokens.filter((deviceToken) => {
       if (!deviceToken.deviceId) {
@@ -87,9 +96,11 @@ export class NotificationService {
     }
 
     // FCM data must be a flat Record<string, string>. Flatten NotificationData and filter nulls.
+    // The enum-validated top-level category is the only outbound category.
+    // data.category is a free string, so honouring it would emit a category the
+    // device opted out of — or a server-only one — after filtering already ran.
     const flatData: Record<string, string> = { category: payload.category };
     if (payload.data) {
-      if (payload.data.category) flatData["category"] = payload.data.category;
       if (payload.data.eventType) flatData["eventType"] = payload.data.eventType;
       if (payload.data.sessionId) flatData["sessionId"] = payload.data.sessionId;
       if (payload.data.projectId) flatData["projectId"] = payload.data.projectId;

--- a/src/services/notification-service.ts
+++ b/src/services/notification-service.ts
@@ -84,26 +84,6 @@ export class NotificationService {
     payload: NotificationPayload,
     abortSignal?: AbortSignal,
   ): Promise<NotificationDeliveryResult> {
-    return this.#deliver(userId, payload, abortSignal, true);
-  }
-
-  // Activation reminders are lifecycle nudges about finishing setup, not the
-  // product "System Updates" the toggle describes, so they are deliberately not
-  // silenced by it even though they ride the same category on the wire.
-  async sendToUserIgnoringDeviceSettings(
-    userId: string,
-    payload: NotificationPayload,
-    abortSignal?: AbortSignal,
-  ): Promise<NotificationDeliveryResult> {
-    return this.#deliver(userId, payload, abortSignal, false);
-  }
-
-  async #deliver(
-    userId: string,
-    payload: NotificationPayload,
-    abortSignal: AbortSignal | undefined,
-    respectDeviceSettings: boolean,
-  ): Promise<NotificationDeliveryResult> {
     abortSignal?.throwIfAborted();
     if (!this.#messaging) {
       return { devicesNotified: 0, retryableFailures: 0 };
@@ -115,9 +95,7 @@ export class NotificationService {
       return { devicesNotified: 0, retryableFailures: 0 };
     }
 
-    const deliverableTokens = respectDeviceSettings
-      ? await this.#selectOptedInTokens(userId, tokens, payload.category)
-      : tokens;
+    const deliverableTokens = await this.#selectOptedInTokens(userId, tokens, payload.category);
     abortSignal?.throwIfAborted();
     if (deliverableTokens.length === 0) {
       return { devicesNotified: 0, retryableFailures: 0 };

--- a/src/services/notification-service.ts
+++ b/src/services/notification-service.ts
@@ -1,5 +1,8 @@
 import { createHash } from "node:crypto";
 import type { Messaging, BaseMessage } from "firebase-admin/messaging";
+import { NOTIFICATION_CATEGORY_SETTING_KEYS, NotificationCategory } from "../models/notification.js";
+import { NOTIFICATION_SETTINGS_DEFAULTS, type NotificationSettings } from "../models/settings.js";
+import type { DeviceToken } from "../models/documents.js";
 import type { DeviceTokenRepository } from "../repositories/device-token-repo.js";
 
 export interface NotificationData {
@@ -10,11 +13,15 @@ export interface NotificationData {
 }
 
 export interface NotificationPayload {
-  category: string;
+  category: NotificationCategory;
   title: string;
   body: string;
   collapseKey?: string | null;
   data?: NotificationData | null;
+}
+
+export interface NotificationSettingsResolver {
+  resolveNotificationsByDevice(userId: string): Promise<Map<string, NotificationSettings>>;
 }
 
 export interface NotificationDeliveryResult {
@@ -25,10 +32,32 @@ export interface NotificationDeliveryResult {
 export class NotificationService {
   readonly #deviceTokenRepo: DeviceTokenRepository;
   readonly #messaging: Messaging | null;
+  readonly #settingsResolver: NotificationSettingsResolver;
 
-  constructor(deviceTokenRepo: DeviceTokenRepository, messaging: Messaging | null) {
+  constructor(
+    deviceTokenRepo: DeviceTokenRepository,
+    messaging: Messaging | null,
+    settingsResolver: NotificationSettingsResolver,
+  ) {
     this.#deviceTokenRepo = deviceTokenRepo;
     this.#messaging = messaging;
+    this.#settingsResolver = settingsResolver;
+  }
+
+  // A token with no deviceId predates per-device settings and cannot be matched
+  // to a stored preference, so it keeps delivering rather than going silent.
+  async #selectOptedInTokens(userId: string, tokens: DeviceToken[], category: NotificationCategory) {
+    const settingKey = NOTIFICATION_CATEGORY_SETTING_KEYS[category];
+    const settingsByDevice = await this.#settingsResolver.resolveNotificationsByDevice(userId);
+
+    return tokens.filter((deviceToken) => {
+      if (!deviceToken.deviceId) {
+        return true;
+      }
+
+      const settings = settingsByDevice.get(deviceToken.deviceId) ?? NOTIFICATION_SETTINGS_DEFAULTS;
+      return settings[settingKey];
+    });
   }
 
   get isAvailable(): boolean {
@@ -51,6 +80,12 @@ export class NotificationService {
       return { devicesNotified: 0, retryableFailures: 0 };
     }
 
+    const deliverableTokens = await this.#selectOptedInTokens(userId, tokens, payload.category);
+    abortSignal?.throwIfAborted();
+    if (deliverableTokens.length === 0) {
+      return { devicesNotified: 0, retryableFailures: 0 };
+    }
+
     // FCM data must be a flat Record<string, string>. Flatten NotificationData and filter nulls.
     const flatData: Record<string, string> = { category: payload.category };
     if (payload.data) {
@@ -60,7 +95,7 @@ export class NotificationService {
       if (payload.data.projectId) flatData["projectId"] = payload.data.projectId;
     }
 
-    const messages: Array<BaseMessage & { token: string }> = tokens.map((t) => ({
+    const messages: Array<BaseMessage & { token: string }> = deliverableTokens.map((t) => ({
       token: t.token,
       notification: { title: payload.title, body: payload.body },
       data: flatData,
@@ -87,12 +122,12 @@ export class NotificationService {
 
       const code = r.error?.code;
       if (code === "messaging/registration-token-not-registered" || code === "messaging/invalid-registration-token") {
-        staleTokens.push(tokens[i].token);
+        staleTokens.push(deliverableTokens[i].token);
         return;
       }
 
       retryableFailures += 1;
-      const tokenFingerprint = createHash("sha256").update(tokens[i].token).digest("hex").slice(0, 12);
+      const tokenFingerprint = createHash("sha256").update(deliverableTokens[i].token).digest("hex").slice(0, 12);
       console.warn("Non-token FCM error while sending push notification", { userId, tokenFingerprint, code });
     });
 

--- a/src/services/notification-service.ts
+++ b/src/services/notification-service.ts
@@ -47,6 +47,12 @@ export class NotificationService {
   // A token with no deviceId predates per-device settings and cannot be matched
   // to a stored preference, so it keeps delivering rather than going silent.
   async #selectOptedInTokens(userId: string, tokens: DeviceToken[], category: NotificationCategory) {
+    // Until clients send deviceId, every token fails open, so the settings read
+    // cannot change the outcome and is skipped on the whole push path.
+    if (!tokens.some((deviceToken) => deviceToken.deviceId)) {
+      return tokens;
+    }
+
     const settingKey = NOTIFICATION_CATEGORY_SETTING_KEYS[category];
 
     let settingsByDevice: Map<string, NotificationSettings>;

--- a/src/services/notification-service.ts
+++ b/src/services/notification-service.ts
@@ -84,6 +84,26 @@ export class NotificationService {
     payload: NotificationPayload,
     abortSignal?: AbortSignal,
   ): Promise<NotificationDeliveryResult> {
+    return this.#deliver(userId, payload, abortSignal, true);
+  }
+
+  // Activation reminders are lifecycle nudges about finishing setup, not the
+  // product "System Updates" the toggle describes, so they are deliberately not
+  // silenced by it even though they ride the same category on the wire.
+  async sendToUserIgnoringDeviceSettings(
+    userId: string,
+    payload: NotificationPayload,
+    abortSignal?: AbortSignal,
+  ): Promise<NotificationDeliveryResult> {
+    return this.#deliver(userId, payload, abortSignal, false);
+  }
+
+  async #deliver(
+    userId: string,
+    payload: NotificationPayload,
+    abortSignal: AbortSignal | undefined,
+    respectDeviceSettings: boolean,
+  ): Promise<NotificationDeliveryResult> {
     abortSignal?.throwIfAborted();
     if (!this.#messaging) {
       return { devicesNotified: 0, retryableFailures: 0 };
@@ -95,7 +115,9 @@ export class NotificationService {
       return { devicesNotified: 0, retryableFailures: 0 };
     }
 
-    const deliverableTokens = await this.#selectOptedInTokens(userId, tokens, payload.category);
+    const deliverableTokens = respectDeviceSettings
+      ? await this.#selectOptedInTokens(userId, tokens, payload.category)
+      : tokens;
     abortSignal?.throwIfAborted();
     if (deliverableTokens.length === 0) {
       return { devicesNotified: 0, retryableFailures: 0 };

--- a/src/services/settings-service.ts
+++ b/src/services/settings-service.ts
@@ -1,6 +1,7 @@
 import type { SettingsConfiguration } from "../models/documents.js";
 import {
   resolveNotificationSettings,
+  type NotificationSettings,
   type SettingsConfigurationView,
   type UpdateSettingsBody,
 } from "../models/settings.js";
@@ -24,6 +25,15 @@ export class SettingsService {
   async getForDevice(userId: string, deviceId: string): Promise<SettingsConfigurationView> {
     const document = await this.#repo.findByUserAndDevice(userId, deviceId);
     return toView(deviceId, document);
+  }
+
+  // Devices absent from the returned map have stored nothing and therefore
+  // resolve to the all-enabled defaults at the call site.
+  async resolveNotificationsByDevice(userId: string): Promise<Map<string, NotificationSettings>> {
+    const documents = await this.#repo.findByUserId(userId);
+    return new Map(
+      documents.map((document) => [document.deviceId, resolveNotificationSettings(document.notifications)]),
+    );
   }
 
   async updateForDevice(

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -179,7 +179,9 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
       iosClientId: config.APPLE_IOS_CLIENT_ID,
     });
 
-  const notificationService = overrides?.notificationService ?? new NotificationService(deviceTokenRepo, null);
+  const settingsService = overrides?.settingsService ?? new SettingsService({ settingsRepo });
+  const notificationService =
+    overrides?.notificationService ?? new NotificationService(deviceTokenRepo, null, settingsService);
   const bridgeStateTracker = overrides?.bridgeStateTracker ?? new BridgeStateTracker(notificationService);
   const bridgeService = overrides?.bridgeService ?? new BridgeService({ bridgeRepo, bridgeStateTracker });
   const activationService =
@@ -191,7 +193,6 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
     userRepo,
     pseudonymizationKey: testProductAnalyticsPseudonymizationKey,
   });
-  const settingsService = overrides?.settingsService ?? new SettingsService({ settingsRepo });
   const authService = new AuthService({ tokenService, userRepo, oauthAccountRepo, passwordAccountRepo, bridgeService });
   const voiceService = new VoiceService({ openai, glossaryRepo, dailyUsageRepo });
   const sessionMetadataService =

--- a/tests/notifications/device-token-repo.test.ts
+++ b/tests/notifications/device-token-repo.test.ts
@@ -32,6 +32,51 @@ describe("DeviceTokenRepository", () => {
     assert.equal(tokens[0]?.platform, "ios");
   });
 
+  it("upsertToken stores the deviceId that scopes notification settings", async () => {
+    const user = await ctx.createUser();
+    const deviceId = "550e8400-e29b-41d4-a716-446655440000";
+
+    await repo.upsertToken(user.userId, "token-with-device", DevicePlatform.ios, deviceId);
+
+    const tokens = await repo.findByUserId(user.userId);
+    assert.equal(tokens[0]?.deviceId, deviceId);
+  });
+
+  it("upsertToken defaults deviceId to null when the client omits it", async () => {
+    const user = await ctx.createUser();
+
+    await repo.upsertToken(user.userId, "token-no-device", DevicePlatform.ios);
+
+    const tokens = await repo.findByUserId(user.userId);
+    assert.equal(tokens[0]?.deviceId, null);
+  });
+
+  it("upsertToken keeps a known deviceId when a later registration omits it", async () => {
+    const user = await ctx.createUser();
+    const deviceId = "6ba7b810-9dad-41d1-80b4-00c04fd430c8";
+
+    await repo.upsertToken(user.userId, "token-sticky-device", DevicePlatform.ios, deviceId);
+    await repo.upsertToken(user.userId, "token-sticky-device", DevicePlatform.android);
+
+    const tokens = await repo.findByUserId(user.userId);
+    assert.equal(tokens[0]?.deviceId, deviceId);
+  });
+
+  // A recycled token must never inherit the previous owner's deviceId, or the
+  // new owner would be filtered against another account's settings.
+  it("upsertToken clears the deviceId when the token changes owner", async () => {
+    const first = await ctx.createUser();
+    const second = await ctx.createUser();
+
+    await repo.upsertToken(first.userId, "token-recycled", DevicePlatform.ios, "550e8400-e29b-41d4-a716-446655440000");
+    await repo.upsertToken(second.userId, "token-recycled", DevicePlatform.ios);
+
+    assert.deepEqual(await repo.findByUserId(first.userId), []);
+    const tokens = await repo.findByUserId(second.userId);
+    assert.equal(tokens.length, 1);
+    assert.equal(tokens[0]?.deviceId, null);
+  });
+
   it("upsertToken preserves createdAt for a same-owner mobile-to-mobile update", async () => {
     const user = await ctx.createUser();
 

--- a/tests/notifications/notification-category-filtering.test.ts
+++ b/tests/notifications/notification-category-filtering.test.ts
@@ -163,7 +163,7 @@ describe("NotificationService category filtering", () => {
     assert.equal(messaging.calls.length, 0);
   });
 
-  it("honours the system update toggle for a bridge-sent notification", async () => {
+  it("honours the system update toggle used by activation reminders", async () => {
     const tokenRepo = createMockDeviceTokenRepo([
       { userId: "user-1", token: "token-a", platform: "ios", deviceId: DEVICE_A },
     ]);
@@ -175,32 +175,6 @@ describe("NotificationService category filtering", () => {
 
     assert.equal(result.devicesNotified, 0);
     assert.equal(messaging.calls.length, 0);
-  });
-
-  // Activation reminders ride system_update but are lifecycle nudges, so they
-  // are exempt by design; this is the only path allowed to ignore a toggle.
-  it("delivers on the unfiltered path even when the device disabled the category", async () => {
-    const tokenRepo = createMockDeviceTokenRepo([
-      { userId: "user-1", token: "token-a", platform: "ios", deviceId: DEVICE_A },
-    ]);
-    const messaging = createMockMessaging([{ success: true }]);
-    let resolverCalls = 0;
-    const settings: NotificationSettingsResolver = {
-      resolveNotificationsByDevice: async () => {
-        resolverCalls += 1;
-        return new Map([[DEVICE_A, { ...NOTIFICATION_SETTINGS_DEFAULTS, systemUpdate: false }]]);
-      },
-    };
-    const service = new NotificationService(tokenRepo.repo, messaging.messaging, settings);
-
-    const result = await service.sendToUserIgnoringDeviceSettings(
-      "user-1",
-      buildPayload(NotificationCategory.SystemUpdate),
-    );
-
-    assert.deepEqual(sentTokens(messaging.calls), ["token-a"]);
-    assert.equal(result.devicesNotified, 1);
-    assert.equal(resolverCalls, 0, "the unfiltered path must not read settings at all");
   });
 
   // Stale-token cleanup indexes FCM responses positionally, so it has to line up

--- a/tests/notifications/notification-category-filtering.test.ts
+++ b/tests/notifications/notification-category-filtering.test.ts
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Messaging } from "firebase-admin/messaging";
+import { NotificationCategory } from "../../src/models/notification.js";
+import { NOTIFICATION_SETTINGS_DEFAULTS, type NotificationSettings } from "../../src/models/settings.js";
+import type { DeviceTokenRepository } from "../../src/repositories/device-token-repo.js";
+import {
+  NotificationService,
+  type NotificationPayload,
+  type NotificationSettingsResolver,
+} from "../../src/services/notification-service.js";
+
+type MockResponse = { success: boolean; error?: { code: string } };
+type MockToken = { userId: string; token: string; platform: string; deviceId?: string | null };
+
+const DEVICE_A = "550e8400-e29b-41d4-a716-446655440000";
+const DEVICE_B = "6ba7b810-9dad-41d1-80b4-00c04fd430c8";
+
+function createMockMessaging(responses: MockResponse[]) {
+  const calls: unknown[][] = [];
+
+  const messaging = {
+    sendEach: async (messages: unknown[]) => {
+      calls.push(messages);
+      return {
+        successCount: responses.filter((r) => r.success).length,
+        failureCount: responses.filter((r) => !r.success).length,
+        responses: responses.map((r) => ({
+          success: r.success,
+          error: r.error ? { code: r.error.code } : undefined,
+        })),
+      };
+    },
+  } as unknown as Messaging;
+
+  return { messaging, calls };
+}
+
+function createMockDeviceTokenRepo(tokens: MockToken[]) {
+  let stored = [...tokens];
+
+  const repo = {
+    findByUserId: async (userId: string) => stored.filter((t) => t.userId === userId),
+    deleteByTokens: async (tokensToDelete: string[]) => {
+      stored = stored.filter((t) => !tokensToDelete.includes(t.token));
+    },
+  } as unknown as DeviceTokenRepository;
+
+  return { repo, getStoredTokens: () => [...stored] };
+}
+
+function createMockSettingsResolver(
+  byDevice: Record<string, Partial<NotificationSettings>>,
+): NotificationSettingsResolver {
+  return {
+    resolveNotificationsByDevice: async () =>
+      new Map(
+        Object.entries(byDevice).map(([deviceId, overrides]) => [
+          deviceId,
+          { ...NOTIFICATION_SETTINGS_DEFAULTS, ...overrides },
+        ]),
+      ),
+  };
+}
+
+function buildPayload(category: NotificationCategory): NotificationPayload {
+  return { category, title: "Title", body: "Body", collapseKey: null };
+}
+
+function sentTokens(calls: unknown[][]): string[] {
+  return (calls[0] ?? []).map((message) => (message as { token: string }).token);
+}
+
+describe("NotificationService category filtering", () => {
+  it("drops a device that disabled the category", async () => {
+    const tokenRepo = createMockDeviceTokenRepo([
+      { userId: "user-1", token: "token-a", platform: "ios", deviceId: DEVICE_A },
+    ]);
+    const messaging = createMockMessaging([]);
+    const settings = createMockSettingsResolver({ [DEVICE_A]: { aiInteraction: false } });
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, settings);
+
+    const result = await service.sendToUser("user-1", buildPayload(NotificationCategory.AiInteraction));
+
+    assert.deepEqual(result, { devicesNotified: 0, retryableFailures: 0 });
+    assert.equal(messaging.calls.length, 0, "FCM must not be called when every device opted out");
+  });
+
+  it("delivers to a device that left the category enabled", async () => {
+    const tokenRepo = createMockDeviceTokenRepo([
+      { userId: "user-1", token: "token-a", platform: "ios", deviceId: DEVICE_A },
+    ]);
+    const messaging = createMockMessaging([{ success: true }]);
+    const settings = createMockSettingsResolver({ [DEVICE_A]: { sessionMessage: false } });
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, settings);
+
+    const result = await service.sendToUser("user-1", buildPayload(NotificationCategory.AiInteraction));
+
+    assert.equal(result.devicesNotified, 1);
+    assert.deepEqual(sentTokens(messaging.calls), ["token-a"]);
+  });
+
+  it("filters per device rather than per user", async () => {
+    const tokenRepo = createMockDeviceTokenRepo([
+      { userId: "user-1", token: "token-a", platform: "ios", deviceId: DEVICE_A },
+      { userId: "user-1", token: "token-b", platform: "android", deviceId: DEVICE_B },
+    ]);
+    const messaging = createMockMessaging([{ success: true }]);
+    const settings = createMockSettingsResolver({
+      [DEVICE_A]: { aiInteraction: false },
+      [DEVICE_B]: { aiInteraction: true },
+    });
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, settings);
+
+    await service.sendToUser("user-1", buildPayload(NotificationCategory.AiInteraction));
+
+    assert.deepEqual(sentTokens(messaging.calls), ["token-b"]);
+  });
+
+  it("delivers to a token that has no deviceId yet", async () => {
+    const tokenRepo = createMockDeviceTokenRepo([
+      { userId: "user-1", token: "legacy-token", platform: "ios", deviceId: null },
+      { userId: "user-1", token: "token-a", platform: "android", deviceId: DEVICE_A },
+    ]);
+    const messaging = createMockMessaging([{ success: true }]);
+    const settings = createMockSettingsResolver({ [DEVICE_A]: { aiInteraction: false } });
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, settings);
+
+    await service.sendToUser("user-1", buildPayload(NotificationCategory.AiInteraction));
+
+    assert.deepEqual(sentTokens(messaging.calls), ["legacy-token"]);
+  });
+
+  it("delivers to a device that has stored no settings at all", async () => {
+    const tokenRepo = createMockDeviceTokenRepo([
+      { userId: "user-1", token: "token-a", platform: "ios", deviceId: DEVICE_A },
+    ]);
+    const messaging = createMockMessaging([{ success: true }]);
+    const settings = createMockSettingsResolver({});
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, settings);
+
+    const result = await service.sendToUser("user-1", buildPayload(NotificationCategory.AiInteraction));
+
+    assert.equal(result.devicesNotified, 1);
+  });
+
+  it("honours the connection status toggle used by bridge state changes", async () => {
+    const tokenRepo = createMockDeviceTokenRepo([
+      { userId: "user-1", token: "token-a", platform: "ios", deviceId: DEVICE_A },
+    ]);
+    const messaging = createMockMessaging([]);
+    const settings = createMockSettingsResolver({ [DEVICE_A]: { connectionStatus: false } });
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, settings);
+
+    const result = await service.sendToUser("user-1", buildPayload(NotificationCategory.ConnectionStatus));
+
+    assert.equal(result.devicesNotified, 0);
+    assert.equal(messaging.calls.length, 0);
+  });
+
+  it("honours the system update toggle used by activation reminders", async () => {
+    const tokenRepo = createMockDeviceTokenRepo([
+      { userId: "user-1", token: "token-a", platform: "ios", deviceId: DEVICE_A },
+    ]);
+    const messaging = createMockMessaging([]);
+    const settings = createMockSettingsResolver({ [DEVICE_A]: { systemUpdate: false } });
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, settings);
+
+    const result = await service.sendToUser("user-1", buildPayload(NotificationCategory.SystemUpdate));
+
+    assert.equal(result.devicesNotified, 0);
+    assert.equal(messaging.calls.length, 0);
+  });
+
+  // Stale-token cleanup indexes FCM responses positionally, so it has to line up
+  // with the filtered list; against the unfiltered list it would delete the wrong
+  // device's token.
+  it("maps stale-token cleanup back to the filtered tokens", async () => {
+    const tokenRepo = createMockDeviceTokenRepo([
+      { userId: "user-1", token: "token-a", platform: "ios", deviceId: DEVICE_A },
+      { userId: "user-1", token: "token-b", platform: "android", deviceId: DEVICE_B },
+    ]);
+    const messaging = createMockMessaging([
+      { success: false, error: { code: "messaging/registration-token-not-registered" } },
+    ]);
+    const settings = createMockSettingsResolver({
+      [DEVICE_A]: { aiInteraction: true },
+      [DEVICE_B]: { aiInteraction: false },
+    });
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, settings);
+
+    await service.sendToUser("user-1", buildPayload(NotificationCategory.AiInteraction));
+
+    assert.deepEqual(
+      tokenRepo.getStoredTokens().map((t) => t.token),
+      ["token-b"],
+      "the opted-out device's token must survive; only the delivered stale token is removed",
+    );
+  });
+
+  it("does not query settings when the user has no tokens", async () => {
+    const tokenRepo = createMockDeviceTokenRepo([]);
+    const messaging = createMockMessaging([]);
+    let resolverCalls = 0;
+    const settings: NotificationSettingsResolver = {
+      resolveNotificationsByDevice: async () => {
+        resolverCalls += 1;
+        return new Map();
+      },
+    };
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, settings);
+
+    const result = await service.sendToUser("user-1", buildPayload(NotificationCategory.AiInteraction));
+
+    assert.deepEqual(result, { devicesNotified: 0, retryableFailures: 0 });
+    assert.equal(resolverCalls, 0);
+  });
+});

--- a/tests/notifications/notification-category-filtering.test.ts
+++ b/tests/notifications/notification-category-filtering.test.ts
@@ -163,7 +163,7 @@ describe("NotificationService category filtering", () => {
     assert.equal(messaging.calls.length, 0);
   });
 
-  it("honours the system update toggle used by activation reminders", async () => {
+  it("honours the system update toggle for a bridge-sent notification", async () => {
     const tokenRepo = createMockDeviceTokenRepo([
       { userId: "user-1", token: "token-a", platform: "ios", deviceId: DEVICE_A },
     ]);
@@ -175,6 +175,32 @@ describe("NotificationService category filtering", () => {
 
     assert.equal(result.devicesNotified, 0);
     assert.equal(messaging.calls.length, 0);
+  });
+
+  // Activation reminders ride system_update but are lifecycle nudges, so they
+  // are exempt by design; this is the only path allowed to ignore a toggle.
+  it("delivers on the unfiltered path even when the device disabled the category", async () => {
+    const tokenRepo = createMockDeviceTokenRepo([
+      { userId: "user-1", token: "token-a", platform: "ios", deviceId: DEVICE_A },
+    ]);
+    const messaging = createMockMessaging([{ success: true }]);
+    let resolverCalls = 0;
+    const settings: NotificationSettingsResolver = {
+      resolveNotificationsByDevice: async () => {
+        resolverCalls += 1;
+        return new Map([[DEVICE_A, { ...NOTIFICATION_SETTINGS_DEFAULTS, systemUpdate: false }]]);
+      },
+    };
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, settings);
+
+    const result = await service.sendToUserIgnoringDeviceSettings(
+      "user-1",
+      buildPayload(NotificationCategory.SystemUpdate),
+    );
+
+    assert.deepEqual(sentTokens(messaging.calls), ["token-a"]);
+    assert.equal(result.devicesNotified, 1);
+    assert.equal(resolverCalls, 0, "the unfiltered path must not read settings at all");
   });
 
   // Stale-token cleanup indexes FCM responses positionally, so it has to line up

--- a/tests/notifications/notification-category-filtering.test.ts
+++ b/tests/notifications/notification-category-filtering.test.ts
@@ -20,12 +20,16 @@ function createMockMessaging(responses: MockResponse[]) {
   const calls: unknown[][] = [];
 
   const messaging = {
+    // FCM returns exactly one response per message sent, so align to what was
+    // actually delivered. Counting the canned responses instead would let a
+    // test report deliveries for tokens that filtering had dropped.
     sendEach: async (messages: unknown[]) => {
       calls.push(messages);
+      const delivered = responses.slice(0, messages.length);
       return {
-        successCount: responses.filter((r) => r.success).length,
-        failureCount: responses.filter((r) => !r.success).length,
-        responses: responses.map((r) => ({
+        successCount: delivered.filter((r) => r.success).length,
+        failureCount: delivered.filter((r) => !r.success).length,
+        responses: delivered.map((r) => ({
           success: r.success,
           error: r.error ? { code: r.error.code } : undefined,
         })),
@@ -141,6 +145,7 @@ describe("NotificationService category filtering", () => {
 
     const result = await service.sendToUser("user-1", buildPayload(NotificationCategory.AiInteraction));
 
+    assert.deepEqual(sentTokens(messaging.calls), ["token-a"]);
     assert.equal(result.devicesNotified, 1);
   });
 
@@ -228,8 +233,10 @@ describe("NotificationService category filtering", () => {
       { userId: "user-1", token: "token-a", platform: "ios", deviceId: DEVICE_A },
     ]);
     const messaging = createMockMessaging([{ success: true }]);
+    let resolverCalls = 0;
     const settings: NotificationSettingsResolver = {
       resolveNotificationsByDevice: async () => {
+        resolverCalls += 1;
         throw new Error("settings unavailable");
       },
     };
@@ -237,6 +244,8 @@ describe("NotificationService category filtering", () => {
 
     const result = await service.sendToUser("user-1", buildPayload(NotificationCategory.AiInteraction));
 
+    assert.equal(resolverCalls, 1, "the failing settings read must actually have been attempted");
+    assert.deepEqual(sentTokens(messaging.calls), ["token-a"]);
     assert.equal(result.devicesNotified, 1);
   });
 
@@ -257,6 +266,7 @@ describe("NotificationService category filtering", () => {
 
     const result = await service.sendToUser("user-1", buildPayload(NotificationCategory.AiInteraction));
 
+    assert.deepEqual(sentTokens(messaging.calls), ["legacy-a", "legacy-b"]);
     assert.equal(result.devicesNotified, 2);
     assert.equal(resolverCalls, 0);
   });

--- a/tests/notifications/notification-category-filtering.test.ts
+++ b/tests/notifications/notification-category-filtering.test.ts
@@ -198,6 +198,48 @@ describe("NotificationService category filtering", () => {
     );
   });
 
+  // data.category is not enum-checked, so letting it through would deliver a
+  // category the device opted out of while filtering ran on the top-level one.
+  it("never lets data.category override the category that was filtered", async () => {
+    const tokenRepo = createMockDeviceTokenRepo([
+      { userId: "user-1", token: "token-a", platform: "ios", deviceId: DEVICE_A },
+    ]);
+    const messaging = createMockMessaging([{ success: true }]);
+    const settings = createMockSettingsResolver({
+      [DEVICE_A]: { aiInteraction: true, sessionMessage: false, connectionStatus: false },
+    });
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, settings);
+
+    await service.sendToUser("user-1", {
+      category: NotificationCategory.AiInteraction,
+      title: "Action required",
+      body: "Approve this command",
+      collapseKey: null,
+      data: { category: NotificationCategory.ConnectionStatus, sessionId: "session-1" },
+    });
+
+    const message = messaging.calls[0]?.[0] as { data?: Record<string, string> };
+    assert.equal(message.data?.category, NotificationCategory.AiInteraction);
+    assert.equal(message.data?.sessionId, "session-1", "other data fields still pass through");
+  });
+
+  it("delivers unfiltered when the settings lookup fails", async () => {
+    const tokenRepo = createMockDeviceTokenRepo([
+      { userId: "user-1", token: "token-a", platform: "ios", deviceId: DEVICE_A },
+    ]);
+    const messaging = createMockMessaging([{ success: true }]);
+    const settings: NotificationSettingsResolver = {
+      resolveNotificationsByDevice: async () => {
+        throw new Error("settings unavailable");
+      },
+    };
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, settings);
+
+    const result = await service.sendToUser("user-1", buildPayload(NotificationCategory.AiInteraction));
+
+    assert.equal(result.devicesNotified, 1);
+  });
+
   it("does not query settings when the user has no tokens", async () => {
     const tokenRepo = createMockDeviceTokenRepo([]);
     const messaging = createMockMessaging([]);

--- a/tests/notifications/notification-category-filtering.test.ts
+++ b/tests/notifications/notification-category-filtering.test.ts
@@ -240,6 +240,27 @@ describe("NotificationService category filtering", () => {
     assert.equal(result.devicesNotified, 1);
   });
 
+  it("does not query settings when no token carries a deviceId", async () => {
+    const tokenRepo = createMockDeviceTokenRepo([
+      { userId: "user-1", token: "legacy-a", platform: "ios", deviceId: null },
+      { userId: "user-1", token: "legacy-b", platform: "android" },
+    ]);
+    const messaging = createMockMessaging([{ success: true }, { success: true }]);
+    let resolverCalls = 0;
+    const settings: NotificationSettingsResolver = {
+      resolveNotificationsByDevice: async () => {
+        resolverCalls += 1;
+        return new Map();
+      },
+    };
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, settings);
+
+    const result = await service.sendToUser("user-1", buildPayload(NotificationCategory.AiInteraction));
+
+    assert.equal(result.devicesNotified, 2);
+    assert.equal(resolverCalls, 0);
+  });
+
   it("does not query settings when the user has no tokens", async () => {
     const tokenRepo = createMockDeviceTokenRepo([]);
     const messaging = createMockMessaging([]);

--- a/tests/notifications/notification-filtering-e2e.test.ts
+++ b/tests/notifications/notification-filtering-e2e.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import type { Messaging } from "firebase-admin/messaging";
+import { DevicePlatform } from "../../src/models/device.js";
+import { NotificationCategory } from "../../src/models/notification.js";
+import { DeviceTokenRepository } from "../../src/repositories/device-token-repo.js";
+import { SettingsConfigurationRepository } from "../../src/repositories/settings-configuration-repo.js";
+import { NotificationService } from "../../src/services/notification-service.js";
+import { SettingsService } from "../../src/services/settings-service.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+const DEVICE_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+function createMockMessaging() {
+  const calls: unknown[][] = [];
+
+  const messaging = {
+    sendEach: async (messages: unknown[]) => {
+      calls.push(messages);
+      return {
+        successCount: messages.length,
+        failureCount: 0,
+        responses: messages.map(() => ({ success: true })),
+      };
+    },
+  } as unknown as Messaging;
+
+  return { messaging, calls };
+}
+
+describe("notification filtering end to end", () => {
+  let ctx: TestContext;
+
+  before(async () => {
+    ctx = await createTestApp();
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("stops delivering a category the device switched off, then resumes when it is switched back on", async () => {
+    const user = await ctx.createUser();
+    const auth = { authorization: `Bearer ${user.accessToken}` };
+
+    const registration = await ctx.app.inject({
+      method: "POST",
+      url: "/notifications/register-token",
+      headers: auth,
+      payload: { token: "fcm-token-e2e", platform: DevicePlatform.ios, deviceId: DEVICE_ID },
+    });
+    assert.equal(registration.statusCode, 200);
+
+    const messaging = createMockMessaging();
+    const notificationService = new NotificationService(
+      new DeviceTokenRepository(ctx.dbAccessor),
+      messaging.messaging,
+      new SettingsService({ settingsRepo: new SettingsConfigurationRepository(ctx.dbAccessor) }),
+    );
+
+    const beforeOptOut = await notificationService.sendToUser(user.userId, {
+      category: NotificationCategory.AiInteraction,
+      title: "Action required",
+      body: "Approve this command",
+      collapseKey: null,
+    });
+    assert.equal(beforeOptOut.devicesNotified, 1, "a device with no stored settings defaults to enabled");
+
+    const optOut = await ctx.app.inject({
+      method: "PATCH",
+      url: `/auth/settings/${DEVICE_ID}`,
+      headers: auth,
+      payload: { notifications: { aiInteraction: false } },
+    });
+    assert.equal(optOut.statusCode, 200);
+    assert.equal(optOut.json().notifications.aiInteraction, false);
+
+    const afterOptOut = await notificationService.sendToUser(user.userId, {
+      category: NotificationCategory.AiInteraction,
+      title: "Action required",
+      body: "Approve this command",
+      collapseKey: null,
+    });
+    assert.equal(afterOptOut.devicesNotified, 0);
+    assert.equal(messaging.calls.length, 1, "FCM must not be called again once the only device opted out");
+
+    const stillDelivered = await notificationService.sendToUser(user.userId, {
+      category: NotificationCategory.SessionMessage,
+      title: "New message",
+      body: "Your session replied",
+      collapseKey: null,
+    });
+    assert.equal(stillDelivered.devicesNotified, 1, "other categories stay unaffected");
+
+    const optIn = await ctx.app.inject({
+      method: "PATCH",
+      url: `/auth/settings/${DEVICE_ID}`,
+      headers: auth,
+      payload: { notifications: { aiInteraction: true } },
+    });
+    assert.equal(optIn.statusCode, 200);
+
+    const afterOptIn = await notificationService.sendToUser(user.userId, {
+      category: NotificationCategory.AiInteraction,
+      title: "Action required",
+      body: "Approve this command",
+      collapseKey: null,
+    });
+    assert.equal(afterOptIn.devicesNotified, 1);
+  });
+
+  it("keeps delivering to a token registered without a deviceId", async () => {
+    const user = await ctx.createUser();
+    const auth = { authorization: `Bearer ${user.accessToken}` };
+
+    const registration = await ctx.app.inject({
+      method: "POST",
+      url: "/notifications/register-token",
+      headers: auth,
+      payload: { token: "fcm-token-legacy", platform: DevicePlatform.android },
+    });
+    assert.equal(registration.statusCode, 200);
+
+    const optOut = await ctx.app.inject({
+      method: "PATCH",
+      url: `/auth/settings/${DEVICE_ID}`,
+      headers: auth,
+      payload: { notifications: { aiInteraction: false } },
+    });
+    assert.equal(optOut.statusCode, 200);
+
+    const messaging = createMockMessaging();
+    const notificationService = new NotificationService(
+      new DeviceTokenRepository(ctx.dbAccessor),
+      messaging.messaging,
+      new SettingsService({ settingsRepo: new SettingsConfigurationRepository(ctx.dbAccessor) }),
+    );
+
+    const result = await notificationService.sendToUser(user.userId, {
+      category: NotificationCategory.AiInteraction,
+      title: "Action required",
+      body: "Approve this command",
+      collapseKey: null,
+    });
+
+    assert.equal(result.devicesNotified, 1, "an unmatched token must fail open rather than go silent");
+  });
+
+  it("rejects a server-originated category on the client send route", async () => {
+    const user = await ctx.createUser();
+
+    const response = await ctx.app.inject({
+      method: "POST",
+      url: "/notifications/send",
+      headers: { authorization: `Bearer ${user.accessToken}` },
+      payload: {
+        category: NotificationCategory.ConnectionStatus,
+        title: "Bridge Online",
+        body: "spoofed",
+        collapseKey: null,
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+  });
+});

--- a/tests/notifications/notification-service.test.ts
+++ b/tests/notifications/notification-service.test.ts
@@ -2,8 +2,18 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { describe, it } from "node:test";
 import type { Messaging } from "firebase-admin/messaging";
+import { NotificationCategory } from "../../src/models/notification.js";
 import type { DeviceTokenRepository } from "../../src/repositories/device-token-repo.js";
-import { NotificationService, type NotificationPayload } from "../../src/services/notification-service.js";
+import {
+  NotificationService,
+  type NotificationPayload,
+  type NotificationSettingsResolver,
+} from "../../src/services/notification-service.js";
+
+// These tokens carry no deviceId, so category filtering leaves them all deliverable.
+const allowAllSettings: NotificationSettingsResolver = {
+  resolveNotificationsByDevice: async () => new Map(),
+};
 
 type MockResponse = { success: boolean; error?: { code: string } };
 type MockToken = { userId: string; token: string; platform: string };
@@ -45,7 +55,7 @@ function createMockDeviceTokenRepo(tokens: MockToken[]) {
 }
 
 const payload: NotificationPayload = {
-  category: "updates",
+  category: NotificationCategory.SessionMessage,
   title: "New update",
   body: "You have a new message",
   collapseKey: "updates-collapse",
@@ -62,8 +72,8 @@ describe("NotificationService", () => {
     const tokenRepo = createMockDeviceTokenRepo([]);
     const messaging = createMockMessaging([]);
 
-    assert.equal(new NotificationService(tokenRepo.repo, messaging.messaging).isAvailable, true);
-    assert.equal(new NotificationService(tokenRepo.repo, null).isAvailable, false);
+    assert.equal(new NotificationService(tokenRepo.repo, messaging.messaging, allowAllSettings).isAvailable, true);
+    assert.equal(new NotificationService(tokenRepo.repo, null, allowAllSettings).isAvailable, false);
   });
 
   it("sends to all user tokens and returns success count", async () => {
@@ -72,7 +82,7 @@ describe("NotificationService", () => {
       { userId: "user-1", token: "token-b", platform: "android" },
     ]);
     const messaging = createMockMessaging([{ success: true }, { success: true }]);
-    const service = new NotificationService(tokenRepo.repo, messaging.messaging);
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, allowAllSettings);
 
     const result = await service.sendToUser("user-1", payload);
 
@@ -89,7 +99,7 @@ describe("NotificationService", () => {
   it("flattens projectId into FCM data payload", async () => {
     const tokenRepo = createMockDeviceTokenRepo([{ userId: "user-1", token: "token-a", platform: "ios" }]);
     const messaging = createMockMessaging([{ success: true }]);
-    const service = new NotificationService(tokenRepo.repo, messaging.messaging);
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, allowAllSettings);
 
     await service.sendToUser("user-1", payload);
 
@@ -105,7 +115,7 @@ describe("NotificationService", () => {
   it("sets a session-scoped Android tag and iOS apns-collapse-id from the collapse key", async () => {
     const tokenRepo = createMockDeviceTokenRepo([{ userId: "user-1", token: "token-a", platform: "android" }]);
     const messaging = createMockMessaging([{ success: true }]);
-    const service = new NotificationService(tokenRepo.repo, messaging.messaging);
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, allowAllSettings);
 
     await service.sendToUser("user-1", payload);
 
@@ -121,7 +131,7 @@ describe("NotificationService", () => {
   it("omits the Android tag and apns-collapse-id when the collapse key is empty", async () => {
     const tokenRepo = createMockDeviceTokenRepo([{ userId: "user-1", token: "token-a", platform: "android" }]);
     const messaging = createMockMessaging([{ success: true }]);
-    const service = new NotificationService(tokenRepo.repo, messaging.messaging);
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, allowAllSettings);
 
     await service.sendToUser("user-1", { ...payload, collapseKey: "" });
 
@@ -136,7 +146,7 @@ describe("NotificationService", () => {
   it("returns 0 and does not call messaging when user has no tokens", async () => {
     const tokenRepo = createMockDeviceTokenRepo([{ userId: "another-user", token: "token-x", platform: "ios" }]);
     const messaging = createMockMessaging([{ success: true }]);
-    const service = new NotificationService(tokenRepo.repo, messaging.messaging);
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, allowAllSettings);
 
     const result = await service.sendToUser("user-1", payload);
 
@@ -153,7 +163,7 @@ describe("NotificationService", () => {
       { success: true },
       { success: false, error: { code: "messaging/registration-token-not-registered" } },
     ]);
-    const service = new NotificationService(tokenRepo.repo, messaging.messaging);
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, allowAllSettings);
 
     const result = await service.sendToUser("user-1", payload);
 
@@ -173,7 +183,7 @@ describe("NotificationService", () => {
       { success: false, error: { code: "messaging/registration-token-not-registered" } },
       { success: false, error: { code: "messaging/invalid-registration-token" } },
     ]);
-    const service = new NotificationService(tokenRepo.repo, messaging.messaging);
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, allowAllSettings);
 
     const result = await service.sendToUser("user-1", payload);
 
@@ -199,7 +209,7 @@ describe("NotificationService", () => {
         };
       },
     } as unknown as Messaging;
-    const service = new NotificationService(tokenRepo.repo, messaging);
+    const service = new NotificationService(tokenRepo.repo, messaging, allowAllSettings);
 
     await assert.rejects(() => service.sendToUser("user-1", payload, abortController.signal), {
       name: "AbortError",
@@ -219,7 +229,7 @@ describe("NotificationService", () => {
       { success: true },
       { success: false, error: { code: "messaging/internal-error" } },
     ]);
-    const service = new NotificationService(tokenRepo.repo, messaging.messaging);
+    const service = new NotificationService(tokenRepo.repo, messaging.messaging, allowAllSettings);
 
     const originalWarn = console.warn;
     const warns: unknown[][] = [];
@@ -249,7 +259,7 @@ describe("NotificationService", () => {
 
   it("returns 0 when Firebase messaging is not configured", async () => {
     const tokenRepo = createMockDeviceTokenRepo([{ userId: "user-1", token: "token-a", platform: "ios" }]);
-    const service = new NotificationService(tokenRepo.repo, null);
+    const service = new NotificationService(tokenRepo.repo, null, allowAllSettings);
 
     const result = await service.sendToUser("user-1", payload);
 

--- a/tests/notifications/register-token-device-id-gate.test.ts
+++ b/tests/notifications/register-token-device-id-gate.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import Fastify, { type FastifyInstance, type FastifyRequest } from "fastify";
+import type { Config } from "../../src/config.js";
+import { ApiError } from "../../src/lib/errors.js";
+import type { AccessTokenPayload } from "../../src/models/jwt.js";
+import { DevicePlatform } from "../../src/models/device.js";
+import { notificationRoutes, type NotificationRouteOptions } from "../../src/routes/notifications.js";
+
+const USER_ID = "69b2aeaa1755fd6c00000001";
+const DEVICE_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+type Registration = { userId: string; token: string; deviceId?: string };
+
+// createTestApp resolves config through loadConfig(), which caches a
+// process-wide singleton, so the flag cannot be varied per app there. Mounting
+// the plugin directly is the only way to exercise both sides of the gate.
+async function buildApp(required: boolean): Promise<{ app: FastifyInstance; registrations: Registration[] }> {
+  const registrations: Registration[] = [];
+  const app = Fastify();
+
+  app.decorateRequest("user", null);
+  app.setErrorHandler((error, _request, reply) => {
+    if (error instanceof ApiError) {
+      return reply.status(error.errorCode).send({ error: error.message });
+    }
+
+    throw error;
+  });
+
+  const options = {
+    config: { AUTH_REQUIRE_DEVICE_ID_IN_TOKEN_REGISTRATION: required } as Config,
+    appClientPresenceService: {
+      registerToken: async (params: Registration) => {
+        registrations.push(params);
+      },
+    },
+    activationService: { recordAppSetup: async () => {} },
+    requireAuth: async (request: FastifyRequest) => {
+      request.user = { userId: USER_ID } as AccessTokenPayload;
+    },
+    requireRelayAuth: async () => {},
+  } as unknown as NotificationRouteOptions;
+
+  await app.register(notificationRoutes, options);
+  await app.ready();
+
+  return { app, registrations };
+}
+
+function registerToken(app: FastifyInstance, deviceId?: string) {
+  return app.inject({
+    method: "POST",
+    url: "/notifications/register-token",
+    payload: { token: "fcm-token", platform: DevicePlatform.ios, ...(deviceId ? { deviceId } : {}) },
+  });
+}
+
+describe("register-token deviceId gate", () => {
+  it("accepts a registration without a deviceId while the gate is off", async () => {
+    const { app, registrations } = await buildApp(false);
+
+    const response = await registerToken(app);
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(registrations.length, 1);
+    assert.equal(registrations[0]?.deviceId, undefined);
+    await app.close();
+  });
+
+  it("rejects a registration without a deviceId once the gate is on", async () => {
+    const { app, registrations } = await buildApp(true);
+
+    const response = await registerToken(app);
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(registrations.length, 0, "a rejected registration must not reach the presence service");
+    await app.close();
+  });
+
+  it("still accepts a registration that supplies a deviceId once the gate is on", async () => {
+    const { app, registrations } = await buildApp(true);
+
+    const response = await registerToken(app, DEVICE_ID);
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(registrations[0]?.deviceId, DEVICE_ID);
+    await app.close();
+  });
+
+  it("rejects a malformed deviceId regardless of the gate", async () => {
+    for (const required of [false, true]) {
+      const { app } = await buildApp(required);
+
+      const response = await registerToken(app, "not-a-uuid");
+
+      assert.equal(response.statusCode, 400, `malformed deviceId must be rejected with gate=${required}`);
+      await app.close();
+    }
+  });
+});

--- a/tests/repositories/settings-configuration-repo.test.ts
+++ b/tests/repositories/settings-configuration-repo.test.ts
@@ -28,6 +28,30 @@ describe("SettingsConfigurationRepository", () => {
     assert.equal(compoundIndex.unique, true);
   });
 
+  it("findByUserId returns only the calling user's devices", async () => {
+    const owner = await ctx.createUser();
+    const other = await ctx.createUser();
+    const repo = new SettingsConfigurationRepository(ctx.dbAccessor);
+    const firstDevice = randomUUID();
+    const secondDevice = randomUUID();
+
+    await repo.upsert(owner.userId, firstDevice, { notifications: { aiInteraction: false } });
+    await repo.upsert(owner.userId, secondDevice, { notifications: { systemUpdate: false } });
+    await repo.upsert(other.userId, randomUUID(), { notifications: { aiInteraction: false } });
+
+    const documents = await repo.findByUserId(owner.userId);
+
+    assert.deepEqual(documents.map((document) => document.deviceId).sort(), [firstDevice, secondDevice].sort());
+    assert.ok(documents.every((document) => document.userId.toHexString() === owner.userId));
+  });
+
+  it("findByUserId returns an empty list for an invalid or unknown user", async () => {
+    const repo = new SettingsConfigurationRepository(ctx.dbAccessor);
+
+    assert.deepEqual(await repo.findByUserId("not-an-object-id"), []);
+    assert.deepEqual(await repo.findByUserId("69b2aeaa1755fd6c00000000"), []);
+  });
+
   it("upsert creates a sparse document scoped to the user and device", async () => {
     const user = await ctx.createUser();
     const repo = new SettingsConfigurationRepository(ctx.dbAccessor);

--- a/tests/services/activation-reminder-service.test.ts
+++ b/tests/services/activation-reminder-service.test.ts
@@ -79,7 +79,14 @@ function createNotification(args?: {
   const sendCalls: SendCall[] = [];
   const service = {
     isAvailable: args?.available ?? true,
-    sendToUser: async (userId: string, payload: NotificationPayload, abortSignal?: AbortSignal) => {
+    // Reminders deliberately use the unfiltered path; a plain sendToUser here
+    // would let the service silently regress to honouring the systemUpdate
+    // toggle without any test noticing.
+    sendToUserIgnoringDeviceSettings: async (
+      userId: string,
+      payload: NotificationPayload,
+      abortSignal?: AbortSignal,
+    ) => {
       sendCalls.push({ userId, payload, abortSignal });
       return args?.send?.(userId, payload, abortSignal) ?? { devicesNotified: 1, retryableFailures: 0 };
     },

--- a/tests/services/activation-reminder-service.test.ts
+++ b/tests/services/activation-reminder-service.test.ts
@@ -79,14 +79,7 @@ function createNotification(args?: {
   const sendCalls: SendCall[] = [];
   const service = {
     isAvailable: args?.available ?? true,
-    // Reminders deliberately use the unfiltered path; a plain sendToUser here
-    // would let the service silently regress to honouring the systemUpdate
-    // toggle without any test noticing.
-    sendToUserIgnoringDeviceSettings: async (
-      userId: string,
-      payload: NotificationPayload,
-      abortSignal?: AbortSignal,
-    ) => {
+    sendToUser: async (userId: string, payload: NotificationPayload, abortSignal?: AbortSignal) => {
       sendCalls.push({ userId, payload, abortSignal });
       return args?.send?.(userId, payload, abortSignal) ?? { devicesNotified: 1, retryableFailures: 0 };
     },


### PR DESCRIPTION
Filters push notifications against the per-device notification toggles from #46 before forwarding them to Firebase.

## What was already in place

The bridge **already sends `category`** on every `POST /notifications/send`, and the client **already has a `deviceId`** (UUIDv4, secure storage, validated with the same regex as `deviceIdSchema`) which it already uses for `GET`/`PATCH /auth/settings/{deviceId}`. The categories map 1:1 to the settings toggles — only the naming convention differed:

| Wire category | Settings toggle | Origin |
|---|---|---|
| `ai_interaction` | `aiInteraction` | Bridge |
| `session_message` | `sessionMessage` | Bridge |
| `system_update` | `systemUpdate` | Bridge + activation reminders |
| `connection_status` | `connectionStatus` | Server (bridge connect/disconnect) |

## The gap this closes

Settings are keyed `(userId, deviceId)`; FCM tokens were keyed `(userId, token)` with **no `deviceId`**. `sendToUser` fanned out to every token, so the server could not tell which settings document governed which token.

`deviceTokens` now stores the `deviceId`, supplied via an optional field on `register-token`. That single field is the join key.

## Changes

- **`NotificationCategory` enum** replaces scattered string literals. `NOTIFICATION_CATEGORY_SETTING_KEYS` is typed `Record<NotificationCategory, NotificationSettingKey>`, so a new category cannot compile until it is mapped to a toggle that can silence it.
- **Filtering lives only in `NotificationService.sendToUser`** — the one choke point all three producers share, so bridge sends, connection-status notifications and activation reminders are all covered without duplicating the rule.
- **One settings query per send**, served by the existing `(userId, deviceId)` unique index as a prefix scan — not one lookup per device.
- **Stale-token cleanup fixed**: FCM responses are positional, so cleanup now indexes the *filtered* list. Against the unfiltered list it would have deleted the wrong device's token. Covered by a regression test.

## Rollout — `deviceId` is optional on purpose

Mirrors the `AUTH_REQUIRE_BRIDGE_ID_IN_STATUS` precedent:

1. **This PR** — server accepts and stores `deviceId`; tokens that have one are filtered, tokens without **fail open and keep delivering**. Existing installs behave exactly as before.
2. **Client** — starts sending `deviceId` on `register-token` (it already holds the value).
3. **Later** — tighten once clients have rolled over.

Failing open is deliberate: an unmatched token cannot be resolved to a preference, and silently muting every pre-rollout install would be far worse than an unwanted notification.

A token that changes owner has its `deviceId` cleared, so a recycled token is never filtered against the previous account's settings.

## Product behaviour to note

Activation reminders send `system_update`, so **a user who disables System Updates now stops receiving them**. When every device opts out, `sendToUser` returns `devicesNotified: 0` without calling FCM, and `ActivationReminderService` treats that as a genuine zero-device result and marks the reminder complete rather than retrying forever. This was an explicit decision.

## Verification

- **End-to-end** (`notification-filtering-e2e.test.ts`): registers a token through the real `POST /notifications/register-token`, flips the toggle through the real `PATCH /auth/settings/:deviceId`, and asserts delivery stops and resumes against real MongoDB. Also asserts a legacy token keeps delivering, and that a client cannot send the server-only `connection_status` (400).
- **Unit** (`notification-category-filtering.test.ts`): per-device isolation, fail-open, defaults, `connection_status`, `system_update`, stale-token index mapping, and no settings query when the user has no tokens.
- **Repository**: `deviceId` persisted, defaulted, preserved when omitted, and cleared on owner change.
- `npm test` — 549 tests, 548 pass, 0 fail, 1 pre-existing skip
- `npm run build` / `lint` / `format:check` / `circular-dependencies` — all clean

## Client follow-up

To take full effect, the client needs to include its existing `deviceId` in the `register-token` body. No other client change is required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters push notifications per device so only opted‑in devices receive each category. Activation reminders respect device settings; the API and delivery path are hardened.

- **New Features**
  - Centralized per-device filtering in `NotificationService.sendToUser` using `NotificationCategory` and `NOTIFICATION_CATEGORY_SETTING_KEYS`.
  - `deviceTokens` store optional `deviceId` from `POST /notifications/register-token`; tokens without it keep delivering (fail open); owner changes clear `deviceId`.
  - Activation reminders send `system_update` and respect the `systemUpdate` toggle.
  - API/hardening: `register-token` accepts `deviceId?`; `POST /notifications/send` only allows client categories and rejects `connection_status`. Outbound category is forced to the top-level enum and ignores `data.category`. Settings read failures deliver unfiltered and log.
  - Gate: `AUTH_REQUIRE_DEVICE_ID_IN_TOKEN_REGISTRATION` can require `deviceId` on `register-token` (400 when missing). Defaults to `false` for rollout.
  - Stale-token cleanup indexes the filtered list to delete the correct token.
  - Perf: skip the settings lookup when no token has a `deviceId`, removing a DB round trip during rollout.

- **Migration**
  - Clients should include their existing `deviceId` when calling `POST /notifications/register-token`. After rollout, set `AUTH_REQUIRE_DEVICE_ID_IN_TOKEN_REGISTRATION=true` to enforce it.

<sup>Written for commit ce45cecbf49e0f171d95a22a2f2b7fff788a91ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

