### PR TITLE
docs(notifications): record the token-rotation gap in the deviceId rollout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,8 @@ Every push producer funnels through `NotificationService.sendToUser`, so that is
 
 `register-token` predates this feature and every shipped client already calls it with only `{ token, platform }`, so requiring `deviceId` outright would 400 every existing install and remove it from push entirely — a registration failure is not a degraded filter, it is no notifications at all. `AUTH_REQUIRE_DEVICE_ID_IN_TOKEN_REGISTRATION` gates that cutover: ship with it unset, ship the client that sends `deviceId`, then flip it once the install base has rolled over. Same shape as the retired `AUTH_REQUIRE_BRIDGE_ID_IN_STATUS` gate; delete it the same way once every client sends the field.
 
+Fail-open has a cost worth stating: `deviceTokens` is unique on `token`, not `deviceId`, so a device can hold several rows and a token rotation leaves the previous one behind until FCM reports it unregistered. A row predating the client change still has `deviceId: null` and delivers a category that device switched off. Enabling the gate stops new null rows but does not rewrite existing ones, so the window closes by attrition unless the remaining `deviceId: null` rows are deleted deliberately. Do not "fix" this by inverting the fail-open default while clients are mid-rollout — that mutes every install that has not updated.
+
 Filtering applies to activation reminders too — they send `system_update`, so a user who disables that toggle stops receiving them. When every device opts out, `sendToUser` returns `devicesNotified: 0` without calling FCM, and `ActivationReminderService` treats that as a genuine zero-device result and marks the reminder complete rather than retrying forever.
 
 ## ANTI-PATTERNS

--- a/README.md
+++ b/README.md
@@ -191,7 +191,14 @@ Do not flip it before step 2 completes. Registration failures do not degrade fil
 
 **Known gap while `deviceId` is still optional.** `deviceTokens` is unique on `token`, not on `deviceId`, so one device can hold more than one row. When FCM rotates a token the client registers the new one, and the previous row survives until FCM reports it unregistered on a later send. A row registered before the client sent `deviceId` therefore still has `deviceId: null`, fails open, and can deliver a category that device has switched off. It resolves itself once the stale token is cleaned up, but it is a real window in which an opt-out is not honoured.
 
-Step 3 stops new rows from being created without a `deviceId`; it does **not** retroactively fix rows that already have `deviceId: null`. Those keep failing open until FCM disowns them. If you need the gap closed immediately rather than by attrition, delete the remaining `deviceId: null` rows after step 3 — clients re-register on the next sign-in or token refresh, at the cost of a short window with no push for those devices.
+Step 3 stops new rows from being created without a `deviceId`; it does **not** retroactively fix rows that already have `deviceId: null`. Those keep failing open until FCM disowns them.
+
+If you need the gap closed immediately rather than by attrition, delete the remaining `deviceId: null` rows after step 3. Deleting a row that is still a live token does remove push for that install until it registers again, so the cost depends on what triggers re-registration:
+
+- **App start.** The client registers on launch for a signed-in user, so a device that is opened again recovers on that launch. This is the normal case and bounds the outage to the user's next session.
+- **Sign-in or FCM token refresh.** Also triggers registration, but neither is time-bounded on its own.
+
+A device whose app is never opened again stays unregistered — it would receive nothing anyway, but it will not self-heal. Run the deletion when you can watch registrations recover rather than immediately before a quiet period, and prefer attrition if you are not in a position to confirm that.
 
 ## Environment variables
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ Sequence the cutover with `AUTH_REQUIRE_DEVICE_ID_IN_TOKEN_REGISTRATION`:
 
 Do not flip it before step 2 completes. Registration failures do not degrade filtering — they remove the client from push entirely until it updates, because the token never reaches the server. Flipping back to unset restores the previous behaviour immediately; no data migration is involved either way.
 
+**Known gap while `deviceId` is still optional.** `deviceTokens` is unique on `token`, not on `deviceId`, so one device can hold more than one row. When FCM rotates a token the client registers the new one, and the previous row survives until FCM reports it unregistered on a later send. A row registered before the client sent `deviceId` therefore still has `deviceId: null`, fails open, and can deliver a category that device has switched off. It resolves itself once the stale token is cleaned up, but it is a real window in which an opt-out is not honoured.
+
+Step 3 stops new rows from being created without a `deviceId`; it does **not** retroactively fix rows that already have `deviceId: null`. Those keep failing open until FCM disowns them. If you need the gap closed immediately rather than by attrition, delete the remaining `deviceId: null` rows after step 3 — clients re-register on the next sign-in or token refresh, at the cost of a short window with no push for those devices.
+
 ## Environment variables
 
 Managed via SOPS-encrypted files in `env/app/`. See `.sops.yaml` for key configuration.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ If you need the gap closed immediately rather than by attrition, delete the rema
 
 A device whose app is never opened again does not self-heal, and the loss there is real rather than theoretical: its token is live and still receiving push today, precisely because an unmatched token fails open. Deleting that row stops notifications the device would otherwise have kept getting, permanently until the app is next opened.
 
