### PR TITLE
🌿 Remove recurring analytics exclusion review

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,5 +9,5 @@ keys/
 !assets/legal/terms.md
 !assets/legal/privacy.md
 tests/
-scripts/
+/scripts/
 .sops.yaml

--- a/README.md
+++ b/README.md
@@ -556,7 +556,6 @@ view:
 - `PRODUCT_ANALYTICS_PSEUDONYMIZATION_KEY`
 - optional `PRODUCT_ANALYTICS_EXPORT_BATCH_LIMIT` (default 500, maximum 1000)
 - optional `PRODUCT_ANALYTICS_INTERNAL_EXCLUSION_MAX_KEYS` (default 10000, maximum 100000)
-- optional `PRODUCT_ANALYTICS_INTERNAL_EXCLUSION_MAX_AGE_MS` (default 48 hours)
 - `MONGODB_URI`
 
 Generate the pseudonymization key once with `openssl rand -base64 32`, store it

--- a/README.md
+++ b/README.md
@@ -566,13 +566,14 @@ targets; a mismatched key breaks privacy joins.
 
 The control view must return `user_key`, `is_active`, and a common
 `control_updated_at`. It must include one row with a nullable `user_key` as a
-freshness sentinel even when there are no active exclusions. Missing, stale,
-malformed, duplicate, or oversized controls abort publication. The job stages
-only pseudonymous/aggregate rows in tables expiring within 24 hours, reconciles
-late preference changes, validates both products, and transactionally replaces
-`auth_user_milestones` and `auth_weekly_setup_cohorts`. Failed runs leave the
-previous publication intact. The same transaction appends aggregate source,
-exclusion, reconciliation, cutoff, and freshness metadata to
+version sentinel even when there are no active exclusions. Missing, future-dated,
+malformed, duplicate, mixed-version, or oversized controls abort publication.
+The job stages only pseudonymous/aggregate rows in tables expiring within 24
+hours, reconciles late preference changes, validates both products, and
+transactionally replaces `auth_user_milestones` and
+`auth_weekly_setup_cohorts`. Failed runs leave the previous publication intact.
+The same transaction appends aggregate source, exclusion, reconciliation,
+cutoff, and freshness metadata to
 `product_analytics_export_runs`; it contains no source account identifiers.
 
 The deployment identity—not the export job—must provision and own the permanent

