### PR TITLE
[real-time-transcription] Project-scope the glossary runtime [S01-W01-P01]

### DIFF
--- a/.plan/active/real-time-transcription/TRACKER.md
+++ b/.plan/active/real-time-transcription/TRACKER.md
@@ -12,8 +12,8 @@
 ## Current Pointer
 
 - **Stage:** S01
-- **Wave:** W01
-- **Next action:** After the plan PR merges, pin the S01/W01 auth `master` baseline after drift assessment, then begin S01-W01-P01.
+- **Wave:** W02
+- **Next action:** After S01-W01-P01 merges, pin the S01/W02 auth `master` baseline after drift assessment, then begin S01-W02-P01.
 
 ## Plan Review
 
@@ -27,7 +27,7 @@
 
 | Stage | Wave | Repository | Base | Pinned SHA | Drift Decision |
 |---|---|---|---|---|---|
-| S01 | W01 | `sesori-ai/sesori_auth_server` | `master` | — | Not started |
+| S01 | W01 | `sesori-ai/sesori_auth_server` | `master` | `287abb307f1e1cbd77c19bb81030b11749ff351b` | Assessed 2026-08-06: drift from the audited `9cc4953` tip is the merged plan-definition PR #59 only, which adds `.plan/active/real-time-transcription/` documentation and no runtime, schema, route, or composition change. Audited baseline remains valid. |
 | S01 | W02 | `sesori-ai/sesori_auth_server` | `master` | — | Not started |
 | S02 | W01 | `sesori-ai/sesori_auth_server` | `master` | — | Not started |
 | S03 | W01 | `sesori-ai/sesori_apps_monorepo` | `main` | — | Not started |
@@ -36,7 +36,7 @@
 
 | Done | ID | Stage | Wave | PR | Branch | Notes |
 |---|---|---|---|---|---|---|
-| [ ] | S01-W01-P01 | S01 | W01 | — | `plan/real-time-transcription/s01-w01-p01-project-scope-glossary` | Auth: scoped glossary runtime and migration-ready index config |
+| [ ] | S01-W01-P01 | S01 | W01 | — | `real-time-config-next-step` | Auth: scoped glossary runtime and migration-ready index config. Implemented on the session-provided worktree branch instead of the planned branch name. |
 | [ ] | S01-W02-P01 | S01 | W02 | — | `plan/real-time-transcription/s01-w02-p01-provider-neutral-async-soniox` | Auth: provider boundary, Soniox async, legal/config/cleanup |
 | [ ] | S02-W01-P01 | S02 | W01 | — | `plan/real-time-transcription/s02-w01-p01-realtime-voice-proxy` | Auth: protocol v1 proxy and minimal shutdown |
 | [ ] | S03-W01-P01 | S03 | W01 | — | `plan/real-time-transcription/s03-w01-p01-stream-mobile-voice` | Apps: PCM streaming, preview, commit, async fallback |
@@ -56,6 +56,8 @@
 
 ## Findings and Plan Deltas
 
+- 2026-08-06 — S01-W01-P01 implementation review found one blocking defect and it was fixed before the PR: rewriting the multipart reader initially caught `FST_REQ_FILE_TOO_LARGE` inside the route and reported an oversized upload as HTTP 400 instead of the shipped 413. The reader now rethrows that framework error and a regression test asserts the preserved 413.
+- 2026-08-06 — S01-W01-P01 implemented. Deltas from the step file: the live `GlossaryEntry` schema is now strict and the migration-only project-scoped schema aliases it rather than re-extending a non-strict base, so one shape owns scoped documents; `src/db/glossary-index-migration.ts` needed no change; and the work uses the session-provided worktree branch. The repository fails closed on malformed persisted documents through `glossaryEntrySchema.safeParse` and returns `InternalServerError` without document content. Legacy unscoped rows are unreachable through scoped reads rather than erroring, so a stale row cannot break a valid project read.
 - 2026-08-06 — PR #59 bot review feedback addressed: re-review date sync, post-merge next-action pointer, reuse of shipped `createRequestCloseSignal` for async cancellation, no-user-ID quota-race logging with regression test, admission-fixed realtime cap without mid-session usage re-reads, explicit staging Soniox/realtime enablement steps, and a production realtime rollback rehearsal. Sixth `aristotle-plan-review` round re-APPROVED; digest refreshed.
 - 2026-08-06 — Fifth `aristotle-plan-review` round APPROVED the plan. All six fourth-round corrections were verified concretely present and consistent with shipped code, the record 7.1.1 SDK, CI workflows, and pinned baselines; digest recorded.
 - 2026-08-04 — Fourth `aristotle-plan-review` rejected six residual contradictions. The plan now gives the pre-auth limiter a named middleware and `src/index.ts` composition owner with corrected hook order; assigns retry headers solely to `src/server.ts`; atomically stops bridge admission and awaits tracker cleanup; uses a recorder start-paused/effective-config-before-start-frame sequence; clamps overshot glossary capacity at zero; and preserves shipped OpenAI HTTP 500 failures through an exact compatibility-marked mapping while Soniox uses detailed errors.

--- a/README.md
+++ b/README.md
@@ -198,18 +198,31 @@ Glossary ownership uses an opaque, stable client-derived project key rather than
 a filesystem path or raw bridge project ID:
 
 ```text
-digestInput = "sesori-project-glossary-v1\0" + bridgeId + "\0" + projectId
+digestInput = "sesori-project-glossary-v1\0" + projectId
 projectKey = "prj_v1_" + base64url(sha256(utf8(digestInput)))
 ```
 
 The result is exactly `prj_v1_` plus a 43-character unpadded base64url digest.
-Including the bridge ID separates bridge-local project namespaces; using stable
-`Project.id` keeps the key unchanged when a directory moves. The server validates
-only this opaque shape and scopes it to the authenticated user. It never accepts
-or persists a raw path for glossary ownership.
+The canonical cross-repository vector is project ID `project-123` →
+`prj_v1_xgjNDm_yyduAKisFHr498ZgcjIU1FACdyEj68wSmbhc`. Using stable `Project.id`
+keeps the key unchanged when a directory moves. The server validates only this
+opaque shape and scopes it to the authenticated user; the key is not an
+authorization credential. It never accepts or persists a raw path for glossary
+ownership. Equal project IDs on two bridges deliberately share one glossary for
+that user, because the composer flow does not carry bridge identity.
 
-PR1 adds a migration command but does not change live glossary behavior or the
-startup index configuration. The command defaults to a read-only dry-run and
+Glossary CRUD requires a project key: `GET /voice/glossary?projectKey=…` and
+`POST`/`DELETE /voice/glossary` with `{ projectKey, words }`. `POST
+/voice/transcribe` accepts an optional `projectKey` multipart field; omission
+means no glossary context is applied and never falls back to a global glossary.
+Safety caps are 100 words per request, 500 per project, 5,000 per user, 200
+characters per word, and an 8,000-character provider context. Caps are checked
+per request rather than serialized, so concurrent requests may narrowly exceed
+them; the compound unique index still prevents duplicates.
+
+The scoped runtime and the `{userId, projectKey, word}` startup index
+configuration ship together; the previously merged migration command owns the
+destructive index cutover. The command defaults to a read-only dry-run and
 reports only counts and closed state enums, never words, user IDs, project keys,
 documents, or index names:
 
@@ -225,12 +238,12 @@ collation, index mismatch, or `repair_required` outcome stops the rollout and
 requires a separately reviewed data/index plan. Do not infer a project key or
 delete production terms ad hoc.
 
-Do **not** run `--apply` from the PR1 deployment. Mutation waits until the reviewed
-PR2 artifact is ready and auth is in a maintenance window. For that cutover:
+Do **not** deploy the scoped runtime before applying the index. Mutation happens
+with the single auth instance stopped, in a maintenance window. For that cutover:
 
 1. Remove the single auth instance from ingress, stop it, and confirm no glossary
    writer remains. Permit exactly one migration command and no manual index DDL.
-2. Run `--apply` from the reviewed PR2 artifact:
+2. Run `--apply` from the reviewed scoped-runtime artifact:
 
    ```bash
    sops exec-env env/app/prod.env \
@@ -244,7 +257,7 @@ PR2 artifact is ready and auth is in a maintenance window. For that cutover:
    - `repair_required`: do not rerun blindly or start either binary. Restore DB
      observability if needed and obtain a separately reviewed repair.
 4. Run `--verify` and require target `exact`, legacy `absent`, every invalid/
-   duplicate count zero, and `completed` before starting PR2:
+   duplicate count zero, and `completed` before starting the scoped runtime:
 
    ```bash
    sops exec-env env/app/prod.env \
@@ -258,8 +271,8 @@ audit again. An exact-both interruption is resumable. Post-drop invalid data,
 mismatched DDL, or unknown state is `repair_required`, not automatically
 recoverable.
 