-So the choice is between leaving a filtering gap open while it drains by attrition, and closing it immediately at the cost of silencing installs that are still reachable but no longer launched. Run the deletion where registrations recovering can be observed, and prefer attrition when they cannot.
+So the choice is between leaving a filtering gap open while it drains by attrition, and closing it immediately at the cost of silencing installs that are still reachable but no longer launched. Run the deletion only where recovering registrations can be observed, and prefer attrition when that recovery cannot be confirmed.
 
 ## Environment variables
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ If you need the gap closed immediately rather than by attrition, delete the rema
 - **App start.** The client registers on launch for a signed-in user, so a device that is opened again recovers on that launch. This is the normal case and bounds the outage to the user's next session.
 - **Sign-in or FCM token refresh.** Also triggers registration, but neither is time-bounded on its own.
 
-A device whose app is never opened again stays unregistered — it would receive nothing anyway, but it will not self-heal. Run the deletion when you can watch registrations recover rather than immediately before a quiet period, and prefer attrition if you are not in a position to confirm that.
+A device whose app is never opened again does not self-heal, and the loss there is real rather than theoretical: its token is live and still receiving push today, precisely because an unmatched token fails open. Deleting that row stops notifications the device would otherwise have kept getting, permanently until the app is next opened.
+
+So the choice is between leaving a filtering gap open while it drains by attrition, and closing it immediately at the cost of silencing installs that are still reachable but no longer launched. Run the deletion where registrations recovering can be observed, and prefer attrition when they cannot.
 
 ## Environment variables
 


### PR DESCRIPTION
Docs only. Records a known gap in the `deviceId` rollout from #56 that was understood while building it but never written down.

## The gap

`deviceTokens` is unique on `token`, **not** on `deviceId`, so one device can hold several rows. When FCM rotates a token the client registers the new one and the previous row survives until FCM reports it unregistered on a later send.

A row registered before the client started sending `deviceId` therefore still has `deviceId: null`, **fails open**, and can deliver a category that device has switched off. It resolves itself once the stale token is cleaned up, but it is a real window in which an opt-out is not honoured.

## What the cutover flag does and does not do

`AUTH_REQUIRE_DEVICE_ID_IN_TOKEN_REGISTRATION` stops *new* rows being created without a `deviceId`. It does **not** rewrite rows that already have `deviceId: null` — those keep failing open until FCM disowns them, so the window closes by attrition rather than at the moment of the flip.

The docs now name the deliberate alternative: delete the remaining `deviceId: null` rows after step 3, accepting a short window with no push for those devices while clients re-register on next sign-in or token refresh. Better as a decision than a discovery.

`AGENTS.md` also carries a warning against the tempting wrong fix — inverting the fail-open default while clients are mid-rollout, which would mute every install that has not updated.

## Why docs rather than code

Fail-open is deliberate and remains correct while `deviceId` is optional: an unmatched token cannot be resolved to a preference, and silently muting a pre-rollout install is worse than an occasional unwanted notification. The gap closes by construction once the rollout finishes, so the useful change now is making it a known consequence.

No behaviour change. `format:check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents a known gap in the `deviceId` rollout: because `deviceTokens` is unique on `token`, FCM token rotation can leave stale rows with `deviceId: null` that fail open and may bypass opt-outs until cleanup. Clarifies that `AUTH_REQUIRE_DEVICE_ID_IN_TOKEN_REGISTRATION` only blocks new null rows, warns against inverting the fail-open default mid-rollout, and records the option to delete remaining `deviceId: null` rows after step 3.

States the cost of deletion: it silences installs that are still reachable today (because unmatched tokens fail open) until they re-register — usually on the next app open for signed-in users; sign-in or FCM token refresh also re-registers but is not time-bounded. Installs never opened again won’t self-heal. Run deletion only when you can observe recovering registrations; prefer attrition otherwise.

<sup>Written for commit cdde6ce1b83d242aaff91969cc56469c33e06f9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

