### PR TITLE
fix: keep src/scripts in the production image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,5 +9,8 @@ keys/
 !assets/legal/terms.md
 !assets/legal/privacy.md
 tests/
-scripts/
+# Anchored: excludes only the repository-root operator scripts. An unanchored
+# "scripts/" also matched src/scripts/, which silently dropped the product
+# analytics export/suppression entry points from the production image.
+/scripts/
 .sops.yaml


### PR DESCRIPTION
## Problem

The product-analytics export could not run in production. Its Cloud Run job
failed immediately at startup:

```
Error: Cannot find module '/app/dist/scripts/export-product-analytics.js'
```

A probe execution against the deployed image confirmed the cause is not a bad
path or a missing build step: `/app/dist` exists and is otherwise complete, but
`/app/dist/scripts` **does not exist at all**.

## Root cause

`.dockerignore` contained the unanchored pattern `scripts/`.

Docker matches an unanchored directory pattern at *any* depth, so it excluded
both:

- `scripts/` at the repository root (intended: operator tooling), and
- `src/scripts/` (not intended: the analytics export and suppression entry
  points).

TypeScript then compiled a build context that never contained those sources, so
the resulting image shipped without `dist/scripts`. `npm run build` succeeds
locally because the local tree is not filtered by `.dockerignore`, which is why
this stayed invisible.

The defect was latent: the export job had never been executed before, so nothing
had exercised this path.

## Fix

Anchor the pattern to the repository root:

```
-scripts/
+/scripts/
```

Root-level operator scripts (`scripts/env-init.sh`, `scripts/generate-keys.sh`,
`scripts/create-password-account.ts`) remain excluded from the image, while
`src/scripts/` is now built and shipped.

## Verification

- Pattern semantics checked both ways: with `/scripts/`, `scripts/env-init.sh`
  is still excluded and `src/scripts/export-product-analytics.ts` is no longer
  excluded.
- `npm run build` emits `dist/scripts/export-product-analytics.js` and
  `dist/scripts/suppress-product-analytics-export.js`.
- No source, dependency, or runtime behavior changes; the server entry point
  `dist/index.js` is unaffected.

Follow-up outside this PR: rebuild and re-pin the analytics auth-export image
from merged `master` so the Cloud Run job can execute.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchored the `scripts/` ignore rule in `.dockerignore` to the repo root so `src/scripts/` is included in the build. This restores `dist/scripts/*` in the production image and fixes the product-analytics export job failing at startup.

- **Bug Fixes**
  - Replaced unanchored `scripts/` with `/scripts/` to exclude only root operator scripts.
  - Verified `npm run build` emits `dist/scripts/export-product-analytics.js` and `dist/scripts/suppress-product-analytics-export.js`.

<sup>Written for commit 86a90f42ca9a636557a2b5079e002c6b7073cf70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

