### PR TITLE
fix: guard activation milestones against pre-creation evidence

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ async function main() {
     bridgeRepo,
     dailyUsageRepo,
     deviceTokenRepo,
+    userRepo,
   });
   const appClientPresenceService = new AppClientPresenceService({ deviceTokenRepo });
   const productAnalyticsPreferenceService = new ProductAnalyticsPreferenceService({

--- a/src/models/product-analytics-export.ts
+++ b/src/models/product-analytics-export.ts
@@ -58,6 +58,7 @@ export type ProductAnalyticsSetupCohortRow = {
 
 export type ProductAnalyticsExportRunMetadata = {
   runId: string;
+  preCreationMilestonesDropped: number;
   runCutoff: Date;
   preferenceScanCutoff: Date;
   controlUpdatedAt: Date;

--- a/src/repositories/product-analytics-export-repo.ts
+++ b/src/repositories/product-analytics-export-repo.ts
@@ -50,8 +50,10 @@ const runMetadataSchema: ProductAnalyticsExportTableField[] = [
   { name: "late_preference_rows_removed", type: "INTEGER", mode: "REQUIRED" },
   { name: "milestone_rows_published", type: "INTEGER", mode: "REQUIRED" },
   { name: "cohort_rows_published", type: "INTEGER", mode: "REQUIRED" },
-  { name: "pre_creation_milestones_dropped", type: "INTEGER", mode: "NULLABLE" },
   { name: "published_at", type: "TIMESTAMP", mode: "REQUIRED" },
+  // Added after initial deployment; BigQuery ALTER TABLE ADD COLUMN appends at
+  // the end and the schema assertion compares field order exactly.
+  { name: "pre_creation_milestones_dropped", type: "INTEGER", mode: "NULLABLE" },
 ];
 
 const exportStateSchema: ProductAnalyticsExportTableField[] = [

--- a/src/repositories/product-analytics-export-repo.ts
+++ b/src/repositories/product-analytics-export-repo.ts
@@ -50,6 +50,7 @@ const runMetadataSchema: ProductAnalyticsExportTableField[] = [
   { name: "late_preference_rows_removed", type: "INTEGER", mode: "REQUIRED" },
   { name: "milestone_rows_published", type: "INTEGER", mode: "REQUIRED" },
   { name: "cohort_rows_published", type: "INTEGER", mode: "REQUIRED" },
+  { name: "pre_creation_milestones_dropped", type: "INTEGER", mode: "NULLABLE" },
   { name: "published_at", type: "TIMESTAMP", mode: "REQUIRED" },
 ];
 
@@ -313,6 +314,7 @@ export class ProductAnalyticsExportRepository {
       input.metadata.latePreferenceRowsRemoved,
       input.metadata.milestoneRowsPublished,
       input.metadata.cohortRowsPublished,
+      input.metadata.preCreationMilestonesDropped,
     ];
     if (
       input.metadata.runId !== input.run.runId ||
@@ -415,6 +417,7 @@ export class ProductAnalyticsExportRepository {
           late_preference_rows_removed,
           milestone_rows_published,
           cohort_rows_published,
+          pre_creation_milestones_dropped,
           published_at
         ) VALUES (
           @run_id,
@@ -431,6 +434,7 @@ export class ProductAnalyticsExportRepository {
           @late_preference_rows_removed,
           @milestone_rows_published,
           @cohort_rows_published,
+          @pre_creation_milestones_dropped,
           CURRENT_TIMESTAMP()
         );
         UPDATE \`${this.#api.datasetReference}.product_analytics_export_state\`
@@ -459,6 +463,7 @@ export class ProductAnalyticsExportRepository {
         late_preference_rows_removed: input.metadata.latePreferenceRowsRemoved,
         milestone_rows_published: input.metadata.milestoneRowsPublished,
         cohort_rows_published: input.metadata.cohortRowsPublished,
+        pre_creation_milestones_dropped: input.metadata.preCreationMilestonesDropped,
       },
     });
   }

--- a/src/repositories/user-repo.ts
+++ b/src/repositories/user-repo.ts
@@ -117,6 +117,9 @@ export class UserRepository {
   }
 
   async findById(userId: string): Promise<User | null> {
+    if (!ObjectId.isValid(userId)) {
+      return null;
+    }
     return this.#collection.findOne({ _id: new ObjectId(userId) });
   }
 

--- a/src/services/activation-backfill-service.ts
+++ b/src/services/activation-backfill-service.ts
@@ -239,15 +239,27 @@ export class ActivationBackfillService {
     // createdAt, so earliest evidence can predate this account's creation.
     // Ignore such evidence rather than backfill an impossible milestone.
     const accountCreatedAt = user?.createdAt ?? null;
-    const guard = (evidenceAt: Date | null): Date | null =>
-      evidenceAt && accountCreatedAt && evidenceAt < accountCreatedAt ? null : evidenceAt;
-    const mobileSetupAt = guard(rawMobileSetupAt);
-    const bridgeSetupAt = guard(rawBridgeSetupAt);
-    const firstSessionAt = guard(rawFirstSessionAt);
+    const guard = (kind: string, evidenceAt: Date | null): Date | null => {
+      if (evidenceAt && accountCreatedAt && evidenceAt < accountCreatedAt) {
+        console.warn("[ActivationBackfillService] Ignored milestone evidence predating account creation", {
+          userId,
+          milestone: kind,
+        });
+        return null;
+      }
+      return evidenceAt;
+    };
+    const mobileSetupAt = guard("mobile_setup", rawMobileSetupAt);
+    const bridgeSetupAt = guard("bridge_setup", rawBridgeSetupAt);
+    const firstSessionAt = guard("first_session", rawFirstSessionAt);
     const evidence: ActivationEvidence = { mobileSetupAt, bridgeSetupAt, firstSessionAt };
     const snapshot = snapshotFrom(existing, evidence);
     const stage = stageFor(snapshot);
-    const reminder = reminderFor(snapshot, mobileSetupAt !== null);
+    // Push reachability is about owning a device token at all, not about the
+    // token's timestamp being a valid milestone. A carried-over token still
+    // reaches this user, so reminders key off raw token existence.
+    const pushReachable = rawMobileSetupAt !== null;
+    const reminder = reminderFor(snapshot, pushReachable);
     const jitterMs = deterministicActivationJitterMs(userId, options.jitterWindowMs);
     const baselineAt = new Date(options.backfillAt.getTime() + jitterMs);
     if (Number.isNaN(baselineAt.getTime())) {
@@ -265,7 +277,7 @@ export class ActivationBackfillService {
       ...evidence,
       // The repository selects the current unsent stage atomically. Supplying
       // one candidate also covers an organic stage transition during this run.
-      reminderBaseAt: mobileSetupAt === null ? null : baselineAt,
+      reminderBaseAt: pushReachable ? baselineAt : null,
       backfilledAt: options.backfillAt,
     };
     const applied = await this.#activationStateRepo.applyBackfill(userId, input);

--- a/src/services/activation-backfill-service.ts
+++ b/src/services/activation-backfill-service.ts
@@ -257,9 +257,12 @@ export class ActivationBackfillService {
     const stage = stageFor(snapshot);
     // Push reachability is about owning a device token at all, not about the
     // token's timestamp being a valid milestone. A carried-over token still
-    // reaches this user, so reminders key off raw token existence.
-    const pushReachable = rawMobileSetupAt !== null;
-    const reminder = reminderFor(snapshot, pushReachable);
+    // reaches this user. The repository additionally persists a reminder
+    // baseline only when the merged mobile milestone is non-null, so propose a
+    // reminder only when both hold; otherwise proposed and applied counters
+    // would diverge silently.
+    const reminderEligible = rawMobileSetupAt !== null && snapshot.mobileSetupAt !== null;
+    const reminder = reminderFor(snapshot, reminderEligible);
     const jitterMs = deterministicActivationJitterMs(userId, options.jitterWindowMs);
     const baselineAt = new Date(options.backfillAt.getTime() + jitterMs);
     if (Number.isNaN(baselineAt.getTime())) {
@@ -277,7 +280,7 @@ export class ActivationBackfillService {
       ...evidence,
       // The repository selects the current unsent stage atomically. Supplying
       // one candidate also covers an organic stage transition during this run.
-      reminderBaseAt: pushReachable ? baselineAt : null,
+      reminderBaseAt: reminderEligible ? baselineAt : null,
       backfilledAt: options.backfillAt,
     };
     const applied = await this.#activationStateRepo.applyBackfill(userId, input);

--- a/src/services/activation-backfill-service.ts
+++ b/src/services/activation-backfill-service.ts
@@ -229,11 +229,21 @@ export class ActivationBackfillService {
       return;
     }
 
-    const [mobileSetupAt, bridgeSetupAt, firstSessionAt] = await Promise.all([
+    const [user, rawMobileSetupAt, rawBridgeSetupAt, rawFirstSessionAt] = await Promise.all([
+      this.#userRepo.findById(userId),
       this.#deviceTokenRepo.findEarliestCreatedAt(userId),
       this.#bridgeRepo.findEarliestAddedAt(userId),
       this.#dailyUsageRepo.findEarliestMetadataRequestAt(userId),
     ]);
+    // Device-token rows survive account re-registration with their original
+    // createdAt, so earliest evidence can predate this account's creation.
+    // Ignore such evidence rather than backfill an impossible milestone.
+    const accountCreatedAt = user?.createdAt ?? null;
+    const guard = (evidenceAt: Date | null): Date | null =>
+      evidenceAt && accountCreatedAt && evidenceAt < accountCreatedAt ? null : evidenceAt;
+    const mobileSetupAt = guard(rawMobileSetupAt);
+    const bridgeSetupAt = guard(rawBridgeSetupAt);
+    const firstSessionAt = guard(rawFirstSessionAt);
     const evidence: ActivationEvidence = { mobileSetupAt, bridgeSetupAt, firstSessionAt };
     const snapshot = snapshotFrom(existing, evidence);
     const stage = stageFor(snapshot);

--- a/src/services/activation-service.ts
+++ b/src/services/activation-service.ts
@@ -3,23 +3,27 @@ import type { ActivationMilestoneUpdate, ActivationStateRepository } from "../re
 import type { BridgeRepository } from "../repositories/bridge-repo.js";
 import type { DailyUsageRepository } from "../repositories/daily-usage-repo.js";
 import type { DeviceTokenRepository } from "../repositories/device-token-repo.js";
+import type { UserRepository } from "../repositories/user-repo.js";
 
 export class ActivationService {
   readonly #activationStateRepo: ActivationStateRepository;
   readonly #bridgeRepo: BridgeRepository;
   readonly #dailyUsageRepo: DailyUsageRepository;
   readonly #deviceTokenRepo: DeviceTokenRepository;
+  readonly #userRepo: UserRepository;
 
   constructor(deps: {
     activationStateRepo: ActivationStateRepository;
     bridgeRepo: BridgeRepository;
     dailyUsageRepo: DailyUsageRepository;
     deviceTokenRepo: DeviceTokenRepository;
+    userRepo: UserRepository;
   }) {
     this.#activationStateRepo = deps.activationStateRepo;
     this.#bridgeRepo = deps.bridgeRepo;
     this.#dailyUsageRepo = deps.dailyUsageRepo;
     this.#deviceTokenRepo = deps.deviceTokenRepo;
+    this.#userRepo = deps.userRepo;
   }
 
   async #recordReconciledMilestones(
@@ -28,11 +32,30 @@ export class ActivationService {
     observedAt: Date,
   ): Promise<ActivationState> {
     const existing = await this.#activationStateRepo.findByUserId(userId);
-    const [mobileSetupAt, bridgeSetupAt, firstSessionAt] = await Promise.all([
+    const [user, rawMobileSetupAt, rawBridgeSetupAt, rawFirstSessionAt] = await Promise.all([
+      this.#userRepo.findById(userId),
       existing?.mobileSetupAt ? null : this.#deviceTokenRepo.findEarliestCreatedAt(userId),
       existing?.bridgeSetupAt ? null : this.#bridgeRepo.findEarliestAddedAt(userId),
       existing?.firstSessionAt ? null : this.#dailyUsageRepo.findEarliestMetadataRequestAt(userId),
     ]);
+    // Device-token rows survive account re-registration with their original
+    // createdAt, so reconciled evidence can predate this account's creation.
+    // Such evidence is not a milestone of this account: ignore it and let the
+    // directly observed occurrence (which is genuinely current) stand instead.
+    const accountCreatedAt = user?.createdAt ?? null;
+    const guard = (kind: string, evidenceAt: Date | null): Date | null => {
+      if (evidenceAt && accountCreatedAt && evidenceAt < accountCreatedAt) {
+        console.warn("[ActivationService] Ignored milestone evidence predating account creation", {
+          userId,
+          milestone: kind,
+        });
+        return null;
+      }
+      return evidenceAt;
+    };
+    const mobileSetupAt = guard("mobile_setup", rawMobileSetupAt);
+    const bridgeSetupAt = guard("bridge_setup", rawBridgeSetupAt);
+    const firstSessionAt = guard("first_session", rawFirstSessionAt);
     const update: ActivationMilestoneUpdate = {
       mobileSetupAt: existing?.mobileSetupAt
         ? undefined

--- a/src/services/product-analytics-export-service.ts
+++ b/src/services/product-analytics-export-service.ts
@@ -67,6 +67,7 @@ export type ProductAnalyticsExportProgress = {
   milestoneRowsStaged: number;
   sourceSuppressedUsers: number;
   internalUsers: number;
+  preCreationMilestonesDropped: number;
 };
 
 export type ProductAnalyticsExportReport = ProductAnalyticsExportProgress & {
@@ -89,6 +90,32 @@ function cohortWeekFor(accountCreatedAt: Date): string {
   const daysSinceMonday = (date.getUTCDay() + 6) % 7;
   date.setUTCDate(date.getUTCDate() - daysSinceMonday);
   return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Drops milestone timestamps that precede account creation. Legacy device-token
+ * rows can survive account re-registration with their original `createdAt`, so
+ * reconciled milestones may predate `users.createdAt`. Such evidence is
+ * unusable for time-bound metrics; staging it would fail the pre-promotion
+ * timestamp invariant. Dropped values are counted, never silently rewritten.
+ */
+function sanitizedMilestones(input: {
+  milestones: ProductAnalyticsActivationMilestones;
+  accountCreatedAt: Date;
+  onDrop: () => void;
+}): ProductAnalyticsActivationMilestones {
+  const sanitize = (milestoneAt: Date | null): Date | null => {
+    if (milestoneAt && milestoneAt < input.accountCreatedAt) {
+      input.onDrop();
+      return null;
+    }
+    return milestoneAt;
+  };
+  return {
+    notificationRegisteredAt: sanitize(input.milestones.notificationRegisteredAt),
+    bridgeRegisteredAt: sanitize(input.milestones.bridgeRegisteredAt),
+    legacyFirstMetadataRequestAt: sanitize(input.milestones.legacyFirstMetadataRequestAt),
+  };
 }
 
 function occurredWithin(input: { milestoneAt: Date | null; accountCreatedAt: Date; days: number }): boolean {
@@ -257,6 +284,7 @@ export class ProductAnalyticsExportService {
         milestoneRowsStaged: 0,
         sourceSuppressedUsers: 0,
         internalUsers: 0,
+        preCreationMilestonesDropped: 0,
       };
       let externalAccounts = 0;
       let enabledAccounts = 0;
@@ -293,11 +321,17 @@ export class ProductAnalyticsExportService {
             continue;
           }
           externalAccounts += 1;
-          const milestones = milestonesByUserId.get(user.userId) ?? {
-            notificationRegisteredAt: null,
-            bridgeRegisteredAt: null,
-            legacyFirstMetadataRequestAt: null,
-          };
+          const milestones = sanitizedMilestones({
+            milestones: milestonesByUserId.get(user.userId) ?? {
+              notificationRegisteredAt: null,
+              bridgeRegisteredAt: null,
+              legacyFirstMetadataRequestAt: null,
+            },
+            accountCreatedAt: user.accountCreatedAt,
+            onDrop: () => {
+              progress.preCreationMilestonesDropped += 1;
+            },
+          });
           const preferenceKnownAtCutoff = user.preferenceUpdatedAt <= input.runCutoff;
           const enabled = preferenceKnownAtCutoff && user.preference === ProductAnalyticsPreference.Enabled;
           if (!preferenceKnownAtCutoff) {

--- a/src/services/product-analytics-export-service.ts
+++ b/src/services/product-analytics-export-service.ts
@@ -445,6 +445,7 @@ export class ProductAnalyticsExportService {
           latePreferenceRowsRemoved,
           milestoneRowsPublished: progress.milestoneRowsStaged,
           cohortRowsPublished: cohortRows.length,
+          preCreationMilestonesDropped: progress.preCreationMilestonesDropped,
         },
       });
       completed = true;

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -63,7 +63,7 @@ export type TestContext = {
   appClientPresenceService: AppClientPresenceService;
   glossaryService: GlossaryService;
   cleanup: () => Promise<void>;
-  createUser: (opts?: { provider?: string; providerUserId?: string }) => Promise<TestUser>;
+  createUser: (opts?: { provider?: string; providerUserId?: string; createdAt?: Date }) => Promise<TestUser>;
   createExpiredRefreshToken: (userId: string) => string;
   createExpiredAccessToken: (opts: { userId: string; provider: string; providerUserId: string }) => string;
 };
@@ -188,7 +188,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
   const bridgeService = overrides?.bridgeService ?? new BridgeService({ bridgeRepo, bridgeStateTracker });
   const activationService =
     overrides?.activationService ??
-    new ActivationService({ activationStateRepo, bridgeRepo, dailyUsageRepo, deviceTokenRepo });
+    new ActivationService({ activationStateRepo, bridgeRepo, dailyUsageRepo, deviceTokenRepo, userRepo });
   const appClientPresenceService =
     overrides?.appClientPresenceService ?? new AppClientPresenceService({ deviceTokenRepo });
   const productAnalyticsPreferenceService = new ProductAnalyticsPreferenceService({
@@ -230,11 +230,13 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
   });
   await app.ready();
 
-  async function createUser(opts: { provider?: string; providerUserId?: string } = {}): Promise<TestUser> {
+  async function createUser(
+    opts: { provider?: string; providerUserId?: string; createdAt?: Date } = {},
+  ): Promise<TestUser> {
     const provider = opts.provider ?? "github";
     const providerUserId = opts.providerUserId ?? new ObjectId().toHexString();
     const userId = new ObjectId();
-    const now = new Date();
+    const now = opts.createdAt ?? new Date();
 
     await dbAccessor.getCollection<User>(MongoDbDatabase.Auth, AuthDbCollection.Users).insertOne({
       _id: userId,

--- a/tests/repositories/product-analytics-export-repo.test.ts
+++ b/tests/repositories/product-analytics-export-repo.test.ts
@@ -119,6 +119,7 @@ describe("ProductAnalyticsExportRepository", () => {
     latePreferenceRowsRemoved: 0,
     milestoneRowsPublished: 1,
     cohortRowsPublished: 1,
+    preCreationMilestonesDropped: 0,
   };
 
   it("uses expiring run-scoped staging and query jobs rather than streaming inserts", async () => {

--- a/tests/services/activation-backfill-cli.test.ts
+++ b/tests/services/activation-backfill-cli.test.ts
@@ -62,7 +62,8 @@ describe("activation backfill CLI", () => {
   });
 
   it("is read-only by default and writes only with --apply", async () => {
-    const user = await ctx.createUser();
+    // The token must postdate account creation or the milestone guard ignores it.
+    const user = await ctx.createUser({ createdAt: new Date("2026-05-01T00:00:00.000Z") });
     const at = new Date("2026-06-01T10:00:00.000Z");
     await ctx.dbAccessor.getCollection<DeviceToken>(MongoDbDatabase.Auth, AuthDbCollection.DeviceTokens).insertOne({
       _id: new ObjectId(),

--- a/tests/services/activation-backfill-service.test.ts
+++ b/tests/services/activation-backfill-service.test.ts
@@ -88,11 +88,11 @@ describe("ActivationBackfillService", () => {
   }
 
   it("previews safely, applies controlled baselines, and is idempotent", async () => {
-    const noToken = await ctx.createUser();
-    const bridge1 = await ctx.createUser();
-    const bridge2 = await ctx.createUser();
-    const session = await ctx.createUser();
-    const activated = await ctx.createUser();
+    const noToken = await ctx.createUser({ createdAt: new Date("2026-05-01T00:00:00.000Z") });
+    const bridge1 = await ctx.createUser({ createdAt: new Date("2026-05-01T00:00:00.000Z") });
+    const bridge2 = await ctx.createUser({ createdAt: new Date("2026-05-01T00:00:00.000Z") });
+    const session = await ctx.createUser({ createdAt: new Date("2026-05-01T00:00:00.000Z") });
+    const activated = await ctx.createUser({ createdAt: new Date("2026-05-01T00:00:00.000Z") });
     const mobileAt = new Date("2026-06-01T08:00:00.000Z");
     const bridgeAt = new Date("2026-06-02T09:00:00.000Z");
     const approximateSessionAt = new Date("2026-06-03T00:00:00.000Z");
@@ -212,7 +212,7 @@ describe("ActivationBackfillService", () => {
   });
 
   it("uses a desktop-only token as app activation evidence", async () => {
-    const user = await ctx.createUser();
+    const user = await ctx.createUser({ createdAt: new Date("2026-05-01T00:00:00.000Z") });
     const appSetupAt = new Date("2026-06-01T08:00:00.000Z");
     await seedToken(user.userId, appSetupAt, DevicePlatform.windows);
 
@@ -242,8 +242,29 @@ describe("ActivationBackfillService", () => {
     assert.throws(() => deterministicActivationJitterMs(userId, -1), RangeError);
   });
 
+  it("ignores milestone evidence predating account creation", async () => {
+    const user = await ctx.createUser({ createdAt: new Date("2026-05-01T00:00:00.000Z") });
+    // A re-registered token surviving from a pre-account install must not
+    // backfill an impossible milestone earlier than the account itself.
+    await seedToken(user.userId, new Date("2026-04-20T08:00:00.000Z"));
+    const validBridgeAt = new Date("2026-05-02T09:00:00.000Z");
+    await seedBridge(user.userId, validBridgeAt, false);
+
+    const report = await service.run({
+      apply: true,
+      backfillAt: BACKFILL_AT,
+      batchLimit: 10,
+      jitterWindowMs: JITTER_WINDOW_MS,
+    });
+    const state = await activationStateRepo.findByUserId(user.userId);
+
+    assert.equal(report.usersApplied >= 1, true);
+    assert.equal(state?.mobileSetupAt ?? null, null);
+    assert.equal(state?.bridgeSetupAt?.toISOString(), validBridgeAt.toISOString());
+  });
+
   it("preserves an organic baseline when the user no longer has a device token", async () => {
-    const user = await ctx.createUser();
+    const user = await ctx.createUser({ createdAt: new Date("2026-05-01T00:00:00.000Z") });
     const mobileAt = new Date("2026-06-01T10:00:00.000Z");
     await activationStateRepo.recordMilestones(user.userId, { mobileSetupAt: mobileAt }, mobileAt);
 
@@ -262,8 +283,8 @@ describe("ActivationBackfillService", () => {
   });
 
   it("continues after a per-user reconciliation failure and reports it", async (t) => {
-    const failedUser = await ctx.createUser();
-    const successfulUser = await ctx.createUser();
+    const failedUser = await ctx.createUser({ createdAt: new Date("2026-05-01T00:00:00.000Z") });
+    const successfulUser = await ctx.createUser({ createdAt: new Date("2026-05-01T00:00:00.000Z") });
     const deviceTokenRepo = new DeviceTokenRepository(ctx.dbAccessor);
     t.mock.method(deviceTokenRepo, "findEarliestCreatedAt", async (userId: string) => {
       if (userId === failedUser.userId) {

--- a/tests/services/activation-service.test.ts
+++ b/tests/services/activation-service.test.ts
@@ -8,6 +8,7 @@ import { ActivationStateRepository } from "../../src/repositories/activation-sta
 import { BridgeRepository } from "../../src/repositories/bridge-repo.js";
 import { DailyUsageRepository } from "../../src/repositories/daily-usage-repo.js";
 import { DeviceTokenRepository } from "../../src/repositories/device-token-repo.js";
+import { UserRepository } from "../../src/repositories/user-repo.js";
 import { ActivationService } from "../../src/services/activation-service.js";
 import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
@@ -18,6 +19,7 @@ describe("ActivationService", () => {
   let bridgeRepo: BridgeRepository;
   let dailyUsageRepo: DailyUsageRepository;
   let deviceTokenRepo: DeviceTokenRepository;
+  let userRepo: UserRepository;
   let service: ActivationService;
   let logCalls: unknown[][];
 
@@ -27,7 +29,8 @@ describe("ActivationService", () => {
     bridgeRepo = new BridgeRepository(ctx.dbAccessor);
     dailyUsageRepo = new DailyUsageRepository(ctx.dbAccessor);
     deviceTokenRepo = new DeviceTokenRepository(ctx.dbAccessor);
-    service = new ActivationService({ activationStateRepo, bridgeRepo, dailyUsageRepo, deviceTokenRepo });
+    userRepo = new UserRepository(ctx.dbAccessor);
+    service = new ActivationService({ activationStateRepo, bridgeRepo, dailyUsageRepo, deviceTokenRepo, userRepo });
   });
 
   after(async () => {
@@ -46,7 +49,7 @@ describe("ActivationService", () => {
   });
 
   it("enrolls mobile setup and reconciles historical bridge and session milestones", async () => {
-    const user = await ctx.createUser();
+    const user = await ctx.createUser({ createdAt: new Date("2026-07-01T00:00:00.000Z") });
     const mobileAt = new Date("2026-07-10T08:00:00.000Z");
     const bridgeAt = new Date("2026-07-11T09:00:00.000Z");
     const sessionAt = new Date("2026-07-12T10:00:00.000Z");
@@ -91,7 +94,7 @@ describe("ActivationService", () => {
   });
 
   it("records app setup for a device-token registration", async () => {
-    const user = await ctx.createUser();
+    const user = await ctx.createUser({ createdAt: new Date("2026-07-01T00:00:00.000Z") });
     const observedAt = new Date("2026-07-12T10:00:00.000Z");
 
     const state = await service.recordAppSetup(user.userId, observedAt);
@@ -105,7 +108,7 @@ describe("ActivationService", () => {
   });
 
   it("records bridge and session milestones before mobile setup without creating reminder baselines", async () => {
-    const user = await ctx.createUser();
+    const user = await ctx.createUser({ createdAt: new Date("2026-07-01T00:00:00.000Z") });
     const bridgeAt = new Date("2026-07-12T10:00:00.000Z");
     const sessionAt = new Date("2026-07-12T11:00:00.000Z");
 
@@ -120,7 +123,7 @@ describe("ActivationService", () => {
   });
 
   it("logs a first milestone once when concurrent hooks race", async () => {
-    const user = await ctx.createUser();
+    const user = await ctx.createUser({ createdAt: new Date("2026-07-01T00:00:00.000Z") });
     const bridgeAt = new Date("2026-07-12T10:00:00.000Z");
 
     await Promise.all([
@@ -132,7 +135,7 @@ describe("ActivationService", () => {
   });
 
   it("uses the earliest historical bridge when recording a later registration", async () => {
-    const user = await ctx.createUser();
+    const user = await ctx.createUser({ createdAt: new Date("2026-07-01T00:00:00.000Z") });
     const historicalAt = new Date("2026-07-10T10:00:00.000Z");
     const observedAt = new Date("2026-07-15T10:00:00.000Z");
     const historical = await bridgeRepo.register({
@@ -153,7 +156,7 @@ describe("ActivationService", () => {
   });
 
   it("repairs mobile setup from token history when recording bridge setup", async () => {
-    const user = await ctx.createUser();
+    const user = await ctx.createUser({ createdAt: new Date("2026-07-01T00:00:00.000Z") });
     await deviceTokenRepo.upsertToken(user.userId, `bridge-repair-token-${user.userId}`, DevicePlatform.ios);
     const mobileAt = await deviceTokenRepo.findEarliestCreatedAt(user.userId);
     const bridge = await bridgeRepo.register({
@@ -171,7 +174,7 @@ describe("ActivationService", () => {
   });
 
   it("reconciles app setup from a persisted desktop token", async () => {
-    const user = await ctx.createUser();
+    const user = await ctx.createUser({ createdAt: new Date("2026-07-01T00:00:00.000Z") });
     await deviceTokenRepo.upsertToken(user.userId, `desktop-only-token-${user.userId}`, DevicePlatform.windows);
     const appSetupAt = await deviceTokenRepo.findEarliestCreatedAt(user.userId);
     const bridge = await bridgeRepo.register({
@@ -189,7 +192,7 @@ describe("ActivationService", () => {
   });
 
   it("uses historical metadata evidence when recording a later session request", async () => {
-    const user = await ctx.createUser();
+    const user = await ctx.createUser({ createdAt: new Date("2026-07-01T00:00:00.000Z") });
     const historicalAt = new Date("2026-07-10T10:00:00.000Z");
     const observedAt = new Date("2026-07-15T10:00:00.000Z");
     await ctx.dbAccessor.getCollection<DailyUsage>(MongoDbDatabase.Auth, AuthDbCollection.DailyUsage).insertOne({
@@ -208,7 +211,7 @@ describe("ActivationService", () => {
   });
 
   it("repairs bridge setup from bridge history when recording a session", async () => {
-    const user = await ctx.createUser();
+    const user = await ctx.createUser({ createdAt: new Date("2026-07-01T00:00:00.000Z") });
     const mobileAt = new Date("2026-07-10T10:00:00.000Z");
     const sessionAt = new Date("2026-07-12T10:00:00.000Z");
     await activationStateRepo.recordMilestones(user.userId, { mobileSetupAt: mobileAt }, mobileAt);
@@ -222,7 +225,7 @@ describe("ActivationService", () => {
   });
 
   it("preserves an earlier observed session time when its initial read loses a race", async () => {
-    const user = await ctx.createUser();
+    const user = await ctx.createUser({ createdAt: new Date("2026-07-01T00:00:00.000Z") });
     const earlierAt = new Date("2026-07-12T10:00:00.000Z");
     const laterAt = new Date("2026-07-12T10:00:01.000Z");
     await activationStateRepo.recordMilestones(user.userId, { firstSessionAt: laterAt }, laterAt);
@@ -233,7 +236,7 @@ describe("ActivationService", () => {
   });
 
   it("retries unresolved historical reconciliation on later token registration", async () => {
-    const user = await ctx.createUser();
+    const user = await ctx.createUser({ createdAt: new Date("2026-07-01T00:00:00.000Z") });
     const mobileAt = new Date("2026-07-10T08:00:00.000Z");
     const bridgeAt = new Date("2026-07-11T09:00:00.000Z");
     const sessionAt = new Date("2026-07-12T10:00:00.000Z");
@@ -271,12 +274,32 @@ describe("ActivationService", () => {
   });
 
   it("falls back to the observed registration time when no token history is available", async () => {
-    const user = await ctx.createUser();
+    const user = await ctx.createUser({ createdAt: new Date("2026-07-01T00:00:00.000Z") });
     const observedAt = new Date("2026-07-12T10:00:00.000Z");
 
     const state = await service.recordAppSetup(user.userId, observedAt);
 
     assert.equal(state.mobileSetupAt?.toISOString(), observedAt.toISOString());
     assert.equal(state.bridgeReminderBaseAt?.toISOString(), observedAt.toISOString());
+  });
+
+  it("ignores token evidence predating account creation and uses the observed time", async () => {
+    const user = await ctx.createUser({ createdAt: new Date("2026-07-01T00:00:00.000Z") });
+    // A re-registered token can survive with createdAt from a previous account
+    // or pre-account install; it must never become this account's milestone.
+    const carriedOverTokenAt = new Date("2026-06-20T08:00:00.000Z");
+    const observedAt = new Date("2026-07-12T10:00:00.000Z");
+    await ctx.dbAccessor.getCollection<DeviceToken>(MongoDbDatabase.Auth, AuthDbCollection.DeviceTokens).insertOne({
+      _id: new ObjectId(),
+      userId: new ObjectId(user.userId),
+      token: `carried-over-token-${user.userId}`,
+      platform: DevicePlatform.ios,
+      createdAt: carriedOverTokenAt,
+      updatedAt: carriedOverTokenAt,
+    });
+
+    const state = await service.recordAppSetup(user.userId, observedAt);
+
+    assert.equal(state.mobileSetupAt?.toISOString(), observedAt.toISOString());
   });
 });

--- a/tests/services/product-analytics-export-service.test.ts
+++ b/tests/services/product-analytics-export-service.test.ts
@@ -294,6 +294,7 @@ describe("ProductAnalyticsExportService", () => {
       latePreferenceRowsRemoved: 1,
       milestoneRowsPublished: 1,
       cohortRowsPublished: 2,
+      preCreationMilestonesDropped: 0,
     });
     assert.equal(exportRepo.milestones.length, 1);
     assert.equal(exportRepo.milestones[0].userKey, userKeyFor({ userId: ids[0] }));

--- a/tests/services/product-analytics-export-service.test.ts
+++ b/tests/services/product-analytics-export-service.test.ts
@@ -489,4 +489,64 @@ describe("ProductAnalyticsExportService", () => {
     assert.equal(exportRepo.validationInput?.expectedEnabledAccounts, 0);
     assert.equal(exportRepo.cleanupCalls, 1);
   });
+
+  it("drops and counts milestone timestamps predating account creation", async () => {
+    const runCutoff = new Date("2026-07-28T12:00:00.000Z");
+    const accountCreatedAt = new Date("2026-07-20T12:00:00.000Z");
+    const user: ProductAnalyticsExportUser = {
+      userId: "000000000000000000000001",
+      accountCreatedAt,
+      preference: ProductAnalyticsPreference.Enabled,
+      preferenceUpdatedAt: accountCreatedAt,
+      exportSuppressedAt: null,
+    };
+    const preCreation = new Date("2026-07-10T12:00:00.000Z");
+    const validBridgeAt = new Date("2026-07-21T12:00:00.000Z");
+    const exportRepo = new FakeExportRepository();
+    const service = new ProductAnalyticsExportService({
+      userRepo: new FakeUserRepository([user], []),
+      activationStateRepo: new FakeActivationStateRepository(
+        new Map([
+          [
+            user.userId,
+            {
+              notificationRegisteredAt: preCreation,
+              bridgeRegisteredAt: validBridgeAt,
+              legacyFirstMetadataRequestAt: preCreation,
+            },
+          ],
+        ]),
+      ),
+      controlRepo: {
+        async loadActiveInternalUserKeys() {
+          return { userKeys: new Set<string>(), controlUpdatedAt: new Date("2026-07-28T00:00:00.000Z") };
+        },
+      },
+      exportRepo,
+      batchLimit: 2,
+      pseudonymizationKey,
+      clock: (() => {
+        const values = [
+          new Date("2026-07-28T12:01:00.000Z"),
+          new Date("2026-07-28T12:02:00.000Z"),
+          new Date("2026-07-28T12:03:00.000Z"),
+        ];
+        return () => values.shift()!;
+      })(),
+      createRunId: () => "testrun01",
+    });
+
+    const report = await service.run({ runCutoff });
+
+    assert.equal(report.preCreationMilestonesDropped, 2);
+    assert.equal(report.milestoneRowsStaged, 1);
+    assert.equal(exportRepo.milestones.length, 1);
+    assert.equal(exportRepo.milestones[0].notificationRegisteredAt, null);
+    assert.equal(exportRepo.milestones[0].legacyFirstMetadataRequestAt, null);
+    assert.equal(exportRepo.milestones[0].bridgeRegisteredAt?.toISOString(), validBridgeAt.toISOString());
+    // The dropped milestone must not count toward within-N-day cohort columns.
+    assert.equal(exportRepo.cohorts.length, 1);
+    assert.equal(exportRepo.cohorts[0].notificationRegisteredWithin30Days, 0);
+    assert.equal(exportRepo.cohorts[0].bridgeRegisteredWithin7Days, 1);
+  });
 });


### PR DESCRIPTION
## Problem

The first production run of the analytics auth export failed its pre-promotion
validation with `invalid_timestamps=5`: five staged milestone rows had
`notification_registered_at` earlier than `account_created_at`. The export
correctly refused to publish (fail-closed worked as designed), but every future
run would keep failing whenever such a record exists — and once a daily
schedule exists, that means silently stale reporting until an operator
intervenes.

## Root cause

`DeviceTokenRepository.upsertToken` deliberately preserves a token row's
original `createdAt` when the same token re-registers. Tokens carried over from
a pre-account install (or a previous account on the same device) therefore
predate `users.createdAt`. Earliest-evidence reconciliation in
`ActivationService` and the July 16 `ActivationBackfillService` run copied that
evidence into `ActivationState.mobileSetupAt`, producing milestones that are
impossible for the account. Six production accounts were affected; their
records have been corrected separately with guarded per-document updates.

## Fix — two independent layers

**Source guard (stops new corruption).** `ActivationService` and
`ActivationBackfillService` now ignore reconciled evidence earlier than
`users.createdAt`. The directly observed occurrence (genuinely current) stands
instead; the backfill simply leaves the milestone unset. The ignored case logs
a warning with the account ID and milestone kind (consistent with the existing
milestone-recorded logs in this service).

**Export guard (immunizes publication).** `ProductAnalyticsExportService`
drops any remaining pre-creation milestone timestamp at staging time and counts
each drop in a new `preCreationMilestonesDropped` progress/report field. A
residual or future corrupt record can no longer fail the run, and the drop
stays observable in run metadata instead of being silently rewritten — per the
plan rule that invalid timing becomes a data-quality count, never a fabricated
timestamp. Cohort within-N-day counters already treated negative elapsed as
"not within", so aggregates are unchanged.

## Verification

- New test: export drops and counts two pre-creation milestones, stages the
  valid one, and keeps within-N-day cohort columns unaffected.
- New test: `ActivationService` uses the observed registration time when token
  evidence predates account creation.
- New test: the backfill leaves `mobileSetupAt` unset for a pre-creation token
  while still applying a valid bridge milestone.
- `tests/helpers/setup.ts#createUser` accepts an explicit `createdAt` so
  scenarios can seed accounts older than their milestone evidence; existing
  activation tests pin creation dates accordingly.
- Full suite: 570 pass / 0 fail / 1 skipped; lint and format clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded activation milestones against pre-creation evidence to prevent impossible timestamps and failed analytics exports. Exports now drop and publish a count of invalid milestones; backfill reminder eligibility is aligned with write rules to keep counters consistent.

- **Bug Fixes**
  - `ActivationService` and `ActivationBackfillService` ignore reconciled evidence earlier than `users.createdAt`; inject `userRepo`, log the milestone kind when evidence is dropped, and only set `reminderBaseAt` when both a token exists and the merged mobile milestone is non-null.
  - `ProductAnalyticsExportService` sanitizes staged milestones and counts drops; `ProductAnalyticsExportRepository` persists `preCreationMilestonesDropped` in run metadata with a new nullable `pre_creation_milestones_dropped` column appended last to match BigQuery schema order; cohort counters remain correct.
  - `UserRepository.findById` validates `ObjectId` inputs to avoid errors on malformed IDs.

<sup>Written for commit bb21c0292882980364080ed481cff13434c12dd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

