### PR TITLE
chore(agents): switch aristotle reviewers to 9router/generic-mid

### DIFF
--- a/.opencode/agents/aristotle-impl-review.md
+++ b/.opencode/agents/aristotle-impl-review.md
@@ -2,9 +2,7 @@
 name: aristotle-impl-review
 description: Reviews changed code, branches, and PRs against strict architectural, security, persistence, compatibility, and operational rules for the Sesori auth server. Rejects misplaced Fastify/MongoDB concerns, unvalidated boundaries, unsafe OAuth/JWT changes, process-local scaling mistakes, speculative abstractions, and uncoordinated apps/relay contract changes. Reviews only new or changed code and always runs before a PR is opened.
 mode: subagent
-model: openai/gpt-5.6-sol
-variant: high
-temperature: 0.1
+model: 9router/generic-mid
 permission:
   "*": deny
   read:

--- a/.opencode/agents/aristotle-plan-review.md
+++ b/.opencode/agents/aristotle-plan-review.md
@@ -2,9 +2,7 @@
 name: aristotle-plan-review
 description: Reviews implementation plans against strict architectural, security, persistence, compatibility, and operational rules for the Sesori auth server. Rejects vague plans, misplaced Fastify/MongoDB concerns, unvalidated boundaries, unsafe OAuth/JWT changes, process-local scaling mistakes, speculative abstractions, and uncoordinated apps/relay contract changes. Input must contain a clear goal and concrete implementation steps. Always invoke before implementation begins.
 mode: subagent
-model: openai/gpt-5.6-sol
-variant: high
-temperature: 0.1
+model: 9router/generic-mid
 permission:
   "*": deny
   read:


### PR DESCRIPTION
## What

Switches both Aristotle review-gate agents (`aristotle-plan-review`, `aristotle-impl-review`) from `openai/gpt-5.6-sol` to `9router/generic-mid`.

The `variant: high` and `temperature: 0.1` overrides are removed **intentionally** — the new model runs with its provider defaults rather than carrying over tuning chosen for the previous model.

## Why

Cost/speed: the review gates are invoked repeatedly during plan and implementation iteration. The mid-tier model was validated in practice on the `real-time-transcription` plan review (#59): it produced multi-round rejections with concrete, code-verified findings and a final approval consistent with the gate's rubric.

## Impact

- Tooling-only change under `.opencode/agents/`; no product code, config, or CI behavior.
- Affects anyone running the Aristotle gates from this repo — review quality now depends on `9router/generic-mid`.
- Rollback is a one-line revert of the `model:` field per agent.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch both Aristotle review gates (`aristotle-plan-review`, `aristotle-impl-review`) from `openai/gpt-5.6-sol` to `9router/generic-mid`, removing `variant: high` and `temperature: 0.1` to use provider defaults. Lowers cost and speeds up repeated reviews; tooling-only change under `.opencode/agents/` with no product code impact.

<sup>Written for commit aa8706f2721400de7054a2c9ad5985340546c61c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