--- a/src/repositories/product-analytics-control-repo.ts
+++ b/src/repositories/product-analytics-control-repo.ts
@@ -15,20 +15,13 @@ type ProductAnalyticsControlApi = {
 export class ProductAnalyticsControlRepository {
   readonly #api: ProductAnalyticsControlApi;
   readonly #maxUserKeys: number;
-  readonly #maxAgeMs: number;
 
-  constructor(deps: { api: ProductAnalyticsControlApi; maxUserKeys: number; maxAgeMs: number }) {
-    if (
-      !Number.isSafeInteger(deps.maxUserKeys) ||
-      deps.maxUserKeys < 1 ||
-      !Number.isSafeInteger(deps.maxAgeMs) ||
-      deps.maxAgeMs < 1
-    ) {
+  constructor(deps: { api: ProductAnalyticsControlApi; maxUserKeys: number }) {
+    if (!Number.isSafeInteger(deps.maxUserKeys) || deps.maxUserKeys < 1) {
       throw new InternalServerError({ debugMessage: "Invalid product analytics control limits" });
     }
     this.#api = deps.api;
     this.#maxUserKeys = deps.maxUserKeys;
-    this.#maxAgeMs = deps.maxAgeMs;
   }
 
   async loadActiveInternalUserKeys(input: { loadedAt: Date }): Promise<ProductAnalyticsInternalExclusionSnapshot> {
@@ -52,7 +45,7 @@ export class ProductAnalyticsControlRepository {
     }
     const controlUpdatedAt = input.rows[0].controlUpdatedAt;
     const userKeys = input.rows.flatMap((row) => (row.userKey === null ? [] : [row.userKey]));
-    // The authorized view must always emit exactly one null-key freshness
+    // The authorized view must always emit exactly one null-key version
     // sentinel, including when there are no active internal exclusions.
     const sentinelCount = input.rows.filter((row) => row.userKey === null).length;
     if (
@@ -63,8 +56,7 @@ export class ProductAnalyticsControlRepository {
       new Set(userKeys).size !== userKeys.length ||
       Number.isNaN(controlUpdatedAt.getTime()) ||
       input.rows.some((row) => row.controlUpdatedAt.getTime() !== controlUpdatedAt.getTime()) ||
-      controlUpdatedAt > input.loadedAt ||
-      input.loadedAt.getTime() - controlUpdatedAt.getTime() > this.#maxAgeMs
+      controlUpdatedAt > input.loadedAt
     ) {
       throw new InternalServerError({ debugMessage: "Invalid product analytics internal-exclusion control" });
     }

--- a/src/scripts/export-product-analytics.ts
+++ b/src/scripts/export-product-analytics.ts
@@ -41,7 +41,6 @@ export async function runProductAnalyticsExport(input: { env?: NodeJS.ProcessEnv
       controlRepo: new ProductAnalyticsControlRepository({
         api,
         maxUserKeys: config.PRODUCT_ANALYTICS_INTERNAL_EXCLUSION_MAX_KEYS,
-        maxAgeMs: config.PRODUCT_ANALYTICS_INTERNAL_EXCLUSION_MAX_AGE_MS,
       }),
       exportRepo: new ProductAnalyticsExportRepository({ api }),
       batchLimit: config.PRODUCT_ANALYTICS_EXPORT_BATCH_LIMIT,

--- a/src/scripts/product-analytics-export-config.ts
+++ b/src/scripts/product-analytics-export-config.ts
@@ -19,10 +19,6 @@ const productAnalyticsExportConfigSchema = z.object({
   PRODUCT_ANALYTICS_PSEUDONYMIZATION_KEY: productAnalyticsPseudonymizationKeySchema,
   PRODUCT_ANALYTICS_EXPORT_BATCH_LIMIT: positiveIntegerFromEnvironment(500, 1_000),
   PRODUCT_ANALYTICS_INTERNAL_EXCLUSION_MAX_KEYS: positiveIntegerFromEnvironment(10_000, 100_000),
-  PRODUCT_ANALYTICS_INTERNAL_EXCLUSION_MAX_AGE_MS: positiveIntegerFromEnvironment(
-    2 * 24 * 60 * 60 * 1_000,
-    30 * 24 * 60 * 60 * 1_000,
-  ),
 });
 
 export type ProductAnalyticsExportConfig = z.infer<typeof productAnalyticsExportConfigSchema>;

--- a/tests/repositories/product-analytics-control-repo.test.ts
+++ b/tests/repositories/product-analytics-control-repo.test.ts
@@ -5,10 +5,10 @@ import { ProductAnalyticsControlRepository } from "../../src/repositories/produc
 
 describe("ProductAnalyticsControlRepository", () => {
   const loadedAt = new Date("2026-07-28T12:00:00.000Z");
-  const controlUpdatedAt = new Date("2026-07-28T11:00:00.000Z");
+  const controlUpdatedAt = new Date("2026-01-01T11:00:00.000Z");
   const key = "a".repeat(64);
 
-  it("loads a bounded fresh key set with a nullable empty-set sentinel", async () => {
+  it("loads a bounded versioned key set with a nullable empty-set sentinel", async () => {
     let requestedMaxRows: number | null = null;
     const repo = new ProductAnalyticsControlRepository({
       api: {
@@ -21,7 +21,6 @@ describe("ProductAnalyticsControlRepository", () => {
         },
       },
       maxUserKeys: 10,
-      maxAgeMs: 2 * 60 * 60 * 1_000,
     });
 
     const snapshot = await repo.loadActiveInternalUserKeys({ loadedAt });
@@ -31,11 +30,11 @@ describe("ProductAnalyticsControlRepository", () => {
     assert.equal(requestedMaxRows, 12);
   });
 
-  it("fails closed for missing, stale, malformed, duplicate, or oversized controls", async () => {
+  it("fails closed for missing, future-dated, malformed, duplicate, or oversized controls", async () => {
     const invalidRows = [
       [],
       [{ userKey: null, controlUpdatedAt: new Date(Number.NaN) }],
-      [{ userKey: key, controlUpdatedAt: new Date("2026-07-28T09:00:00.000Z") }],
+      [{ userKey: null, controlUpdatedAt: new Date("2026-07-28T13:00:00.000Z") }],
       [{ userKey: "invalid", controlUpdatedAt }],
       [{ userKey: key, controlUpdatedAt }],
       [
@@ -62,7 +61,6 @@ describe("ProductAnalyticsControlRepository", () => {
           },
         },
         maxUserKeys: 1,
-        maxAgeMs: 2 * 60 * 60 * 1_000,
       });
       await assert.rejects(
         () => repo.loadActiveInternalUserKeys({ loadedAt }),

--- a/tests/repositories/product-analytics-control-repo.test.ts
+++ b/tests/repositories/product-analytics-control-repo.test.ts
@@ -39,6 +39,10 @@ describe("ProductAnalyticsControlRepository", () => {
       [{ userKey: key, controlUpdatedAt }],
       [
         { userKey: null, controlUpdatedAt },
+        { userKey: key, controlUpdatedAt: new Date(controlUpdatedAt.getTime() + 1_000) },
+      ],
+      [
+        { userKey: null, controlUpdatedAt },
         { userKey: null, controlUpdatedAt },
       ],
       [


### PR DESCRIPTION
## Complexity

🌿 Straightforward: removes one obsolete time-based export gate while retaining fail-closed control validation.

## What

- Remove the 48-hour internal-exclusion review expiry from the product analytics auth export.
- Remove the associated runtime environment setting.
- Keep missing, malformed, oversized, mixed-version, and future-dated controls fail-closed.
- Keep the before-promotion control revalidation.

## Why

The daily export scheduler ran successfully but every export after the control timestamp aged past 48 hours failed. Permanent exclusions are already versioned and revalidated; requiring a manual no-change review every two days prevented unattended analytics operation.

## Risk and test focus

Security-sensitive analytics export behavior. Review the retained shape, bounds, future-date, and concurrent-change checks. No user-visible or database schema impact.

## Expected result

Daily auth exports continue without recurring operator review while still failing closed when the exclusion control is invalid or changes during publication.

## Verification

- `npm run build`
- focused `product-analytics-control-repo` tests
- `npm run lint`
- `npm run format:check`
- architecture implementation review findings addressed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the 48-hour expiry on the internal-exclusion control for product analytics export to restore unattended daily runs; exports no longer fail after 48 hours and still fail closed on invalid controls. Clarifies validation to use a version sentinel instead of freshness.

- Remove `PRODUCT_ANALYTICS_INTERNAL_EXCLUSION_MAX_AGE_MS` from config and README; drop staleness validation and the `maxAgeMs` dependency while keeping: exactly one null-key version sentinel, consistent `controlUpdatedAt` across rows (no mixed versions), future-dated guard, unique user keys, and the max-keys bound.
- Update tests and README to reflect the versioned control and future-dated/mixed-version checks.
- Docker: anchor `.dockerignore` to `/scripts/` so `src/scripts` are included in the build context.
- Migration: remove `PRODUCT_ANALYTICS_INTERNAL_EXCLUSION_MAX_AGE_MS` from the environment.

<sup>Written for commit e569eb7aa10ce124584b8c25510164b231e48ea3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