-Rollback is allowed only while the glossary collection is empty. If PR2 fails
-before any project-scoped term is written, keep it stopped and run:
+Rollback is allowed only while the glossary collection is empty. If the scoped
+runtime fails before any project-scoped term is written, keep it stopped and run:
 
 ```bash
 sops exec-env env/app/prod.env \
@@ -269,7 +282,7 @@ sops exec-env env/app/prod.env \
 Require the rollback report itself to show legacy `exact`, target `absent`, zero
 documents, and `completed` before restoring the old binary. Do not use forward
 `--verify` after rollback. Once any scoped term exists, rollback is forbidden;
-repair or roll forward with PR2.
+repair or roll forward with the scoped runtime.
 
 ## Activation backfill
 
@@ -447,7 +460,7 @@ the restricted target dataset/table and deletion identity exist.
 | `npm run backfill-product-analytics-preference` | Validate preference migration; pass `-- --apply` to persist bounded batches |
 | `npm run export-product-analytics` | Run one isolated auth-private export using ADC (unscheduled until analytics IAM exists) |
 | `npm run suppress-product-analytics-export` | Read one protected suppression request from stdin and hand off a restricted deletion target |
-| `npm run migrate-project-glossary-index` | Dry-run glossary index migration; mutation flags require the documented PR2 maintenance window |
+| `npm run migrate-project-glossary-index` | Dry-run glossary index migration; mutation flags require the documented maintenance window |
 
 ## Project structure
 

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -85,10 +85,14 @@ export function indexMatchesDesired(existing: Record<string, unknown>, desired: 
 }
 
 /**
- * Exact-metadata check for the project-scoped glossary index. `indexMatchesDesired`
- * compares only key and `unique`, so a sparse, partial, hidden, or non-simple
- * collated index would pass it while changing duplicate semantics. The startup
- * guard must accept exactly what the migration command accepts.
+ * Rejects every glossary target-index option that changes duplicate or lookup
+ * semantics; `indexMatchesDesired` compares only key and `unique`, which is too
+ * weak for this guard. This deliberately covers semantics, not the migration's
+ * complete metadata audit: `--verify` additionally rejects `v: 1`, storage-engine
+ * options, and type-specific fields, all of which leave duplicate behavior
+ * unchanged. Startup therefore never accepts an index whose behavior differs
+ * from the migrated state, but the operator command remains the authority on
+ * exact index shape. Keep these predicates aligned when either side changes.
  */
 function isExactGlossaryTargetIndex(index: Record<string, unknown>): boolean {
   const collation = index.collation as { locale?: unknown } | undefined;
@@ -163,9 +167,22 @@ export class MongoDbAccessor {
           const legacyIndex = currentIndexes.find((index) =>
             indexKeyMatches(index.key as IndexSpecification, { userId: 1, word: 1 }),
           );
-          const targetExists = currentIndexes.some((index) => isExactGlossaryTargetIndex(index));
+          // Exactly one index may own the target key: duplicates on the same key
+          // are a mismatched cutover state that `--verify` also refuses.
+          const targetKeyIndexes = currentIndexes.filter((index) =>
+            indexKeyMatches(index.key as IndexSpecification, { userId: 1, projectKey: 1, word: 1 }),
+          );
+          const targetExists = targetKeyIndexes.length === 1 && isExactGlossaryTargetIndex(targetKeyIndexes[0]);
+          // A non-simple default collation is inherited by lookups such as the
+          // repository's `word: { $in: [...] }` delete, silently changing match
+          // semantics, so the collection itself must be simple.
+          const [collectionMetadata] = await db
+            .listCollections({ name: collectionName }, { nameOnly: false })
+            .toArray();
+          const collectionLocale = collectionMetadata?.options?.collation?.locale;
+          const collationIsSimple = collectionLocale === undefined || collectionLocale === "simple";
 
-          if (legacyIndex || !targetExists) {
+          if (legacyIndex || !targetExists || !collationIsSimple) {
             throw new Error(
               "Glossary index migration incomplete: expected only the unique {userId, projectKey, word} index. " +
                 "Run `npm run migrate-project-glossary-index -- --apply` with this instance stopped, then --verify.",

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -132,6 +132,28 @@ export class MongoDbAccessor {
           }
         }
 
+        // A partial glossary cutover leaves the legacy {userId, word} unique
+        // index in place, which rejects the same term in a second project and
+        // makes the repository report it as an ordinary duplicate — silent word
+        // loss. Refuse to serve until the operator migration finished. Index
+        // ownership stays with the migration command; startup never drops here.
+        if (dbName === MongoDbDatabase.Auth && collectionName === AuthDbCollection.GlossaryEntries) {
+          const currentIndexes = await collection.indexes();
+          const legacyIndex = currentIndexes.find((index) =>
+            indexKeyMatches(index.key as IndexSpecification, { userId: 1, word: 1 }),
+          );
+          const targetExists = currentIndexes.some((index) =>
+            indexMatchesDesired(index, { spec: { userId: 1, projectKey: 1, word: 1 }, options: { unique: true } }),
+          );
+
+          if (legacyIndex || !targetExists) {
+            throw new Error(
+              "Glossary index migration incomplete: expected only the unique {userId, projectKey, word} index. " +
+                "Run `npm run migrate-project-glossary-index -- --apply` with this instance stopped, then --verify.",
+            );
+          }
+        }
+
         // The compound lookup index supersedes PR1's user-only token index.
         // Drop the old index only after confirming its replacement exists.
         if (dbName === MongoDbDatabase.Auth && collectionName === AuthDbCollection.DeviceTokens) {

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -84,6 +84,27 @@ export function indexMatchesDesired(existing: Record<string, unknown>, desired: 
   return true;
 }
 
+/**
+ * Exact-metadata check for the project-scoped glossary index. `indexMatchesDesired`
+ * compares only key and `unique`, so a sparse, partial, hidden, or non-simple
+ * collated index would pass it while changing duplicate semantics. The startup
+ * guard must accept exactly what the migration command accepts.
+ */
+function isExactGlossaryTargetIndex(index: Record<string, unknown>): boolean {
+  const collation = index.collation as { locale?: unknown } | undefined;
+
+  return (
+    indexKeyMatches(index.key as IndexSpecification, { userId: 1, projectKey: 1, word: 1 }) &&
+    index.unique === true &&
+    index.sparse !== true &&
+    index.hidden !== true &&
+    index.prepareUnique !== true &&
+    index.partialFilterExpression === undefined &&
+    index.expireAfterSeconds === undefined &&
+    (collation === undefined || collation.locale === "simple")
+  );
+}
+
 export class MongoDbAccessor {
   readonly #connector: MongoDbConnector;
 
@@ -142,9 +163,7 @@ export class MongoDbAccessor {
           const legacyIndex = currentIndexes.find((index) =>
             indexKeyMatches(index.key as IndexSpecification, { userId: 1, word: 1 }),
           );
-          const targetExists = currentIndexes.some((index) =>
-            indexMatchesDesired(index, { spec: { userId: 1, projectKey: 1, word: 1 }, options: { unique: true } }),
-          );
+          const targetExists = currentIndexes.some((index) => isExactGlossaryTargetIndex(index));
 
           if (legacyIndex || !targetExists) {
             throw new Error(

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -105,8 +105,17 @@ function isExactGlossaryTargetIndex(index: Record<string, unknown>): boolean {
     index.prepareUnique !== true &&
     index.partialFilterExpression === undefined &&
     index.expireAfterSeconds === undefined &&
-    (collation === undefined || collation.locale === "simple")
+    isSimpleCollationLocale(collation?.locale)
   );
+}
+
+/**
+ * Binary/simple collation is the only accepted state for the glossary index and
+ * its collection: anything else changes term comparison. Mirrors
+ * `isSimpleCollation` in glossary-index-migration.ts.
+ */
+function isSimpleCollationLocale(locale: unknown): boolean {
+  return locale === undefined || locale === "simple";
 }
 
 export class MongoDbAccessor {
@@ -180,7 +189,7 @@ export class MongoDbAccessor {
             .listCollections({ name: collectionName }, { nameOnly: false })
             .toArray();
           const collectionLocale = collectionMetadata?.options?.collation?.locale;
-          const collationIsSimple = collectionLocale === undefined || collectionLocale === "simple";
+          const collationIsSimple = isSimpleCollationLocale(collectionLocale);
 
           if (legacyIndex || !targetExists || !collationIsSimple) {
             throw new Error(

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -30,7 +30,7 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
         { spec: { email: 1 }, options: { unique: true } },
         { spec: { userId: 1 }, options: { unique: true } },
       ],
-      [AuthDbCollection.GlossaryEntries]: [{ spec: { userId: 1, word: 1 }, options: { unique: true } }],
+      [AuthDbCollection.GlossaryEntries]: [{ spec: { userId: 1, projectKey: 1, word: 1 }, options: { unique: true } }],
       [AuthDbCollection.DailyUsage]: [{ spec: { userId: 1, date: 1 }, options: { unique: true } }],
       [AuthDbCollection.DeviceTokens]: [
         { spec: { token: 1 }, options: { unique: true } },

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { NotificationService } from "./services/notification-service.js";
 import { PendingAuthStore } from "./services/pending-auth-store.js";
 import { SessionMetadataService } from "./services/session-metadata-service.js";
 import { TokenService } from "./services/token-service.js";
+import { GlossaryService } from "./services/glossary-service.js";
 import { VoiceService } from "./services/voice-service.js";
 import { AppClientPresenceService } from "./services/app-client-presence-service.js";
 import { ProductAnalyticsPreferenceService } from "./services/product-analytics-preference-service.js";
@@ -147,7 +148,8 @@ async function main() {
     deviceTokenRepo,
     bridgeService,
   });
-  const voiceService = new VoiceService({ openai, glossaryRepo, dailyUsageRepo });
+  const glossaryService = new GlossaryService({ glossaryRepo });
+  const voiceService = new VoiceService({ openai, glossaryService, dailyUsageRepo });
 
   const sessionMetadataService = new SessionMetadataService({
     openai,
@@ -167,6 +169,7 @@ async function main() {
     bridgeService,
     tokenService,
     voiceService,
+    glossaryService,
     sessionMetadataService,
     installScriptService,
     legalDocumentService,

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -200,6 +200,7 @@ export type GlossaryListReply = {
 };
 
 export type GlossaryAddBody = {
+  projectKey: string;
   words: string[];
 };
 
@@ -208,7 +209,12 @@ export type GlossaryAddReply = {
 };
 
 export type GlossaryRemoveBody = {
+  projectKey: string;
   words: string[];
+};
+
+export type GlossaryListQuery = {
+  projectKey: string;
 };
 
 export type GlossaryRemoveReply = {

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -58,20 +58,21 @@ export const passwordAccountInputSchema = passwordAccountSchema.omit({
 
 export type PasswordAccountInput = z.infer<typeof passwordAccountInputSchema>;
 
-export const glossaryEntrySchema = z.object({
-  _id: z.instanceof(ObjectId),
-  userId: z.instanceof(ObjectId),
-  word: z.string(),
-  createdAt: z.date(),
-});
+export const glossaryEntrySchema = z
+  .object({
+    _id: z.instanceof(ObjectId),
+    userId: z.instanceof(ObjectId),
+    projectKey: projectKeySchema,
+    word: z.string(),
+    createdAt: z.date(),
+  })
+  .strict();
 
 export type GlossaryEntry = z.infer<typeof glossaryEntrySchema>;
 
 // COMPATIBILITY 2026-08-02 (v0.1.0): Supports auditing pre-PR2 unscoped glossary documents during project-scope cutover and rollback. After PR2 is verified in production, its rollback window closes, and no pre-PR2 binary can be deployed, remove this schema; the legacy document audit, index constants/classification, apply-drop, and rollback paths in glossary-index-migration.ts; the CLI rollback mode/runbook if no longer operationally needed; and their model/migration tests.
-export const legacyGlossaryEntryMigrationSchema = glossaryEntrySchema.strict();
-export const projectScopedGlossaryEntryMigrationSchema = glossaryEntrySchema
-  .extend({ projectKey: projectKeySchema })
-  .strict();
+export const legacyGlossaryEntryMigrationSchema = glossaryEntrySchema.omit({ projectKey: true });
+export const projectScopedGlossaryEntryMigrationSchema = glossaryEntrySchema;
 
 export const dailyUsageSchema = z.object({
   _id: z.instanceof(ObjectId),

--- a/src/models/voice.ts
+++ b/src/models/voice.ts
@@ -6,3 +6,29 @@ export const projectKeySchema = z
   .brand<"ProjectKey">();
 
 export type ProjectKey = z.infer<typeof projectKeySchema>;
+
+export const glossaryWordSchema = z.string().trim().min(1).max(200);
+
+export const glossaryWordsSchema = z.array(glossaryWordSchema).min(1).max(100);
+
+export const glossaryAddBodySchema = z
+  .object({
+    projectKey: projectKeySchema,
+    words: glossaryWordsSchema,
+  })
+  .strict();
+
+export const glossaryRemoveBodySchema = glossaryAddBodySchema;
+
+export const glossaryListQuerySchema = z
+  .object({
+    projectKey: projectKeySchema,
+  })
+  .strict();
+
+export const transcribeMultipartSchema = z
+  .object({
+    // COMPATIBILITY 2026-08-06 (v0.1.0): Apps at or before 1.6.1 omit projectKey from multipart transcription requests. Require it after every supported app sends project context.
+    projectKey: projectKeySchema.optional(),
+  })
+  .strict();

--- a/src/repositories/glossary-entry-repo.ts
+++ b/src/repositories/glossary-entry-repo.ts
@@ -1,9 +1,12 @@
 import { Collection, MongoBulkWriteError, ObjectId } from "mongodb";
+import { z } from "zod";
 import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
 import { glossaryEntrySchema, type GlossaryEntry } from "../models/documents.js";
 import type { ProjectKey } from "../models/voice.js";
 import { InternalServerError } from "../lib/errors.js";
 import { MongoDbDatabase, AuthDbCollection } from "../types/mongo.js";
+
+const countSchema = z.number().int().nonnegative().safe();
 
 export class GlossaryEntryRepository {
   readonly #collection: Collection<GlossaryEntry>;
@@ -12,21 +15,31 @@ export class GlossaryEntryRepository {
     this.#collection = accessor.getCollection<GlossaryEntry>(MongoDbDatabase.Auth, AuthDbCollection.GlossaryEntries);
   }
 
-  async findByUserAndProject(args: { userId: string; projectKey: ProjectKey }): Promise<GlossaryEntry[]> {
+  /** Returns the project's words. Documents stay inside the repository boundary. */
+  async findWordsByUserAndProject(args: { userId: string; projectKey: ProjectKey }): Promise<string[]> {
     const entries = await this.#collection
       .find({ userId: new ObjectId(args.userId), projectKey: args.projectKey })
       .sort({ word: 1 })
       .toArray();
 
-    return entries.map((entry) => this.#parseEntry(entry));
+    return entries.map((entry) => this.#parseEntry(entry).word);
   }
 
   async countByUserAndProject(args: { userId: string; projectKey: ProjectKey }): Promise<number> {
-    return this.#collection.countDocuments({ userId: new ObjectId(args.userId), projectKey: args.projectKey });
+    return this.#parseCount(
+      await this.#collection.countDocuments({ userId: new ObjectId(args.userId), projectKey: args.projectKey }),
+    );
   }
 
-  async countByUserId(userId: string): Promise<number> {
-    return this.#collection.countDocuments({ userId: new ObjectId(userId) });
+  /**
+   * Counts a user's project-scoped terms. Unscoped legacy documents are excluded
+   * because scoped CRUD cannot list or delete them, so they must not permanently
+   * consume the per-user capacity.
+   */
+  async countScopedByUserId(userId: string): Promise<number> {
+    return this.#parseCount(
+      await this.#collection.countDocuments({ userId: new ObjectId(userId), projectKey: { $type: "string" } }),
+    );
   }
 
   async insertMany(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<string[]> {
@@ -70,7 +83,16 @@ export class GlossaryEntryRepository {
       projectKey,
       word: { $in: words },
     });
-    return result.deletedCount;
+    return this.#parseCount(result.deletedCount);
+  }
+
+  #parseCount(value: unknown): number {
+    const result = countSchema.safeParse(value);
+    if (!result.success) {
+      throw new InternalServerError({ debugMessage: "Invalid glossary count result" });
+    }
+
+    return result.data;
   }
 
   #parseEntry(entry: unknown): GlossaryEntry {

--- a/src/repositories/glossary-entry-repo.ts
+++ b/src/repositories/glossary-entry-repo.ts
@@ -1,6 +1,8 @@
 import { Collection, MongoBulkWriteError, ObjectId } from "mongodb";
 import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
-import type { GlossaryEntry } from "../models/documents.js";
+import { glossaryEntrySchema, type GlossaryEntry } from "../models/documents.js";
+import type { ProjectKey } from "../models/voice.js";
+import { InternalServerError } from "../lib/errors.js";
 import { MongoDbDatabase, AuthDbCollection } from "../types/mongo.js";
 
 export class GlossaryEntryRepository {
@@ -10,26 +12,35 @@ export class GlossaryEntryRepository {
     this.#collection = accessor.getCollection<GlossaryEntry>(MongoDbDatabase.Auth, AuthDbCollection.GlossaryEntries);
   }
 
-  async findByUserId(userId: string): Promise<GlossaryEntry[]> {
-    return this.#collection
-      .find({ userId: new ObjectId(userId) })
+  async findByUserAndProject(args: { userId: string; projectKey: ProjectKey }): Promise<GlossaryEntry[]> {
+    const entries = await this.#collection
+      .find({ userId: new ObjectId(args.userId), projectKey: args.projectKey })
       .sort({ word: 1 })
       .toArray();
+
+    return entries.map((entry) => this.#parseEntry(entry));
+  }
+
+  async countByUserAndProject(args: { userId: string; projectKey: ProjectKey }): Promise<number> {
+    return this.#collection.countDocuments({ userId: new ObjectId(args.userId), projectKey: args.projectKey });
   }
 
   async countByUserId(userId: string): Promise<number> {
     return this.#collection.countDocuments({ userId: new ObjectId(userId) });
   }
 
-  async insertMany(args: { userId: string; words: string[] }): Promise<string[]> {
-    const { userId, words } = args;
-    if (words.length === 0) return [];
-    const objectUserId = new ObjectId(userId);
+  async insertMany(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<string[]> {
+    const { userId, projectKey, words } = args;
+    if (words.length === 0) {
+      return [];
+    }
 
+    const objectUserId = new ObjectId(userId);
     const now = new Date();
     const docs: GlossaryEntry[] = words.map((word) => ({
       _id: new ObjectId(),
       userId: objectUserId,
+      projectKey,
       word,
       createdAt: now,
     }));
@@ -37,30 +48,37 @@ export class GlossaryEntryRepository {
     try {
       const result = await this.#collection.insertMany(docs, { ordered: false });
       const insertedIds = new Set(Object.values(result.insertedIds).map((id) => id.toHexString()));
-      return docs.filter((d) => insertedIds.has(d._id.toHexString())).map((d) => d.word);
+      return docs.filter((document) => insertedIds.has(document._id.toHexString())).map((document) => document.word);
     } catch (error: unknown) {
-      // ordered:false + duplicate key (11000) → throws but non-duplicate inserts still succeed.
       if (error instanceof MongoBulkWriteError && error.code === 11000) {
-        const insertedCount = error.result?.insertedCount ?? 0;
-        if (insertedCount > 0) {
-          const errors = Array.isArray(error.writeErrors) ? error.writeErrors : [error.writeErrors];
-          const failedIndices = new Set(errors.map((e) => e.index));
-          return docs.filter((_, i) => !failedIndices.has(i)).map((d) => d.word);
-        }
-        return [];
+        const errors = Array.isArray(error.writeErrors) ? error.writeErrors : [error.writeErrors];
+        const failedIndices = new Set(errors.map((entry) => entry.index));
+        return docs.filter((_, index) => !failedIndices.has(index)).map((document) => document.word);
       }
       throw error;
     }
   }
 
-  async deleteMany(args: { userId: string; words: string[] }): Promise<number> {
-    const { userId, words } = args;
-    if (words.length === 0) return 0;
+  async deleteMany(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<number> {
+    const { userId, projectKey, words } = args;
+    if (words.length === 0) {
+      return 0;
+    }
 
     const result = await this.#collection.deleteMany({
       userId: new ObjectId(userId),
+      projectKey,
       word: { $in: words },
     });
     return result.deletedCount;
+  }
+
+  #parseEntry(entry: unknown): GlossaryEntry {
+    const result = glossaryEntrySchema.safeParse(entry);
+    if (!result.success) {
+      throw new InternalServerError({ debugMessage: "Invalid glossary entry persistence" });
+    }
+
+    return result.data;
   }
 }

--- a/src/routes/voice.ts
+++ b/src/routes/voice.ts
@@ -74,16 +74,22 @@ async function readTranscribeRequest(request: FastifyRequest): Promise<{
   projectKey: ProjectKey | null;
 }> {
   let audio: { buffer: Buffer; filename: string; mimetype: string } | null = null;
-  const fields: Record<string, string> = {};
+  // Null-prototype map: a `__proto__` part must land as an own key so the strict
+  // schema rejects it as an unknown field instead of silently vanishing.
+  const fields: Record<string, string> = Object.create(null);
 
   try {
     for await (const part of request.parts()) {
       if (part.type === "file") {
+        // Drain a rejected file stream before throwing so the parser can finish
+        // its cleanup instead of stalling on an unconsumed part.
         if (part.fieldname !== AUDIO_FIELD_NAME || audio !== null) {
+          part.file.resume();
           throw new BadRequestError({ debugMessage: "Unexpected file part" });
         }
 
         if (!ALLOWED_AUDIO_MIMES.has(part.mimetype)) {
+          part.file.resume();
           throw new BadRequestError({ debugMessage: `Unsupported audio MIME type: ${part.mimetype}` });
         }
 
@@ -98,11 +104,15 @@ async function readTranscribeRequest(request: FastifyRequest): Promise<{
       fields[part.fieldname] = part.value;
     }
   } catch (error) {
-    if (error instanceof ApiError) throw error;
+    if (error instanceof ApiError) {
+      throw error;
+    }
 
     // FST_REQ_FILE_TOO_LARGE carries its own 413; the global handler must keep
     // that status rather than see an oversized upload reported as a 400.
-    if (isFileTooLargeError(error)) throw error;
+    if (isFileTooLargeError(error)) {
+      throw error;
+    }
 
     throw new BadRequestError({
       debugMessage: "Request must be multipart/form-data with an audio file",
@@ -131,7 +141,14 @@ export const voiceRoutes: FastifyPluginAsync<VoiceRouteOptions> = async (fastify
   const { voiceService, glossaryService, requireAuth } = opts;
 
   await fastify.register(multipart, {
-    limits: { fileSize: AUDIO_MAX_FILE_SIZE, files: 1, fieldSize: TRANSCRIBE_FIELD_MAX_SIZE },
+    limits: {
+      fileSize: AUDIO_MAX_FILE_SIZE,
+      files: 1,
+      // One audio file plus at most one optional projectKey field.
+      fields: 1,
+      parts: 2,
+      fieldSize: TRANSCRIBE_FIELD_MAX_SIZE,
+    },
   });
 
   fastify.post<{ Reply: TranscribeReply }>(
@@ -158,7 +175,9 @@ export const voiceRoutes: FastifyPluginAsync<VoiceRouteOptions> = async (fastify
       } catch (error) {
         // Re-throw any ApiError subclass (BadRequestError, InternalServerError, QuotaExceededError, etc.)
         // so the global error handler returns the correct status code.
-        if (error instanceof ApiError) throw error;
+        if (error instanceof ApiError) {
+          throw error;
+        }
         throw new InternalServerError({
           debugMessage: "Transcription failed",
           nestedError: error,

--- a/src/routes/voice.ts
+++ b/src/routes/voice.ts
@@ -1,18 +1,28 @@
 import { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
 import multipart from "@fastify/multipart";
-import { z } from "zod";
 import { ApiError, BadRequestError, InternalServerError, UnauthenticatedError } from "../lib/errors.js";
 import type {
   TranscribeReply,
+  GlossaryListQuery,
   GlossaryListReply,
   GlossaryAddBody,
   GlossaryAddReply,
   GlossaryRemoveBody,
   GlossaryRemoveReply,
 } from "../models/api.js";
+import {
+  glossaryAddBodySchema,
+  glossaryListQuerySchema,
+  glossaryRemoveBodySchema,
+  transcribeMultipartSchema,
+  type ProjectKey,
+} from "../models/voice.js";
+import type { GlossaryService } from "../services/glossary-service.js";
 import type { VoiceService } from "../services/voice-service.js";
 
 const AUDIO_MAX_FILE_SIZE = 25 * 1024 * 1024;
+const AUDIO_FIELD_NAME = "audio";
+const TRANSCRIBE_FIELD_MAX_SIZE = 1024;
 
 // MIME types accepted by the OpenAI Whisper API.
 const ALLOWED_AUDIO_MIMES = new Set([
@@ -35,16 +45,9 @@ const TRANSCRIBE_RATE_LIMIT = {
   keyGenerator: (request: FastifyRequest) => request.headers.authorization ?? request.ip,
 };
 
-const glossaryAddBodySchema = z.object({
-  words: z.array(z.string().min(1).max(200)).min(1).max(100),
-});
-
-const glossaryRemoveBodySchema = z.object({
-  words: z.array(z.string().min(1)).min(1).max(100),
-});
-
 export type VoiceRouteOptions = {
   voiceService: VoiceService;
+  glossaryService: GlossaryService;
   requireAuth: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
 };
 
@@ -57,47 +60,94 @@ function getUserId(request: FastifyRequest): string {
   return request.user.userId;
 }
 
+/** Reports whether the multipart parser rejected the upload for exceeding the file-size limit. */
+function isFileTooLargeError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "FST_REQ_FILE_TOO_LARGE";
+}
+
+/**
+ * Reads the transcription multipart body: exactly one `audio` file plus at most
+ * one optional `projectKey` text field, accepted in any part order.
+ */
+async function readTranscribeRequest(request: FastifyRequest): Promise<{
+  audio: { buffer: Buffer; filename: string; mimetype: string };
+  projectKey: ProjectKey | null;
+}> {
+  let audio: { buffer: Buffer; filename: string; mimetype: string } | null = null;
+  const fields: Record<string, string> = {};
+
+  try {
+    for await (const part of request.parts()) {
+      if (part.type === "file") {
+        if (part.fieldname !== AUDIO_FIELD_NAME || audio !== null) {
+          throw new BadRequestError({ debugMessage: "Unexpected file part" });
+        }
+
+        if (!ALLOWED_AUDIO_MIMES.has(part.mimetype)) {
+          throw new BadRequestError({ debugMessage: `Unsupported audio MIME type: ${part.mimetype}` });
+        }
+
+        audio = { buffer: await part.toBuffer(), filename: part.filename, mimetype: part.mimetype };
+        continue;
+      }
+
+      if (Object.hasOwn(fields, part.fieldname) || part.valueTruncated || typeof part.value !== "string") {
+        throw new BadRequestError({ debugMessage: "Invalid text part" });
+      }
+
+      fields[part.fieldname] = part.value;
+    }
+  } catch (error) {
+    if (error instanceof ApiError) throw error;
+
+    // FST_REQ_FILE_TOO_LARGE carries its own 413; the global handler must keep
+    // that status rather than see an oversized upload reported as a 400.
+    if (isFileTooLargeError(error)) throw error;
+
+    throw new BadRequestError({
+      debugMessage: "Request must be multipart/form-data with an audio file",
+      nestedError: error,
+    });
+  }
+
+  if (!audio) {
+    throw new BadRequestError({ debugMessage: "No audio file provided" });
+  }
+
+  if (audio.buffer.length === 0) {
+    throw new BadRequestError({ debugMessage: "Audio file is empty" });
+  }
+
+  const parsedFields = transcribeMultipartSchema.safeParse(fields);
+  if (!parsedFields.success) {
+    throw new BadRequestError({ debugMessage: "Invalid multipart fields", nestedError: parsedFields.error.issues });
+  }
+
+  // COMPATIBILITY 2026-08-06 (v0.1.0): Apps at or before 1.6.1 omit projectKey. Omission means no glossary context — never a global glossary. Remove with the optional schema member once every supported app sends project context.
+  return { audio, projectKey: parsedFields.data.projectKey ?? null };
+}
+
 export const voiceRoutes: FastifyPluginAsync<VoiceRouteOptions> = async (fastify, opts) => {
-  const { voiceService, requireAuth } = opts;
+  const { voiceService, glossaryService, requireAuth } = opts;
 
   await fastify.register(multipart, {
-    limits: { fileSize: AUDIO_MAX_FILE_SIZE, files: 1 },
+    limits: { fileSize: AUDIO_MAX_FILE_SIZE, files: 1, fieldSize: TRANSCRIBE_FIELD_MAX_SIZE },
   });
 
   fastify.post<{ Reply: TranscribeReply }>(
     "/voice/transcribe",
     { preHandler: requireAuth, config: { rateLimit: TRANSCRIBE_RATE_LIMIT } },
     async (request) => {
-      let file;
-      try {
-        file = await request.file();
-      } catch (error) {
-        throw new BadRequestError({
-          debugMessage: "Request must be multipart/form-data with an audio file",
-          nestedError: error,
-        });
-      }
-      if (!file) {
-        throw new BadRequestError({ debugMessage: "No audio file provided" });
-      }
-
-      if (!ALLOWED_AUDIO_MIMES.has(file.mimetype)) {
-        throw new BadRequestError({ debugMessage: `Unsupported audio MIME type: ${file.mimetype}` });
-      }
-
-      const buffer = await file.toBuffer();
-      if (buffer.length === 0) {
-        throw new BadRequestError({ debugMessage: "Audio file is empty" });
-      }
-
+      const { audio, projectKey } = await readTranscribeRequest(request);
       const userId = getUserId(request);
 
       try {
         const { text, dailySecondsRemaining } = await voiceService.transcribe({
           userId,
-          fileBuffer: buffer,
-          filename: file.filename,
-          mimetype: file.mimetype,
+          projectKey,
+          fileBuffer: audio.buffer,
+          filename: audio.filename,
+          mimetype: audio.mimetype,
         });
 
         if (!text || text.trim().length === 0) {
@@ -117,11 +167,20 @@ export const voiceRoutes: FastifyPluginAsync<VoiceRouteOptions> = async (fastify
     },
   );
 
-  fastify.get<{ Reply: GlossaryListReply }>("/voice/glossary", { preHandler: requireAuth }, async (request) => {
-    const userId = getUserId(request);
-    const words = await voiceService.getGlossaryWords(userId);
-    return { words };
-  });
+  fastify.get<{ Querystring: GlossaryListQuery; Reply: GlossaryListReply }>(
+    "/voice/glossary",
+    { preHandler: requireAuth },
+    async (request) => {
+      const queryResult = glossaryListQuerySchema.safeParse(request.query);
+      if (!queryResult.success) {
+        throw new BadRequestError({ debugMessage: "Invalid query", nestedError: queryResult.error.issues });
+      }
+
+      const userId = getUserId(request);
+      const words = await glossaryService.listWords({ userId, projectKey: queryResult.data.projectKey });
+      return { words };
+    },
+  );
 
   fastify.post<{ Body: GlossaryAddBody; Reply: GlossaryAddReply }>(
     "/voice/glossary",
@@ -133,7 +192,11 @@ export const voiceRoutes: FastifyPluginAsync<VoiceRouteOptions> = async (fastify
       }
 
       const userId = getUserId(request);
-      const added = await voiceService.addGlossaryWords({ userId, words: bodyResult.data.words });
+      const added = await glossaryService.addWords({
+        userId,
+        projectKey: bodyResult.data.projectKey,
+        words: bodyResult.data.words,
+      });
       return { added };
     },
   );
@@ -148,7 +211,11 @@ export const voiceRoutes: FastifyPluginAsync<VoiceRouteOptions> = async (fastify
       }
 
       const userId = getUserId(request);
-      const removed = await voiceService.removeGlossaryWords({ userId, words: bodyResult.data.words });
+      const removed = await glossaryService.removeWords({
+        userId,
+        projectKey: bodyResult.data.projectKey,
+        words: bodyResult.data.words,
+      });
       return { removed };
     },
   );

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import type { AuthService } from "./services/auth-service.js";
 import type { BridgeService } from "./services/bridge-service.js";
 import type { NotificationService } from "./services/notification-service.js";
 import type { TokenService } from "./services/token-service.js";
+import type { GlossaryService } from "./services/glossary-service.js";
 import type { VoiceService } from "./services/voice-service.js";
 import type { SessionMetadataService } from "./services/session-metadata-service.js";
 import type { InstallScriptService } from "./services/install-script-service.js";
@@ -46,6 +47,7 @@ export type AppServices = {
   bridgeService: BridgeService;
   tokenService: TokenService;
   voiceService: VoiceService;
+  glossaryService: GlossaryService;
   sessionMetadataService: SessionMetadataService;
   installScriptService: InstallScriptService;
   legalDocumentService: LegalDocumentService;
@@ -164,6 +166,7 @@ export async function buildApp(services: AppServices): Promise<FastifyInstance> 
   });
   await app.register(voiceRoutes, {
     voiceService: services.voiceService,
+    glossaryService: services.glossaryService,
     requireAuth,
   });
   await app.register(notificationRoutes, {

--- a/src/services/glossary-service.ts
+++ b/src/services/glossary-service.ts
@@ -1,0 +1,70 @@
+import type { ProjectKey } from "../models/voice.js";
+import { GlossaryEntryRepository } from "../repositories/glossary-entry-repo.js";
+
+export const glossaryPolicy = {
+  maxWordsPerRequest: 100,
+  maxWordsPerProject: 500,
+  maxWordsPerUser: 5_000,
+  maxWordCharacters: 200,
+  maxContextCharacters: 8_000,
+} as const;
+
+export class GlossaryService {
+  readonly #glossaryRepo: GlossaryEntryRepository;
+  readonly #policy: typeof glossaryPolicy;
+
+  constructor(deps: { glossaryRepo: GlossaryEntryRepository; policy?: typeof glossaryPolicy }) {
+    this.#glossaryRepo = deps.glossaryRepo;
+    this.#policy = deps.policy ?? glossaryPolicy;
+  }
+
+  async listWords(args: { userId: string; projectKey: ProjectKey }): Promise<string[]> {
+    const entries = await this.#glossaryRepo.findByUserAndProject(args);
+    return entries.map((entry) => entry.word);
+  }
+
+  async addWords(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<string[]> {
+    const words = this.#uniqueWords(args.words);
+    const [projectCount, userCount] = await Promise.all([
+      this.#glossaryRepo.countByUserAndProject(args),
+      this.#glossaryRepo.countByUserId(args.userId),
+    ]);
+    const remaining = Math.max(
+      0,
+      Math.min(this.#policy.maxWordsPerProject - projectCount, this.#policy.maxWordsPerUser - userCount),
+    );
+
+    return this.#glossaryRepo.insertMany({ ...args, words: words.slice(0, remaining) });
+  }
+
+  async removeWords(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<number> {
+    return this.#glossaryRepo.deleteMany({ ...args, words: this.#uniqueWords(args.words) });
+  }
+
+  async getContextWords(args: { userId: string; projectKey: ProjectKey | null }): Promise<string[]> {
+    if (args.projectKey === null) {
+      return [];
+    }
+
+    const words = await this.listWords({ userId: args.userId, projectKey: args.projectKey });
+    const sorted = [...words].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+    const context: string[] = [];
+    let length = 0;
+
+    for (const word of sorted) {
+      const nextLength = length + (context.length === 0 ? 0 : 2) + word.length;
+      if (nextLength > this.#policy.maxContextCharacters) {
+        break;
+      }
+
+      context.push(word);
+      length = nextLength;
+    }
+
+    return context;
+  }
+
+  #uniqueWords(words: string[]): string[] {
+    return [...new Set(words)];
+  }
+}

--- a/src/services/glossary-service.ts
+++ b/src/services/glossary-service.ts
@@ -27,6 +27,8 @@ export class GlossaryService {
   }
 
   async addWords(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<string[]> {
+    // Validate before any database work so a rejected request costs no queries.
+    const requested = this.#uniqueWords(args.words);
     const [existing, projectCount, userCount] = await Promise.all([
       this.listWords(args),
       this.#glossaryRepo.countByUserAndProject(args),
@@ -36,7 +38,7 @@ export class GlossaryService {
     // Drop already-persisted terms before applying capacity so a duplicate
     // early in the request cannot consume a slot a new term could have used.
     const persisted = new Set(existing);
-    const candidates = this.#uniqueWords(args.words).filter((word) => !persisted.has(word));
+    const candidates = requested.filter((word) => !persisted.has(word));
     const remaining = Math.max(
       0,
       Math.min(this.#policy.maxWordsPerProject - projectCount, this.#policy.maxWordsPerUser - userCount),
@@ -89,8 +91,8 @@ export class GlossaryService {
 
   /**
    * Applies the safety policy the routes also validate, so a non-route caller
-   * cannot bypass it. Words are trimmed, empties dropped, and exact duplicates
-   * removed while preserving first request occurrence.
+   * cannot bypass it. Words are trimmed, empty and over-long words are
+   * rejected, and exact duplicates are removed preserving first occurrence.
    */
   #uniqueWords(words: string[]): string[] {
     if (words.length > this.#policy.maxWordsPerRequest) {

--- a/src/services/glossary-service.ts
+++ b/src/services/glossary-service.ts
@@ -1,5 +1,9 @@
+import { BadRequestError } from "../lib/errors.js";
 import type { ProjectKey } from "../models/voice.js";
 import { GlossaryEntryRepository } from "../repositories/glossary-entry-repo.js";
+
+const PROMPT_PREFIX = "The following terms may appear in the audio: ";
+const PROMPT_SUFFIX = ".";
 
 export const glossaryPolicy = {
   maxWordsPerRequest: 100,
@@ -19,26 +23,44 @@ export class GlossaryService {
   }
 
   async listWords(args: { userId: string; projectKey: ProjectKey }): Promise<string[]> {
-    const entries = await this.#glossaryRepo.findByUserAndProject(args);
-    return entries.map((entry) => entry.word);
+    return this.#glossaryRepo.findWordsByUserAndProject(args);
   }
 
   async addWords(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<string[]> {
-    const words = this.#uniqueWords(args.words);
-    const [projectCount, userCount] = await Promise.all([
+    const [existing, projectCount, userCount] = await Promise.all([
+      this.listWords(args),
       this.#glossaryRepo.countByUserAndProject(args),
-      this.#glossaryRepo.countByUserId(args.userId),
+      this.#glossaryRepo.countScopedByUserId(args.userId),
     ]);
+
+    // Drop already-persisted terms before applying capacity so a duplicate
+    // early in the request cannot consume a slot a new term could have used.
+    const persisted = new Set(existing);
+    const candidates = this.#uniqueWords(args.words).filter((word) => !persisted.has(word));
     const remaining = Math.max(
       0,
       Math.min(this.#policy.maxWordsPerProject - projectCount, this.#policy.maxWordsPerUser - userCount),
     );
 
-    return this.#glossaryRepo.insertMany({ ...args, words: words.slice(0, remaining) });
+    return this.#glossaryRepo.insertMany({ ...args, words: candidates.slice(0, remaining) });
   }
 
   async removeWords(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<number> {
     return this.#glossaryRepo.deleteMany({ ...args, words: this.#uniqueWords(args.words) });
+  }
+
+  /**
+   * Builds the provider prompt for one project, or null when there is no
+   * context. The cap is enforced on the rendered prompt, so the wrapper text is
+   * reserved rather than allowed to push the request past the budget.
+   */
+  async buildTranscriptionPrompt(args: { userId: string; projectKey: ProjectKey | null }): Promise<string | null> {
+    const words = await this.getContextWords(args);
+    if (words.length === 0) {
+      return null;
+    }
+
+    return `${PROMPT_PREFIX}${words.join(", ")}${PROMPT_SUFFIX}`;
   }
 
   async getContextWords(args: { userId: string; projectKey: ProjectKey | null }): Promise<string[]> {
@@ -48,12 +70,13 @@ export class GlossaryService {
 
     const words = await this.listWords({ userId: args.userId, projectKey: args.projectKey });
     const sorted = [...words].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+    const budget = this.#policy.maxContextCharacters - PROMPT_PREFIX.length - PROMPT_SUFFIX.length;
     const context: string[] = [];
     let length = 0;
 
     for (const word of sorted) {
       const nextLength = length + (context.length === 0 ? 0 : 2) + word.length;
-      if (nextLength > this.#policy.maxContextCharacters) {
+      if (nextLength > budget) {
         break;
       }
 
@@ -64,7 +87,21 @@ export class GlossaryService {
     return context;
   }
 
+  /**
+   * Applies the safety policy the routes also validate, so a non-route caller
+   * cannot bypass it. Words are trimmed, empties dropped, and exact duplicates
+   * removed while preserving first request occurrence.
+   */
   #uniqueWords(words: string[]): string[] {
-    return [...new Set(words)];
+    if (words.length > this.#policy.maxWordsPerRequest) {
+      throw new BadRequestError({ debugMessage: "Too many glossary words in one request" });
+    }
+
+    const normalized = words.map((word) => word.trim());
+    if (normalized.some((word) => word.length === 0 || word.length > this.#policy.maxWordCharacters)) {
+      throw new BadRequestError({ debugMessage: "Invalid glossary word length" });
+    }
+
+    return [...new Set(normalized)];
   }
 }

--- a/src/services/voice-service.ts
+++ b/src/services/voice-service.ts
@@ -32,11 +32,10 @@ export class VoiceService {
       });
     }
 
-    const glossaryWords = await this.#glossaryService.getContextWords({
+    const prompt = await this.#glossaryService.buildTranscriptionPrompt({
       userId: args.userId,
       projectKey: args.projectKey,
     });
-    const prompt = this.#buildTranscriptionPrompt(glossaryWords);
     const { text, durationSeconds } = await this.#openai.transcribe({
       fileBuffer: args.fileBuffer,
       filename: args.filename,
@@ -66,13 +65,5 @@ export class VoiceService {
     }
 
     return { text, dailySecondsRemaining };
-  }
-
-  #buildTranscriptionPrompt(glossaryWords: string[]): string | null {
-    if (glossaryWords.length === 0) {
-      return null;
-    }
-
-    return `The following terms may appear in the audio: ${glossaryWords.join(", ")}.`;
   }
 }

--- a/src/services/voice-service.ts
+++ b/src/services/voice-service.ts
@@ -1,49 +1,28 @@
-import { GlossaryEntryRepository } from "../repositories/glossary-entry-repo.js";
 import { DailyUsageRepository } from "../repositories/daily-usage-repo.js";
 import { OpenAIClient } from "../clients/openai-client.js";
 import { QuotaExceededError } from "../lib/errors.js";
 import { loadConfig } from "../config.js";
-
-// Hardcoded cap to prevent unbounded DB growth and prompt latency.
-const MAX_GLOSSARY_SIZE = 500;
+import { GlossaryService } from "./glossary-service.js";
+import type { ProjectKey } from "../models/voice.js";
 
 export class VoiceService {
   readonly #openai: OpenAIClient;
-  readonly #glossaryRepo: GlossaryEntryRepository;
+  readonly #glossaryService: GlossaryService;
   readonly #dailyUsageRepo: DailyUsageRepository;
 
-  constructor(deps: {
-    openai: OpenAIClient;
-    glossaryRepo: GlossaryEntryRepository;
-    dailyUsageRepo: DailyUsageRepository;
-  }) {
+  constructor(deps: { openai: OpenAIClient; glossaryService: GlossaryService; dailyUsageRepo: DailyUsageRepository }) {
     this.#openai = deps.openai;
-    this.#glossaryRepo = deps.glossaryRepo;
+    this.#glossaryService = deps.glossaryService;
     this.#dailyUsageRepo = deps.dailyUsageRepo;
   }
 
-  /**
-   * Transcribes audio after checking the user's daily quota.
-   *
-   * Flow:
-   *  1. Pre-check: read current usage; throw QuotaExceededError if already at limit.
-   *  2. Transcribe via OpenAI.
-   *  3. Atomic increment: detects concurrent quota races via "before" snapshot.
-   *     If a race is detected (another request consumed quota between steps 1 and 3),
-   *     returns `dailySecondsRemaining: 0` without failing the response.
-   *  4. Soft-fail on increment DB error: the transcription already completed, so we
-   *     log and return an estimated remaining value rather than penalising the user
-   *     for an infrastructure failure. The pre-check in step 1 is the primary quota gate.
-   *
-   * @throws QuotaExceededError when the daily limit is reached before transcription.
-   */
   async transcribe(args: {
     userId: string;
+    projectKey: ProjectKey | null;
     fileBuffer: Buffer;
     filename: string;
     mimetype: string;
   }): Promise<{ text: string; dailySecondsRemaining: number }> {
-    // Step 1 — pre-check (fast rejection before spending OpenAI credits).
     const usedSeconds = await this.#dailyUsageRepo.getDailyTranscriptionSeconds(args.userId);
 
     if (usedSeconds >= loadConfig().DAILY_TRANSCRIPTION_LIMIT_SECONDS) {
@@ -53,10 +32,11 @@ export class VoiceService {
       });
     }
 
-    // Step 2 — transcribe.
-    const glossaryWords = await this.getGlossaryWords(args.userId);
+    const glossaryWords = await this.#glossaryService.getContextWords({
+      userId: args.userId,
+      projectKey: args.projectKey,
+    });
     const prompt = this.#buildTranscriptionPrompt(glossaryWords);
-
     const { text, durationSeconds } = await this.#openai.transcribe({
       fileBuffer: args.fileBuffer,
       filename: args.filename,
@@ -64,10 +44,6 @@ export class VoiceService {
       prompt: prompt ?? undefined,
     });
 
-    // Step 3 — atomic increment with race detection.
-    // returnDocument "before" exposes the snapshot prior to our increment, letting us
-    // detect whether a concurrent request already consumed the quota in the window
-    // between our pre-check (step 1) and now.
     let dailySecondsRemaining: number;
     try {
       const { previousTotal, newTotal } = await this.#dailyUsageRepo.incrementTranscriptionSeconds(
@@ -76,18 +52,12 @@ export class VoiceService {
       );
 
       if (previousTotal >= loadConfig().DAILY_TRANSCRIPTION_LIMIT_SECONDS) {
-        // Race condition: a concurrent request exhausted the quota between our pre-check and increment.
-        // We do not fail the response — the transcription is already complete.
-        console.warn("[VoiceService] Concurrent quota race detected for user", args.userId);
+        console.warn("[VoiceService] Concurrent quota race detected");
         dailySecondsRemaining = 0;
       } else {
         dailySecondsRemaining = Math.max(0, loadConfig().DAILY_TRANSCRIPTION_LIMIT_SECONDS - newTotal);
       }
     } catch (error) {
-      // Soft-fail: if the usage-recording write fails (e.g., transient DB error), we
-      // do not fail the response. Failing here would penalise the user for an
-      // infrastructure issue after their audio has already been transcribed.
-      // The pre-check at step 1 is the primary quota enforcement gate.
       console.error("[VoiceService] Failed to record transcription usage", error);
       dailySecondsRemaining = Math.max(
         0,
@@ -96,30 +66,6 @@ export class VoiceService {
     }
 
     return { text, dailySecondsRemaining };
-  }
-
-  async getGlossaryWords(userId: string): Promise<string[]> {
-    const entries = await this.#glossaryRepo.findByUserId(userId);
-    return entries.map((e) => e.word);
-  }
-
-  async addGlossaryWords(args: { userId: string; words: string[] }): Promise<string[]> {
-    const existing = await this.#glossaryRepo.findByUserId(args.userId);
-    const remaining = MAX_GLOSSARY_SIZE - existing.length;
-
-    if (remaining <= 0) {
-      return [];
-    }
-
-    const existingWords = new Set(existing.map((e) => e.word));
-    const newWords = args.words.filter((w) => !existingWords.has(w));
-    const wordsToAdd = newWords.slice(0, remaining);
-
-    return this.#glossaryRepo.insertMany({ userId: args.userId, words: wordsToAdd });
-  }
-
-  async removeGlossaryWords(args: { userId: string; words: string[] }): Promise<number> {
-    return this.#glossaryRepo.deleteMany({ userId: args.userId, words: args.words });
   }
 
   #buildTranscriptionPrompt(glossaryWords: string[]): string | null {

--- a/tests/auth/oauth-callback-confirmation.test.ts
+++ b/tests/auth/oauth-callback-confirmation.test.ts
@@ -116,6 +116,7 @@ function createTestServices(params: {
     bridgeService: {} as AppServices["bridgeService"],
     tokenService: {} as AppServices["tokenService"],
     voiceService: {} as AppServices["voiceService"],
+    glossaryService: {} as AppServices["glossaryService"],
     sessionMetadataService: {} as AppServices["sessionMetadataService"],
     installScriptService: {} as AppServices["installScriptService"],
     legalDocumentService: {} as AppServices["legalDocumentService"],

--- a/tests/db/mongo-db-accessor.test.ts
+++ b/tests/db/mongo-db-accessor.test.ts
@@ -77,6 +77,24 @@ describe("glossary index cutover guard", () => {
     }
   });
 
+  it("refuses startup when the target index exists but is semantically wrong", async () => {
+    const ctx = await createTestApp();
+    try {
+      const collection = ctx.dbAccessor.getDb(MongoDbDatabase.Auth).collection(AuthDbCollection.GlossaryEntries);
+      const target = (await collection.indexes()).find((index) => index.name === "userId_1_projectKey_1_word_1");
+      assert.ok(target?.name);
+      await collection.dropIndex(target.name);
+      await collection.createIndex(
+        { userId: 1, projectKey: 1, word: 1 },
+        { unique: true, sparse: true, name: "userId_1_projectKey_1_word_1" },
+      );
+
+      await assert.rejects(() => ctx.dbAccessor.ensureIndexes(), /Glossary index migration incomplete/);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
   it("allows startup once only the project-scoped target index exists", async () => {
     const ctx = await createTestApp();
     try {

--- a/tests/db/mongo-db-accessor.test.ts
+++ b/tests/db/mongo-db-accessor.test.ts
@@ -1,6 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { indexKeyMatches, indexMatchesDesired, type IndexDefinition } from "../../src/db/mongo-db-accessor.js";
+import { createTestApp } from "../helpers/setup.js";
+import { MongoDbDatabase, AuthDbCollection } from "../../src/types/mongo.js";
 
 describe("indexKeyMatches", () => {
   it("returns true for identical single-field specs", () => {
@@ -57,5 +59,30 @@ describe("indexMatchesDesired", () => {
     const existing = { key: { userId: 1 }, unique: true, name: "userId_1", v: 2 };
     const desired: IndexDefinition = { spec: { userId: 1 } };
     assert.equal(indexMatchesDesired(existing, desired), false);
+  });
+});
+
+describe("glossary index cutover guard", () => {
+  it("refuses startup while the legacy glossary index survives beside the target", async () => {
+    const ctx = await createTestApp();
+    try {
+      await ctx.dbAccessor
+        .getDb(MongoDbDatabase.Auth)
+        .collection(AuthDbCollection.GlossaryEntries)
+        .createIndex({ userId: 1, word: 1 }, { unique: true });
+
+      await assert.rejects(() => ctx.dbAccessor.ensureIndexes(), /Glossary index migration incomplete/);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it("allows startup once only the project-scoped target index exists", async () => {
+    const ctx = await createTestApp();
+    try {
+      await assert.doesNotReject(() => ctx.dbAccessor.ensureIndexes());
+    } finally {
+      await ctx.cleanup();
+    }
   });
 });

--- a/tests/db/mongo-db-accessor.test.ts
+++ b/tests/db/mongo-db-accessor.test.ts
@@ -95,6 +95,36 @@ describe("glossary index cutover guard", () => {
     }
   });
 
+  it("refuses startup when two indexes share the target key", async () => {
+    const ctx = await createTestApp();
+    try {
+      await ctx.dbAccessor
+        .getDb(MongoDbDatabase.Auth)
+        .collection(AuthDbCollection.GlossaryEntries)
+        .createIndex(
+          { userId: 1, projectKey: 1, word: 1 },
+          { unique: true, name: "duplicate_target_key", collation: { locale: "en", strength: 2 } },
+        );
+
+      await assert.rejects(() => ctx.dbAccessor.ensureIndexes(), /Glossary index migration incomplete/);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it("refuses startup when the glossary collection has a non-simple default collation", async () => {
+    const ctx = await createTestApp();
+    try {
+      const db = ctx.dbAccessor.getDb(MongoDbDatabase.Auth);
+      await db.collection(AuthDbCollection.GlossaryEntries).drop();
+      await db.createCollection(AuthDbCollection.GlossaryEntries, { collation: { locale: "en", strength: 2 } });
+
+      await assert.rejects(() => ctx.dbAccessor.ensureIndexes(), /Glossary index migration incomplete/);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
   it("allows startup once only the project-scoped target index exists", async () => {
     const ctx = await createTestApp();
     try {

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -34,6 +34,7 @@ import { SessionMetadataService } from "../../src/services/session-metadata-serv
 import { InstallScriptService } from "../../src/services/install-script-service.js";
 import { LegalDocumentService } from "../../src/services/legal-document-service.js";
 import { TokenService } from "../../src/services/token-service.js";
+import { GlossaryService } from "../../src/services/glossary-service.js";
 import { VoiceService } from "../../src/services/voice-service.js";
 import { AppClientPresenceService } from "../../src/services/app-client-presence-service.js";
 import { ProductAnalyticsPreferenceService } from "../../src/services/product-analytics-preference-service.js";
@@ -60,6 +61,7 @@ export type TestContext = {
   tokenService: TokenService;
   pendingAuthStore: PendingAuthStore;
   appClientPresenceService: AppClientPresenceService;
+  glossaryService: GlossaryService;
   cleanup: () => Promise<void>;
   createUser: (opts?: { provider?: string; providerUserId?: string }) => Promise<TestUser>;
   createExpiredRefreshToken: (userId: string) => string;
@@ -80,6 +82,8 @@ export type TestAppOverrides = {
   activationService?: ActivationService;
   appClientPresenceService?: AppClientPresenceService;
   settingsService?: SettingsService;
+  glossaryService?: GlossaryService;
+  voiceService?: VoiceService;
 };
 
 export type { OAuthClient };
@@ -193,7 +197,8 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
   });
   const settingsService = overrides?.settingsService ?? new SettingsService({ settingsRepo });
   const authService = new AuthService({ tokenService, userRepo, oauthAccountRepo, passwordAccountRepo, bridgeService });
-  const voiceService = new VoiceService({ openai, glossaryRepo, dailyUsageRepo });
+  const glossaryService = overrides?.glossaryService ?? new GlossaryService({ glossaryRepo });
+  const voiceService = overrides?.voiceService ?? new VoiceService({ openai, glossaryService, dailyUsageRepo });
   const sessionMetadataService =
     overrides?.sessionMetadataService ?? new SessionMetadataService({ openai, dailyUsageRepo, model: "gpt-4o-mini" });
   const installScriptService = overrides?.installScriptService ?? new InstallScriptService();
@@ -206,6 +211,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
     bridgeService,
     tokenService,
     voiceService,
+    glossaryService,
     sessionMetadataService,
     installScriptService,
     legalDocumentService,
@@ -321,6 +327,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
     tokenService,
     pendingAuthStore,
     appClientPresenceService,
+    glossaryService,
     cleanup,
     createUser,
     createExpiredRefreshToken,

--- a/tests/repositories/glossary-entry-repo.test.ts
+++ b/tests/repositories/glossary-entry-repo.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { ObjectId } from "mongodb";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+import { GlossaryEntryRepository } from "../../src/repositories/glossary-entry-repo.js";
+import { InternalServerError } from "../../src/lib/errors.js";
+import type { GlossaryEntry } from "../../src/models/documents.js";
+import { projectKeySchema } from "../../src/models/voice.js";
+import { MongoDbDatabase, AuthDbCollection } from "../../src/types/mongo.js";
+
+const projectA = projectKeySchema.parse(`prj_v1_${"A".repeat(43)}`);
+const projectB = projectKeySchema.parse(`prj_v1_${"B".repeat(43)}`);
+
+describe("GlossaryEntryRepository", () => {
+  let ctx: TestContext;
+  let repo: GlossaryEntryRepository;
+  let userId: string;
+
+  before(async () => {
+    ctx = await createTestApp();
+    repo = new GlossaryEntryRepository(ctx.dbAccessor);
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  beforeEach(async () => {
+    await ctx.dbAccessor
+      .getCollection<GlossaryEntry>(MongoDbDatabase.Auth, AuthDbCollection.GlossaryEntries)
+      .deleteMany({});
+    userId = new ObjectId().toHexString();
+  });
+
+  function insertRaw(document: Record<string, unknown>): Promise<unknown> {
+    return ctx.dbAccessor.getDb(MongoDbDatabase.Auth).collection(AuthDbCollection.GlossaryEntries).insertOne(document);
+  }
+
+  it("persists project scope and returns only the requested project's words", async () => {
+    await repo.insertMany({ userId, projectKey: projectA, words: ["Beta", "Alpha"] });
+    await repo.insertMany({ userId, projectKey: projectB, words: ["Gamma"] });
+
+    const entries = await repo.findByUserAndProject({ userId, projectKey: projectA });
+
+    assert.deepEqual(
+      entries.map((entry) => entry.word),
+      ["Alpha", "Beta"],
+    );
+    assert.ok(entries.every((entry) => entry.projectKey === projectA));
+    assert.ok(entries.every((entry) => entry.userId instanceof ObjectId));
+  });
+
+  it("keeps the same word independent across projects and users", async () => {
+    const otherUserId = new ObjectId().toHexString();
+
+    assert.deepEqual(await repo.insertMany({ userId, projectKey: projectA, words: ["Shared"] }), ["Shared"]);
+    assert.deepEqual(await repo.insertMany({ userId, projectKey: projectB, words: ["Shared"] }), ["Shared"]);
+    assert.deepEqual(await repo.insertMany({ userId: otherUserId, projectKey: projectA, words: ["Shared"] }), [
+      "Shared",
+    ]);
+  });
+
+  it("treats a repeated word in the same project as an idempotent duplicate", async () => {
+    await repo.insertMany({ userId, projectKey: projectA, words: ["Alpha"] });
+
+    const inserted = await repo.insertMany({ userId, projectKey: projectA, words: ["Alpha", "Beta"] });
+
+    assert.deepEqual(inserted, ["Beta"]);
+    assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 2);
+  });
+
+  it("counts per project and per user", async () => {
+    await repo.insertMany({ userId, projectKey: projectA, words: ["Alpha", "Beta"] });
+    await repo.insertMany({ userId, projectKey: projectB, words: ["Gamma"] });
+
+    assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 2);
+    assert.equal(await repo.countByUserId(userId), 3);
+  });
+
+  it("deletes only words within the requested project", async () => {
+    await repo.insertMany({ userId, projectKey: projectA, words: ["Alpha", "Beta"] });
+    await repo.insertMany({ userId, projectKey: projectB, words: ["Alpha"] });
+
+    assert.equal(await repo.deleteMany({ userId, projectKey: projectA, words: ["Alpha"] }), 1);
+    assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 1);
+    assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectB }), 1);
+  });
+
+  it("performs no database work for empty word lists", async () => {
+    assert.deepEqual(await repo.insertMany({ userId, projectKey: projectA, words: [] }), []);
+    assert.equal(await repo.deleteMany({ userId, projectKey: projectA, words: [] }), 0);
+  });
+
+  it("never returns unscoped legacy documents through a scoped read", async () => {
+    await insertRaw({ _id: new ObjectId(), userId: new ObjectId(userId), word: "Legacy", createdAt: new Date() });
+
+    assert.deepEqual(await repo.findByUserAndProject({ userId, projectKey: projectA }), []);
+    assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 0);
+  });
+
+  it("fails closed on a malformed persisted document without leaking its content", async () => {
+    await insertRaw({
+      _id: new ObjectId(),
+      userId: new ObjectId(userId),
+      projectKey: projectA,
+      word: "Broken",
+      createdAt: new Date(),
+      unexpected: "SecretValue",
+    });
+
+    await assert.rejects(
+      () => repo.findByUserAndProject({ userId, projectKey: projectA }),
+      (error: unknown) => {
+        assert.ok(error instanceof InternalServerError);
+        assert.equal(error.message, "internal_server_error");
+        const diagnostics = `${error.debugMessage ?? ""}${JSON.stringify(error.nestedError ?? null)}`;
+        assert.ok(!diagnostics.includes("Broken") && !diagnostics.includes("SecretValue"));
+        return true;
+      },
+    );
+  });
+});

--- a/tests/repositories/glossary-entry-repo.test.ts
+++ b/tests/repositories/glossary-entry-repo.test.ts
@@ -40,14 +40,13 @@ describe("GlossaryEntryRepository", () => {
     await repo.insertMany({ userId, projectKey: projectA, words: ["Beta", "Alpha"] });
     await repo.insertMany({ userId, projectKey: projectB, words: ["Gamma"] });
 
-    const entries = await repo.findByUserAndProject({ userId, projectKey: projectA });
+    const words = await repo.findWordsByUserAndProject({ userId, projectKey: projectA });
 
-    assert.deepEqual(
-      entries.map((entry) => entry.word),
-      ["Alpha", "Beta"],
+    assert.deepEqual(words, ["Alpha", "Beta"]);
+    assert.ok(
+      words.every((word) => typeof word === "string"),
+      "documents must not escape the repository boundary",
     );
-    assert.ok(entries.every((entry) => entry.projectKey === projectA));
-    assert.ok(entries.every((entry) => entry.userId instanceof ObjectId));
   });
 
   it("keeps the same word independent across projects and users", async () => {
@@ -74,7 +73,7 @@ describe("GlossaryEntryRepository", () => {
     await repo.insertMany({ userId, projectKey: projectB, words: ["Gamma"] });
 
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 2);
-    assert.equal(await repo.countByUserId(userId), 3);
+    assert.equal(await repo.countScopedByUserId(userId), 3);
   });
 
   it("deletes only words within the requested project", async () => {
@@ -94,7 +93,7 @@ describe("GlossaryEntryRepository", () => {
   it("never returns unscoped legacy documents through a scoped read", async () => {
     await insertRaw({ _id: new ObjectId(), userId: new ObjectId(userId), word: "Legacy", createdAt: new Date() });
 
-    assert.deepEqual(await repo.findByUserAndProject({ userId, projectKey: projectA }), []);
+    assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectA }), []);
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 0);
   });
 
@@ -109,7 +108,7 @@ describe("GlossaryEntryRepository", () => {
     });
 
     await assert.rejects(
-      () => repo.findByUserAndProject({ userId, projectKey: projectA }),
+      () => repo.findWordsByUserAndProject({ userId, projectKey: projectA }),
       (error: unknown) => {
         assert.ok(error instanceof InternalServerError);
         assert.equal(error.message, "internal_server_error");

--- a/tests/services/glossary-service.test.ts
+++ b/tests/services/glossary-service.test.ts
@@ -6,6 +6,7 @@ import { GlossaryEntryRepository } from "../../src/repositories/glossary-entry-r
 import { GlossaryService, glossaryPolicy } from "../../src/services/glossary-service.js";
 import type { GlossaryEntry } from "../../src/models/documents.js";
 import { projectKeySchema } from "../../src/models/voice.js";
+import { BadRequestError } from "../../src/lib/errors.js";
 import { MongoDbDatabase, AuthDbCollection } from "../../src/types/mongo.js";
 
 const projectA = projectKeySchema.parse(`prj_v1_${"A".repeat(43)}`);
@@ -66,7 +67,7 @@ describe("GlossaryService", () => {
     const added = await service.addWords({ userId, projectKey: projectA, words: ["Last", "Overflow"] });
 
     assert.deepEqual(added, ["Last"]);
-    assert.equal(await repo.countByUserId(userId), glossaryPolicy.maxWordsPerUser);
+    assert.equal(await repo.countScopedByUserId(userId), glossaryPolicy.maxWordsPerUser);
   });
 
   it("adds nothing and never passes a negative limit when a cap is already exceeded", async () => {
@@ -83,6 +84,69 @@ describe("GlossaryService", () => {
       await repo.countByUserAndProject({ userId, projectKey: projectA }),
       glossaryPolicy.maxWordsPerProject + 5,
     );
+  });
+
+  it("does not let an already-stored word consume the last free capacity slot", async () => {
+    await repo.insertMany({
+      userId,
+      projectKey: projectA,
+      words: [...words("w", glossaryPolicy.maxWordsPerProject - 2), "Dup"],
+    });
+
+    const added = await service.addWords({ userId, projectKey: projectA, words: ["Dup", "BrandNew"] });
+
+    assert.deepEqual(added, ["BrandNew"]);
+  });
+
+  it("excludes unscoped legacy rows from the per-user capacity", async () => {
+    await ctx.dbAccessor
+      .getDb(MongoDbDatabase.Auth)
+      .collection(AuthDbCollection.GlossaryEntries)
+      .insertOne({ _id: new ObjectId(), userId: new ObjectId(userId), word: "Legacy", createdAt: new Date() });
+
+    assert.equal(await repo.countScopedByUserId(userId), 0);
+    assert.deepEqual(await service.addWords({ userId, projectKey: projectA, words: ["Scoped"] }), ["Scoped"]);
+  });
+
+  it("enforces request and word-length caps for non-route callers", async () => {
+    await assert.rejects(
+      () =>
+        service.addWords({ userId, projectKey: projectA, words: words("x", glossaryPolicy.maxWordsPerRequest + 1) }),
+      BadRequestError,
+    );
+    await assert.rejects(
+      () =>
+        service.addWords({ userId, projectKey: projectA, words: ["y".repeat(glossaryPolicy.maxWordCharacters + 1)] }),
+      BadRequestError,
+    );
+    await assert.rejects(() => service.addWords({ userId, projectKey: projectA, words: ["   "] }), BadRequestError);
+    await assert.rejects(
+      () =>
+        service.removeWords({ userId, projectKey: projectA, words: words("z", glossaryPolicy.maxWordsPerRequest + 1) }),
+      BadRequestError,
+    );
+  });
+
+  it("keeps the rendered prompt within the context budget", async () => {
+    const term = "x".repeat(glossaryPolicy.maxWordCharacters);
+    await repo.insertMany({
+      userId,
+      projectKey: projectA,
+      words: Array.from({ length: 90 }, (_, index) => `${String(index).padStart(3, "0")}${term}`),
+    });
+
+    const prompt = await service.buildTranscriptionPrompt({ userId, projectKey: projectA });
+
+    assert.ok(prompt);
+    assert.ok(
+      prompt.length <= glossaryPolicy.maxContextCharacters,
+      `rendered prompt ${prompt.length} exceeded ${glossaryPolicy.maxContextCharacters}`,
+    );
+  });
+
+  it("builds no prompt without project context or terms", async () => {
+    assert.equal(await service.buildTranscriptionPrompt({ userId, projectKey: null }), null);
+    assert.equal(await service.buildTranscriptionPrompt({ userId, projectKey: projectA }), null);
   });
 
   it("lists and removes only within one project", async () => {

--- a/tests/services/glossary-service.test.ts
+++ b/tests/services/glossary-service.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { ObjectId } from "mongodb";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+import { GlossaryEntryRepository } from "../../src/repositories/glossary-entry-repo.js";
+import { GlossaryService, glossaryPolicy } from "../../src/services/glossary-service.js";
+import type { GlossaryEntry } from "../../src/models/documents.js";
+import { projectKeySchema } from "../../src/models/voice.js";
+import { MongoDbDatabase, AuthDbCollection } from "../../src/types/mongo.js";
+
+const projectA = projectKeySchema.parse(`prj_v1_${"A".repeat(43)}`);
+const projectB = projectKeySchema.parse(`prj_v1_${"B".repeat(43)}`);
+
+function words(prefix: string, count: number, start = 0): string[] {
+  return Array.from({ length: count }, (_, index) => `${prefix}${String(start + index).padStart(5, "0")}`);
+}
+
+describe("GlossaryService", () => {
+  let ctx: TestContext;
+  let repo: GlossaryEntryRepository;
+  let service: GlossaryService;
+  let userId: string;
+
+  before(async () => {
+    ctx = await createTestApp();
+    repo = new GlossaryEntryRepository(ctx.dbAccessor);
+    service = new GlossaryService({ glossaryRepo: repo });
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  beforeEach(async () => {
+    await ctx.dbAccessor
+      .getCollection<GlossaryEntry>(MongoDbDatabase.Auth, AuthDbCollection.GlossaryEntries)
+      .deleteMany({});
+    userId = new ObjectId().toHexString();
+  });
+
+  it("deduplicates a request while preserving first occurrence order", async () => {
+    const added = await service.addWords({ userId, projectKey: projectA, words: ["Beta", "Alpha", "Beta"] });
+
+    assert.deepEqual(added, ["Beta", "Alpha"]);
+  });
+
+  it("truncates to the remaining per-project capacity", async () => {
+    await repo.insertMany({ userId, projectKey: projectA, words: words("p", glossaryPolicy.maxWordsPerProject - 2) });
+
+    const added = await service.addWords({ userId, projectKey: projectA, words: ["One", "Two", "Three"] });
+
+    assert.deepEqual(added, ["One", "Two"]);
+    assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), glossaryPolicy.maxWordsPerProject);
+  });
+
+  it("truncates to the remaining per-user capacity across projects", async () => {
+    const perProject = glossaryPolicy.maxWordsPerProject;
+    const projects = Array.from({ length: 9 }, (_, index) =>
+      projectKeySchema.parse(`prj_v1_${String(index).repeat(43)}`),
+    );
+    for (const [index, projectKey] of projects.entries()) {
+      await repo.insertMany({ userId, projectKey, words: words(`u${index}_`, perProject) });
+    }
+    await repo.insertMany({ userId, projectKey: projectA, words: words("tail_", 499) });
+
+    const added = await service.addWords({ userId, projectKey: projectA, words: ["Last", "Overflow"] });
+
+    assert.deepEqual(added, ["Last"]);
+    assert.equal(await repo.countByUserId(userId), glossaryPolicy.maxWordsPerUser);
+  });
+
+  it("adds nothing and never passes a negative limit when a cap is already exceeded", async () => {
+    await repo.insertMany({
+      userId,
+      projectKey: projectA,
+      words: words("over", glossaryPolicy.maxWordsPerProject + 5),
+    });
+
+    const added = await service.addWords({ userId, projectKey: projectA, words: ["Blocked"] });
+
+    assert.deepEqual(added, []);
+    assert.equal(
+      await repo.countByUserAndProject({ userId, projectKey: projectA }),
+      glossaryPolicy.maxWordsPerProject + 5,
+    );
+  });
+
+  it("lists and removes only within one project", async () => {
+    await service.addWords({ userId, projectKey: projectA, words: ["Alpha", "Beta"] });
+    await service.addWords({ userId, projectKey: projectB, words: ["Alpha"] });
+
+    assert.deepEqual(await service.listWords({ userId, projectKey: projectA }), ["Alpha", "Beta"]);
+    assert.equal(await service.removeWords({ userId, projectKey: projectA, words: ["Alpha", "Alpha"] }), 1);
+    assert.deepEqual(await service.listWords({ userId, projectKey: projectA }), ["Beta"]);
+    assert.deepEqual(await service.listWords({ userId, projectKey: projectB }), ["Alpha"]);
+  });
+
+  it("returns no context when project scope is absent", async () => {
+    await service.addWords({ userId, projectKey: projectA, words: ["Alpha"] });
+
+    assert.deepEqual(await service.getContextWords({ userId, projectKey: null }), []);
+  });
+
+  it("selects context by code-unit order without locale collation", async () => {
+    await service.addWords({ userId, projectKey: projectA, words: ["Zebra", "apple", "Émile", "Apple"] });
+
+    assert.deepEqual(await service.getContextWords({ userId, projectKey: projectA }), [
+      "Apple",
+      "Zebra",
+      "apple",
+      "Émile",
+    ]);
+  });
+
+  it("takes the longest whole-term prefix within the context budget", async () => {
+    const term = "x".repeat(100);
+    const stored = words("", 0).concat(
+      Array.from({ length: 120 }, (_, index) => `${String(index).padStart(3, "0")}${term}`),
+    );
+    await repo.insertMany({ userId, projectKey: projectA, words: stored });
+
+    const context = await service.getContextWords({ userId, projectKey: projectA });
+
+    assert.ok(context.length > 0 && context.length < stored.length);
+    assert.ok(context.join(", ").length <= glossaryPolicy.maxContextCharacters);
+    assert.ok(context.every((word) => word.length === term.length + 3));
+    assert.deepEqual(context, [...stored].sort().slice(0, context.length));
+  });
+});

--- a/tests/services/glossary-service.test.ts
+++ b/tests/services/glossary-service.test.ts
@@ -108,6 +108,38 @@ describe("GlossaryService", () => {
     assert.deepEqual(await service.addWords({ userId, projectKey: projectA, words: ["Scoped"] }), ["Scoped"]);
   });
 
+  it("rejects an invalid request before performing any database work", async () => {
+    let queried = false;
+    const spyRepo = {
+      findWordsByUserAndProject: async () => {
+        queried = true;
+        return [];
+      },
+      countByUserAndProject: async () => {
+        queried = true;
+        return 0;
+      },
+      countScopedByUserId: async () => {
+        queried = true;
+        return 0;
+      },
+      insertMany: async () => [],
+      deleteMany: async () => 0,
+    } as unknown as GlossaryEntryRepository;
+    const spyService = new GlossaryService({ glossaryRepo: spyRepo });
+
+    await assert.rejects(
+      () =>
+        spyService.addWords({
+          userId,
+          projectKey: projectA,
+          words: words("x", glossaryPolicy.maxWordsPerRequest + 1),
+        }),
+      BadRequestError,
+    );
+    assert.equal(queried, false, "no query should run for a request that is guaranteed to be rejected");
+  });
+
   it("enforces request and word-length caps for non-route callers", async () => {
     await assert.rejects(
       () =>

--- a/tests/voice/glossary.test.ts
+++ b/tests/voice/glossary.test.ts
@@ -2,6 +2,9 @@ import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
 
+const projectA = `prj_v1_${"A".repeat(43)}`;
+const projectB = `prj_v1_${"B".repeat(43)}`;
+
 describe("Glossary routes", () => {
   let ctx: TestContext;
 
@@ -13,111 +16,119 @@ describe("Glossary routes", () => {
     await ctx.cleanup();
   });
 
+  async function addWords(accessToken: string, projectKey: string, words: string[]) {
+    return ctx.app.inject({
+      method: "POST",
+      url: "/voice/glossary",
+      headers: { authorization: `Bearer ${accessToken}`, "content-type": "application/json" },
+      payload: JSON.stringify({ projectKey, words }),
+    });
+  }
+
+  async function listWords(accessToken: string, query: string) {
+    return ctx.app.inject({
+      method: "GET",
+      url: `/voice/glossary${query}`,
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+  }
+
+  async function removeWords(accessToken: string, projectKey: string, words: string[]) {
+    return ctx.app.inject({
+      method: "DELETE",
+      url: "/voice/glossary",
+      headers: { authorization: `Bearer ${accessToken}`, "content-type": "application/json" },
+      payload: JSON.stringify({ projectKey, words }),
+    });
+  }
+
   describe("GET /voice/glossary", () => {
-    it("returns empty array for a new user", async () => {
+    it("returns an empty array for a valid project with no entries", async () => {
       const user = await ctx.createUser();
 
-      const res = await ctx.app.inject({
-        method: "GET",
-        url: "/voice/glossary",
-        headers: { authorization: `Bearer ${user.accessToken}` },
-      });
+      const res = await listWords(user.accessToken, `?projectKey=${projectA}`);
 
       assert.equal(res.statusCode, 200);
       assert.deepEqual(res.json(), { words: [] });
     });
 
+    it("returns 400 when the project key is missing, malformed, or duplicated", async () => {
+      const user = await ctx.createUser();
+
+      for (const query of ["", "?projectKey=nope", `?projectKey=${projectA}&projectKey=${projectB}`, "?unknown=1"]) {
+        const res = await listWords(user.accessToken, query);
+        assert.equal(res.statusCode, 400, query);
+      }
+    });
+
     it("returns 401 when called without authentication", async () => {
-      const res = await ctx.app.inject({
-        method: "GET",
-        url: "/voice/glossary",
-      });
+      const res = await ctx.app.inject({ method: "GET", url: `/voice/glossary?projectKey=${projectA}` });
 
       assert.equal(res.statusCode, 401);
     });
   });
 
   describe("POST /voice/glossary", () => {
-    it("adds words and returns them in the response", async () => {
+    it("adds words scoped to the requested project", async () => {
       const user = await ctx.createUser();
 
-      const res = await ctx.app.inject({
-        method: "POST",
-        url: "/voice/glossary",
-        headers: {
-          authorization: `Bearer ${user.accessToken}`,
-          "content-type": "application/json",
-        },
-        payload: JSON.stringify({ words: ["Sesori", "HKDF", "XChaCha20"] }),
-      });
+      const res = await addWords(user.accessToken, projectA, ["Sesori", "HKDF", "XChaCha20"]);
 
       assert.equal(res.statusCode, 200);
-      const body = res.json<{ added: string[] }>();
-      assert.equal(body.added.length, 3);
-      assert.ok(body.added.includes("Sesori"));
-      assert.ok(body.added.includes("HKDF"));
-      assert.ok(body.added.includes("XChaCha20"));
+      assert.deepEqual(res.json<{ added: string[] }>().added.sort(), ["HKDF", "Sesori", "XChaCha20"]);
+      assert.deepEqual((await listWords(user.accessToken, `?projectKey=${projectB}`)).json(), { words: [] });
     });
 
-    it("skips duplicates and returns only newly added words", async () => {
+    it("normalizes surrounding whitespace and deduplicates within a request", async () => {
       const user = await ctx.createUser();
 
-      await ctx.app.inject({
-        method: "POST",
-        url: "/voice/glossary",
-        headers: {
-          authorization: `Bearer ${user.accessToken}`,
-          "content-type": "application/json",
-        },
-        payload: JSON.stringify({ words: ["Alpha", "Beta"] }),
-      });
-
-      const res = await ctx.app.inject({
-        method: "POST",
-        url: "/voice/glossary",
-        headers: {
-          authorization: `Bearer ${user.accessToken}`,
-          "content-type": "application/json",
-        },
-        payload: JSON.stringify({ words: ["Beta", "Gamma"] }),
-      });
+      const res = await addWords(user.accessToken, projectA, ["  Alpha  ", "Alpha", "Beta"]);
 
       assert.equal(res.statusCode, 200);
-      const body = res.json<{ added: string[] }>();
-      assert.equal(body.added.length, 1);
-      assert.ok(body.added.includes("Gamma"));
+      assert.deepEqual(res.json<{ added: string[] }>().added.sort(), ["Alpha", "Beta"]);
     });
 
-    it("returns 400 when words array is empty", async () => {
+    it("skips duplicates already persisted in the same project", async () => {
       const user = await ctx.createUser();
+      await addWords(user.accessToken, projectA, ["Alpha", "Beta"]);
 
-      const res = await ctx.app.inject({
-        method: "POST",
-        url: "/voice/glossary",
-        headers: {
-          authorization: `Bearer ${user.accessToken}`,
-          "content-type": "application/json",
-        },
-        payload: JSON.stringify({ words: [] }),
-      });
+      const res = await addWords(user.accessToken, projectA, ["Beta", "Gamma"]);
 
-      assert.equal(res.statusCode, 400);
+      assert.equal(res.statusCode, 200);
+      assert.deepEqual(res.json<{ added: string[] }>().added, ["Gamma"]);
     });
 
-    it("returns 400 when body is missing words field", async () => {
+    it("keeps the same word independent across projects", async () => {
       const user = await ctx.createUser();
+      await addWords(user.accessToken, projectA, ["Shared"]);
 
-      const res = await ctx.app.inject({
-        method: "POST",
-        url: "/voice/glossary",
-        headers: {
-          authorization: `Bearer ${user.accessToken}`,
-          "content-type": "application/json",
-        },
-        payload: JSON.stringify({}),
-      });
+      const res = await addWords(user.accessToken, projectB, ["Shared"]);
 
-      assert.equal(res.statusCode, 400);
+      assert.equal(res.statusCode, 200);
+      assert.deepEqual(res.json<{ added: string[] }>().added, ["Shared"]);
+      assert.deepEqual((await listWords(user.accessToken, `?projectKey=${projectB}`)).json(), { words: ["Shared"] });
+    });
+
+    it("returns 400 for missing/invalid project keys, empty words, and unknown fields", async () => {
+      const user = await ctx.createUser();
+      const invalidBodies = [
+        { words: ["Test"] },
+        { projectKey: "prj_v1_short", words: ["Test"] },
+        { projectKey: projectA, words: [] },
+        { projectKey: projectA, words: ["   "] },
+        { projectKey: projectA, words: ["Test"], unexpected: true },
+        { projectKey: projectA, words: [`${"x".repeat(201)}`] },
+      ];
+
+      for (const body of invalidBodies) {
+        const res = await ctx.app.inject({
+          method: "POST",
+          url: "/voice/glossary",
+          headers: { authorization: `Bearer ${user.accessToken}`, "content-type": "application/json" },
+          payload: JSON.stringify(body),
+        });
+        assert.equal(res.statusCode, 400, JSON.stringify(body));
+      }
     });
 
     it("returns 401 when called without authentication", async () => {
@@ -125,7 +136,7 @@ describe("Glossary routes", () => {
         method: "POST",
         url: "/voice/glossary",
         headers: { "content-type": "application/json" },
-        payload: JSON.stringify({ words: ["Test"] }),
+        payload: JSON.stringify({ projectKey: projectA, words: ["Test"] }),
       });
 
       assert.equal(res.statusCode, 401);
@@ -133,69 +144,36 @@ describe("Glossary routes", () => {
   });
 
   describe("DELETE /voice/glossary", () => {
-    it("removes existing words and returns the count", async () => {
+    it("removes only words in the requested project", async () => {
       const user = await ctx.createUser();
+      await addWords(user.accessToken, projectA, ["ToRemove", "ToKeep"]);
+      await addWords(user.accessToken, projectB, ["ToRemove"]);
 
-      await ctx.app.inject({
-        method: "POST",
-        url: "/voice/glossary",
-        headers: {
-          authorization: `Bearer ${user.accessToken}`,
-          "content-type": "application/json",
-        },
-        payload: JSON.stringify({ words: ["ToRemove1", "ToRemove2", "ToKeep"] }),
-      });
-
-      const res = await ctx.app.inject({
-        method: "DELETE",
-        url: "/voice/glossary",
-        headers: {
-          authorization: `Bearer ${user.accessToken}`,
-          "content-type": "application/json",
-        },
-        payload: JSON.stringify({ words: ["ToRemove1", "ToRemove2"] }),
-      });
+      const res = await removeWords(user.accessToken, projectA, ["ToRemove"]);
 
       assert.equal(res.statusCode, 200);
-      assert.deepEqual(res.json(), { removed: 2 });
-
-      const listRes = await ctx.app.inject({
-        method: "GET",
-        url: "/voice/glossary",
-        headers: { authorization: `Bearer ${user.accessToken}` },
-      });
-      const remaining = listRes.json<{ words: string[] }>();
-      assert.deepEqual(remaining.words, ["ToKeep"]);
+      assert.deepEqual(res.json(), { removed: 1 });
+      assert.deepEqual((await listWords(user.accessToken, `?projectKey=${projectA}`)).json(), { words: ["ToKeep"] });
+      assert.deepEqual((await listWords(user.accessToken, `?projectKey=${projectB}`)).json(), { words: ["ToRemove"] });
     });
 
     it("returns 0 when removing words that do not exist", async () => {
       const user = await ctx.createUser();
 
-      const res = await ctx.app.inject({
-        method: "DELETE",
-        url: "/voice/glossary",
-        headers: {
-          authorization: `Bearer ${user.accessToken}`,
-          "content-type": "application/json",
-        },
-        payload: JSON.stringify({ words: ["NonExistent"] }),
-      });
+      const res = await removeWords(user.accessToken, projectA, ["NonExistent"]);
 
       assert.equal(res.statusCode, 200);
       assert.deepEqual(res.json(), { removed: 0 });
     });
 
-    it("returns 400 when words array is empty", async () => {
+    it("returns 400 when the project key is missing", async () => {
       const user = await ctx.createUser();
 
       const res = await ctx.app.inject({
         method: "DELETE",
         url: "/voice/glossary",
-        headers: {
-          authorization: `Bearer ${user.accessToken}`,
-          "content-type": "application/json",
-        },
-        payload: JSON.stringify({ words: [] }),
+        headers: { authorization: `Bearer ${user.accessToken}`, "content-type": "application/json" },
+        payload: JSON.stringify({ words: ["Test"] }),
       });
 
       assert.equal(res.statusCode, 400);
@@ -206,105 +184,41 @@ describe("Glossary routes", () => {
         method: "DELETE",
         url: "/voice/glossary",
         headers: { "content-type": "application/json" },
-        payload: JSON.stringify({ words: ["Test"] }),
+        payload: JSON.stringify({ projectKey: projectA, words: ["Test"] }),
       });
 
       assert.equal(res.statusCode, 401);
     });
   });
 
-  describe("glossary isolation between users", () => {
-    it("each user has an independent glossary", async () => {
+  describe("isolation and full CRUD flow", () => {
+    it("keeps the same project key independent per user", async () => {
       const userA = await ctx.createUser();
       const userB = await ctx.createUser();
 
-      await ctx.app.inject({
-        method: "POST",
-        url: "/voice/glossary",
-        headers: {
-          authorization: `Bearer ${userA.accessToken}`,
-          "content-type": "application/json",
-        },
-        payload: JSON.stringify({ words: ["UserA_Word"] }),
-      });
+      await addWords(userA.accessToken, projectA, ["UserA_Word"]);
+      await addWords(userB.accessToken, projectA, ["UserB_Word"]);
 
-      await ctx.app.inject({
-        method: "POST",
-        url: "/voice/glossary",
-        headers: {
-          authorization: `Bearer ${userB.accessToken}`,
-          "content-type": "application/json",
-        },
-        payload: JSON.stringify({ words: ["UserB_Word"] }),
+      assert.deepEqual((await listWords(userA.accessToken, `?projectKey=${projectA}`)).json(), {
+        words: ["UserA_Word"],
       });
-
-      const resA = await ctx.app.inject({
-        method: "GET",
-        url: "/voice/glossary",
-        headers: { authorization: `Bearer ${userA.accessToken}` },
+      assert.deepEqual((await listWords(userB.accessToken, `?projectKey=${projectA}`)).json(), {
+        words: ["UserB_Word"],
       });
-      const resB = await ctx.app.inject({
-        method: "GET",
-        url: "/voice/glossary",
-        headers: { authorization: `Bearer ${userB.accessToken}` },
-      });
-
-      assert.deepEqual(resA.json<{ words: string[] }>().words, ["UserA_Word"]);
-      assert.deepEqual(resB.json<{ words: string[] }>().words, ["UserB_Word"]);
     });
-  });
 
-  describe("full CRUD flow", () => {
     it("add → list → remove → list works end-to-end", async () => {
       const user = await ctx.createUser();
 
-      const addRes = await ctx.app.inject({
-        method: "POST",
-        url: "/voice/glossary",
-        headers: {
-          authorization: `Bearer ${user.accessToken}`,
-          "content-type": "application/json",
-        },
-        payload: JSON.stringify({ words: ["Fastify", "MongoDB", "Zod"] }),
+      assert.equal((await addWords(user.accessToken, projectA, ["Fastify", "MongoDB", "Zod"])).statusCode, 200);
+      assert.deepEqual((await listWords(user.accessToken, `?projectKey=${projectA}`)).json(), {
+        words: ["Fastify", "MongoDB", "Zod"],
       });
-      assert.equal(addRes.statusCode, 200);
-      assert.equal(addRes.json<{ added: string[] }>().added.length, 3);
 
-      const listRes = await ctx.app.inject({
-        method: "GET",
-        url: "/voice/glossary",
-        headers: { authorization: `Bearer ${user.accessToken}` },
+      assert.deepEqual((await removeWords(user.accessToken, projectA, ["MongoDB"])).json(), { removed: 1 });
+      assert.deepEqual((await listWords(user.accessToken, `?projectKey=${projectA}`)).json(), {
+        words: ["Fastify", "Zod"],
       });
-      assert.equal(listRes.statusCode, 200);
-      const words = listRes.json<{ words: string[] }>().words;
-      assert.equal(words.length, 3);
-      assert.ok(words.includes("Fastify"));
-      assert.ok(words.includes("MongoDB"));
-      assert.ok(words.includes("Zod"));
-
-      const deleteRes = await ctx.app.inject({
-        method: "DELETE",
-        url: "/voice/glossary",
-        headers: {
-          authorization: `Bearer ${user.accessToken}`,
-          "content-type": "application/json",
-        },
-        payload: JSON.stringify({ words: ["MongoDB"] }),
-      });
-      assert.equal(deleteRes.statusCode, 200);
-      assert.deepEqual(deleteRes.json(), { removed: 1 });
-
-      const finalListRes = await ctx.app.inject({
-        method: "GET",
-        url: "/voice/glossary",
-        headers: { authorization: `Bearer ${user.accessToken}` },
-      });
-      assert.equal(finalListRes.statusCode, 200);
-      const remaining = finalListRes.json<{ words: string[] }>().words;
-      assert.equal(remaining.length, 2);
-      assert.ok(remaining.includes("Fastify"));
-      assert.ok(remaining.includes("Zod"));
-      assert.ok(!remaining.includes("MongoDB"));
     });
   });
 });

--- a/tests/voice/transcribe.test.ts
+++ b/tests/voice/transcribe.test.ts
@@ -10,23 +10,36 @@ import type { DailyUsage } from "../../src/models/documents.js";
 import { MongoDbDatabase, AuthDbCollection } from "../../src/types/mongo.js";
 
 const BOUNDARY = "----TestBoundary9876543210";
+const PROJECT_KEY = `prj_v1_${"A".repeat(43)}`;
+const OTHER_PROJECT_KEY = `prj_v1_${"B".repeat(43)}`;
 
-function buildMultipartPayload(args: { fieldName: string; filename: string; content: Buffer; contentType: string }): {
+function buildMultipartPayload(args: {
+  fieldName: string;
+  filename: string;
+  content: Buffer;
+  contentType: string;
+  fields?: { name: string; value: string }[];
+  fieldsFirst?: boolean;
+}): {
   body: Buffer;
   contentType: string;
 } {
-  const parts: Buffer[] = [
+  const fieldParts = (args.fields ?? []).map((field) =>
+    Buffer.from(`--${BOUNDARY}\r\nContent-Disposition: form-data; name="${field.name}"\r\n\r\n${field.value}\r\n`),
+  );
+  const filePart = Buffer.concat([
     Buffer.from(
       `--${BOUNDARY}\r\n` +
         `Content-Disposition: form-data; name="${args.fieldName}"; filename="${args.filename}"\r\n` +
         `Content-Type: ${args.contentType}\r\n\r\n`,
     ),
     args.content,
-    Buffer.from(`\r\n--${BOUNDARY}--\r\n`),
-  ];
+    Buffer.from("\r\n"),
+  ]);
+  const ordered = args.fieldsFirst ? [...fieldParts, filePart] : [filePart, ...fieldParts];
 
   return {
-    body: Buffer.concat(parts),
+    body: Buffer.concat([...ordered, Buffer.from(`--${BOUNDARY}--\r\n`)]),
     contentType: `multipart/form-data; boundary=${BOUNDARY}`,
   };
 }
@@ -115,6 +128,30 @@ describe("POST /voice/transcribe", () => {
     assert.equal(res.statusCode, 400);
   });
 
+  it("preserves the framework 413 when the audio file exceeds the size limit", async () => {
+    const user = await ctx.createUser();
+    mock.method(OpenAIClient.prototype, "transcribe", async () => ({ text: "unused", durationSeconds: 1 }));
+
+    const { body, contentType } = buildMultipartPayload({
+      fieldName: "audio",
+      filename: "too-large.m4a",
+      content: Buffer.alloc(25 * 1024 * 1024 + 1024, 1),
+      contentType: "audio/m4a",
+    });
+
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/voice/transcribe",
+      headers: {
+        authorization: `Bearer ${user.accessToken}`,
+        "content-type": contentType,
+      },
+      payload: body,
+    });
+
+    assert.equal(res.statusCode, 413);
+  });
+
   it("returns transcribed text and dailySecondsRemaining on success", async () => {
     const user = await ctx.createUser();
 
@@ -148,34 +185,41 @@ describe("POST /voice/transcribe", () => {
     assert.equal(json.dailySecondsRemaining, 3590);
   });
 
-  it("passes glossary words in the prompt to OpenAI", async () => {
-    const user = await ctx.createUser();
-
-    await ctx.app.inject({
+  async function seedGlossary(accessToken: string, projectKey: string, words: string[]): Promise<void> {
+    const res = await ctx.app.inject({
       method: "POST",
       url: "/voice/glossary",
-      headers: {
-        authorization: `Bearer ${user.accessToken}`,
-        "content-type": "application/json",
-      },
-      payload: JSON.stringify({ words: ["Sesori", "XChaCha20"] }),
+      headers: { authorization: `Bearer ${accessToken}`, "content-type": "application/json" },
+      payload: JSON.stringify({ projectKey, words }),
     });
+    assert.equal(res.statusCode, 200);
+  }
 
+  function capturePrompt(text: string, durationSeconds: number): { read: () => string | undefined } {
     let capturedPrompt: string | undefined;
     mock.method(
       OpenAIClient.prototype,
       "transcribe",
       async (args: { fileBuffer: Buffer; filename: string; mimetype: string; prompt?: string }) => {
         capturedPrompt = args.prompt;
-        return { text: "Sesori uses XChaCha20 encryption.", durationSeconds: 5 };
+        return { text, durationSeconds };
       },
     );
+    return { read: () => capturedPrompt };
+  }
 
+  it("passes the requested project's glossary words in the prompt to OpenAI", async () => {
+    const user = await ctx.createUser();
+    await seedGlossary(user.accessToken, PROJECT_KEY, ["Sesori", "XChaCha20"]);
+    await seedGlossary(user.accessToken, OTHER_PROJECT_KEY, ["OtherProjectTerm"]);
+
+    const prompt = capturePrompt("Sesori uses XChaCha20 encryption.", 5);
     const { body, contentType } = buildMultipartPayload({
       fieldName: "audio",
       filename: "test.m4a",
       content: Buffer.from("fake-audio-data-for-testing"),
       contentType: "audio/m4a",
+      fields: [{ name: "projectKey", value: PROJECT_KEY }],
     });
 
     const res = await ctx.app.inject({
@@ -189,24 +233,72 @@ describe("POST /voice/transcribe", () => {
     });
 
     assert.equal(res.statusCode, 200);
+    const capturedPrompt = prompt.read();
     assert.ok(capturedPrompt, "A prompt should have been passed to OpenAI");
     assert.ok(capturedPrompt.includes("Sesori"), "Prompt should contain glossary word 'Sesori'");
     assert.ok(capturedPrompt.includes("XChaCha20"), "Prompt should contain glossary word 'XChaCha20'");
+    assert.ok(!capturedPrompt.includes("OtherProjectTerm"), "Prompt must not leak another project's terms");
   });
 
-  it("sends no prompt when user has no glossary entries", async () => {
+  it("accepts the projectKey field before the audio part", async () => {
+    const user = await ctx.createUser();
+    await seedGlossary(user.accessToken, PROJECT_KEY, ["Sesori"]);
+
+    const prompt = capturePrompt("Sesori.", 2);
+    const { body, contentType } = buildMultipartPayload({
+      fieldName: "audio",
+      filename: "test.m4a",
+      content: Buffer.from("fake-audio-data-for-testing"),
+      contentType: "audio/m4a",
+      fields: [{ name: "projectKey", value: PROJECT_KEY }],
+      fieldsFirst: true,
+    });
+
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/voice/transcribe",
+      headers: {
+        authorization: `Bearer ${user.accessToken}`,
+        "content-type": contentType,
+      },
+      payload: body,
+    });
+
+    assert.equal(res.statusCode, 200);
+    assert.ok(prompt.read()?.includes("Sesori"));
+  });
+
+  it("sends no prompt when the requested project has no glossary entries", async () => {
     const user = await ctx.createUser();
 
-    let capturedPrompt: string | undefined;
-    mock.method(
-      OpenAIClient.prototype,
-      "transcribe",
-      async (args: { fileBuffer: Buffer; filename: string; mimetype: string; prompt?: string }) => {
-        capturedPrompt = args.prompt;
-        return { text: "Hello world.", durationSeconds: 3 };
-      },
-    );
+    const prompt = capturePrompt("Hello world.", 3);
+    const { body, contentType } = buildMultipartPayload({
+      fieldName: "audio",
+      filename: "test.m4a",
+      content: Buffer.from("fake-audio-data-for-testing"),
+      contentType: "audio/m4a",
+      fields: [{ name: "projectKey", value: PROJECT_KEY }],
+    });
 
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/voice/transcribe",
+      headers: {
+        authorization: `Bearer ${user.accessToken}`,
+        "content-type": contentType,
+      },
+      payload: body,
+    });
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(prompt.read(), undefined, "No prompt should be sent when the project glossary is empty");
+  });
+
+  it("sends no prompt when a legacy client omits projectKey even if other projects have terms", async () => {
+    const user = await ctx.createUser();
+    await seedGlossary(user.accessToken, PROJECT_KEY, ["Sesori"]);
+
+    const prompt = capturePrompt("Hello world.", 3);
     const { body, contentType } = buildMultipartPayload({
       fieldName: "audio",
       filename: "test.m4a",
@@ -225,7 +317,43 @@ describe("POST /voice/transcribe", () => {
     });
 
     assert.equal(res.statusCode, 200);
-    assert.equal(capturedPrompt, undefined, "No prompt should be sent when glossary is empty");
+    assert.equal(prompt.read(), undefined, "Omitted project context must never fall back to a global glossary");
+  });
+
+  it("returns 400 for malformed, duplicated, or unknown multipart text fields", async () => {
+    const user = await ctx.createUser();
+    mock.method(OpenAIClient.prototype, "transcribe", async () => ({ text: "unused", durationSeconds: 1 }));
+
+    const invalidFieldSets = [
+      [{ name: "projectKey", value: "prj_v1_short" }],
+      [
+        { name: "projectKey", value: PROJECT_KEY },
+        { name: "projectKey", value: OTHER_PROJECT_KEY },
+      ],
+      [{ name: "unexpected", value: "value" }],
+    ];
+
+    for (const fields of invalidFieldSets) {
+      const { body, contentType } = buildMultipartPayload({
+        fieldName: "audio",
+        filename: "test.m4a",
+        content: Buffer.from("fake-audio-data-for-testing"),
+        contentType: "audio/m4a",
+        fields,
+      });
+
+      const res = await ctx.app.inject({
+        method: "POST",
+        url: "/voice/transcribe",
+        headers: {
+          authorization: `Bearer ${user.accessToken}`,
+          "content-type": contentType,
+        },
+        payload: body,
+      });
+
+      assert.equal(res.statusCode, 400, JSON.stringify(fields));
+    }
   });
 
   it("returns 500 when OpenAI returns empty text", async () => {

--- a/tests/voice/transcribe.test.ts
+++ b/tests/voice/transcribe.test.ts
@@ -202,7 +202,7 @@ describe("POST /voice/transcribe", () => {
       payload: Buffer.concat([filePart("audio"), filePart("extra"), Buffer.from(`--${BOUNDARY}--\r\n`)]),
     });
 
-    assert.ok(res.statusCode >= 400 && res.statusCode < 500, `expected a 4xx, got ${res.statusCode}`);
+    assert.equal(res.statusCode, 400, "an unexpected extra file part must be a bounded 400");
   });
 
   it("returns transcribed text and dailySecondsRemaining on success", async () => {

--- a/tests/voice/transcribe.test.ts
+++ b/tests/voice/transcribe.test.ts
@@ -152,6 +152,59 @@ describe("POST /voice/transcribe", () => {
     assert.equal(res.statusCode, 413);
   });
 
+  it("rejects an unknown __proto__ multipart field instead of silently dropping it", async () => {
+    const user = await ctx.createUser();
+    mock.method(OpenAIClient.prototype, "transcribe", async () => ({ text: "unused", durationSeconds: 1 }));
+
+    const { body, contentType } = buildMultipartPayload({
+      fieldName: "audio",
+      filename: "test.m4a",
+      content: Buffer.from("fake-audio-data-for-testing"),
+      contentType: "audio/m4a",
+      fields: [{ name: "__proto__", value: "polluted" }],
+    });
+
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/voice/transcribe",
+      headers: {
+        authorization: `Bearer ${user.accessToken}`,
+        "content-type": contentType,
+      },
+      payload: body,
+    });
+
+    assert.equal(res.statusCode, 400);
+    assert.equal(({} as Record<string, unknown>).polluted, undefined);
+  });
+
+  it("rejects an unexpected extra file part without stalling the request", async () => {
+    const user = await ctx.createUser();
+    mock.method(OpenAIClient.prototype, "transcribe", async () => ({ text: "unused", durationSeconds: 1 }));
+
+    const filePart = (name: string) =>
+      Buffer.concat([
+        Buffer.from(
+          `--${BOUNDARY}\r\nContent-Disposition: form-data; name="${name}"; filename="f.m4a"\r\n` +
+            `Content-Type: audio/m4a\r\n\r\n`,
+        ),
+        Buffer.from("fake-audio-data-for-testing"),
+        Buffer.from("\r\n"),
+      ]);
+
+    const res = await ctx.app.inject({
+      method: "POST",
+      url: "/voice/transcribe",
+      headers: {
+        authorization: `Bearer ${user.accessToken}`,
+        "content-type": `multipart/form-data; boundary=${BOUNDARY}`,
+      },
+      payload: Buffer.concat([filePart("audio"), filePart("extra"), Buffer.from(`--${BOUNDARY}--\r\n`)]),
+    });
+
+    assert.ok(res.statusCode >= 400 && res.statusCode < 500, `expected a 4xx, got ${res.statusCode}`);
+  });
+
   it("returns transcribed text and dailySecondsRemaining on success", async () => {
     const user = await ctx.createUser();
 


### PR DESCRIPTION
## Summary

Implements plan step **S01-W01-P01** (`.plan/active/real-time-transcription/stages/01-data-and-async/w01-p01-project-scope-glossary.md`) — the runtime half of the already-merged glossary index migration.

- glossary list/add/remove now require an opaque `projectKey`
- `POST /voice/transcribe` accepts an optional multipart `projectKey`, normalized to explicit `null`
- persisted glossary documents and `DATABASE_CONFIG` move to the unique `{userId, projectKey, word}` index
- new `GlossaryService` owns CRUD, safety caps, and deterministic provider context selection
- `VoiceService` consumes glossary terms only for the exact project key

Provider selection is unchanged: async transcription still runs on OpenAI.

## Behavior notes

- **Omission never falls back to a global glossary.** A legacy client that omits `projectKey` transcribes with no glossary context. Marked with `COMPATIBILITY 2026-08-06 (v0.1.0)` in `src/models/voice.ts` and `src/routes/voice.ts`.
- **Glossary CRUD requiring project context is an approved break** — no repository-visible caller exists in the apps monorepo and the last production dry-run reported zero rows.
- **Caps are safety bounds, not exact entitlements.** 100/request, 500/project, 5,000/user, 200 chars/word, 8,000-char context. Counts are ordinary prechecks, so concurrent requests may narrowly exceed a cap; the compound unique index still prevents duplicates.
- The multipart reader now accepts the `audio` file and the optional `projectKey` field in any order, and rejects duplicate/unknown/truncated fields and extra files. `FST_REQ_FILE_TOO_LARGE` is rethrown so an oversized upload keeps its **413** rather than collapsing to 400.
- Malformed persisted glossary documents fail closed with an internal error and no document content in logs. Legacy unscoped rows are unreachable through scoped reads.

## Deployment ordering (required)

Do **not** deploy this runtime before the index cutover. With the single auth instance stopped, run the existing `migrate-project-glossary-index` dry-run, then `--apply`, then `--verify`. Any row, duplicate, collation mismatch, or `repair_required` outcome pauses rollout. Once a scoped term exists, rollback to the old index is forbidden.

## Verification

MongoDB backend disclosure: Docker was unavailable on this machine, so the suite ran against the `mongodb-memory-server` fallback (real `mongod`), **not** MongoDB 7. CI enforces MongoDB 7 via `MONGODB_URI_TEST`.

- full suite: 555 tests, 554 passed, 1 pre-existing skip, 0 failed
- focused: `tests/models/voice.test.ts`, `tests/voice/glossary.test.ts`, `tests/voice/transcribe.test.ts`, `tests/repositories/glossary-entry-repo.test.ts` (new), `tests/services/glossary-service.test.ts` (new), `tests/scripts/project-glossary-index-migration.test.ts` (unchanged, still green)
- `format:check`, `lint`, `tsc --noEmit`, `build`, `circular-dependencies` all pass
- authored/generated diff: 1,215 / 0

Implementation review ran the `aristotle-impl-review` ruleset (via a generic model, as the reviewer's own model is unavailable). Round 1 rejected on the 413→400 regression; that is fixed and covered by a regression test, and round 2 approved.

## Next slice

S01-W02-P01 — provider-neutral async Soniox support, starting only after this merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Project-scope the voice glossary runtime with stricter startup guards. Glossary CRUD now requires a `projectKey`, `POST /voice/transcribe` optionally takes `projectKey` to use only that project’s terms, and startup refuses to serve unless the exact project-scoped index and simple collation are in place (simple-collation check is now centralized to avoid drift).

- **New Features**
  - Store entries under `{userId, projectKey, word}` with a unique index; added `GlossaryService` with caps (100/request, 500/project, 5,000/user, 200 chars/word, 8,000-char context), enforced before any DB query; filters already-persisted terms before applying capacity, excludes legacy unscoped rows from the per-user cap, keeps documents inside the repo, validates driver counts, and builds prompts within the context budget.
  - `GET|POST|DELETE /voice/glossary` require `projectKey`; multipart `POST /voice/transcribe` accepts `projectKey` (any order), rejects duplicate/unknown fields (including `__proto__`) and extra files, bounds fields/parts, and preserves 413 on oversized uploads; omission means no glossary and never falls back; `VoiceService` uses only the exact project’s context; startup guard also refuses legacy and mismatched index states and non-simple collection collation.

- **Migration**
  - Do not deploy this runtime before the `{userId, projectKey, word}` index cutover is applied and verified; startup will refuse to serve if the legacy `{userId, word}` index remains, the target is missing or not exactly unique/simple/non-sparse/non-partial/non-hidden/non-TTL, more than one index shares the target key, or the glossary collection’s default collation isn’t simple. With the single auth instance stopped, run the existing migration `--apply` then `--verify`; rollback is allowed only before any scoped term exists.

<sup>Written for commit fb9795be8e74664e70851da48fff2cf86b2a1dad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

