### PR TITLE
Add Cookie Statement and align service terms

### DIFF
--- a/assets/legal/cookies.md
+++ b/assets/legal/cookies.md
@@ -1,0 +1,108 @@
+# Sesori Cookie Statement
+
+_Last updated: August 25, 2026_
+
+This Cookie Statement explains how **Digitalblock Labs LTD** ("**Sesori**," "we," "us," or "our") uses cookies and similar technologies on `sesori.com` and related official web pages. It supplements the Sesori Privacy Policy and Terms and Conditions.
+
+## 1. What cookies and similar technologies are
+
+Cookies are small text files stored by a browser. Similar technologies include local storage, pixels, tags, software-development kits, advertising identifiers, and other mechanisms that recognize a browser or device, remember a preference, or report an event.
+
+Some technologies are set directly by Sesori. Others are provided by companies such as Google, Meta, or Cloudflare and may allow those companies to recognize a browser or associate activity with information they already hold, subject to their own terms and privacy policies.
+
+## 2. How we use these technologies
+
+We use cookies and similar technologies to:
+
+- operate and secure the website
+- remember consent and privacy choices
+- understand website traffic and interactions
+- measure visits to app stores, documentation, and Bridge installation flows
+- attribute visits or conversions to advertising campaigns
+- measure, optimize, and deliver advertising
+- create or measure advertising audiences where permitted
+- detect fraud, abuse, or duplicate attribution events
+
+We do not intentionally send source code, prompts, AI responses, repository names, file paths, terminal output, authentication tokens, form contents, or other coding-session content through website analytics or advertising tags.
+
+## 3. Cookie categories
+
+### 3.1 Strictly necessary
+
+Strictly necessary technologies support security, network delivery, and storage of consent choices. They cannot be disabled through the banner when they are required for the website to operate or remember a privacy request. Browser controls may still block them, but doing so can prevent the relevant feature from working.
+
+### 3.2 Analytics
+
+Analytics technologies help us understand how visitors reach and use the website. Google Analytics 4 uses measurement ID `G-5R35L8J3NT`. It may receive page views, configured interaction events, referral and campaign information, browser and device data, IP-derived approximate location, and online identifiers.
+
+### 3.3 Advertising and marketing
+
+Advertising technologies help us attribute campaigns, measure conversions, create or measure audiences, avoid repeatedly advertising to the same browser, and optimize advertising. Meta Pixel uses pixel ID `1619146889579169`. It may receive page views, advertising click information, browser and device data, IP address, and Meta or browser identifiers.
+
+Meta Pixel and its `<noscript>` image fallback are treated as advertising technologies and remain disabled where advertising consent is required until that consent is granted.
+
+## 4. Current website inventory
+
+The exact cookies present can depend on browser settings, consent choices, campaign parameters, whether a provider recognizes the browser, and which security features are active.
+
+| Category | Cookie or technology | Provider | Purpose | Typical lifespan |
+| --- | --- | --- | --- | --- |
+| Strictly necessary | Sesori consent preference in cookie or local storage | Sesori | Remembers accepted, rejected, and category-level choices | Up to 12 months |
+| Strictly necessary | Security or traffic-management cookies, when activated | Cloudflare | Protects the website, distinguishes legitimate traffic, and supports edge delivery | Provider- and event-dependent |
+| Analytics | `_ga` | Google Analytics | Distinguishes browsers for website analytics | Up to 2 years, subject to configuration |
+| Analytics | `_ga_*` | Google Analytics | Maintains Google Analytics session and measurement state | Up to 2 years, subject to configuration |
+| Advertising | `_fbp` | Meta | Supports advertising delivery, measurement, and browser attribution | Up to 90 days, subject to Meta settings |
+| Advertising | `_fbc` | Meta | Stores Meta advertising click attribution when a Meta click identifier is present | Up to 90 days, subject to Meta settings |
+| Advertising | Meta Pixel and Meta request identifiers | Meta | Sends page-view and configured advertising events to Meta | Request- and provider-dependent |
+
+Cookie lifespans can be refreshed when the relevant technology runs. Provider-controlled lifespans and names may change. We review the production inventory and update this statement when our material use changes.
+
+## 5. Consent and regional behavior
+
+The website presents a cookie banner and persistent Cookie Settings control.
+
+In jurisdictions requiring opt-in consent:
+
+- Analytics and Advertising are disabled by default.
+- Google Analytics and Meta Pixel do not load until the visitor accepts the relevant category.
+- Rejecting non-essential technologies does not prevent access to the public website or core Service.
+
+In jurisdictions using an opt-out model, non-essential technologies operate subject to saved preferences and applicable opt-out rights.
+
+You can accept all, reject all, choose categories, or later withdraw consent through Cookie Settings. Withdrawal affects future processing on that browser or device and does not automatically delete data already transmitted to a provider.
+
+## 6. Do Not Sell or Share and Global Privacy Control
+
+Where required by applicable United States privacy law, the website provides a "Do Not Sell or Share My Personal Information" control. We also treat a recognized opt-out preference signal, including Global Privacy Control, as an opt-out request for the browser or device that sends it where required by law.
+
+A browser-level opt-out may not identify an account or another device. Account-level requests can also be submitted to [contact@sesori.com](mailto:contact@sesori.com) or [gdpr@sesori.com](mailto:gdpr@sesori.com).
+
+## 7. Provider controls
+
+Additional provider or browser controls include:
+
+- [Google Analytics opt-out tools](https://tools.google.com/dlpage/gaoptout)
+- [Meta Ad Preferences](https://www.facebook.com/adpreferences/ad_settings)
+- browser controls for deleting or blocking cookies and local storage
+
+These controls are operated by the relevant provider and may not remove data already processed under that provider's terms.
+
+## 8. Mobile attribution and advertising identifiers
+
+The Singular Flutter SDK, Apple advertising and attribution frameworks, Android advertising identifiers, and mobile-app privacy settings are not browser cookies. Their use is described in the Sesori Privacy Policy. Mobile platform permissions such as Apple's App Tracking Transparency are separate from website cookie consent.
+
+Meta Customer List Custom Audiences and Lookalike Audiences can use a hashed account-associated email address rather than a browser cookie. That processing, including applicable consent and opt-out rights, is also described in the Privacy Policy.
+
+## 9. Updates to this Cookie Statement
+
+We may update this Cookie Statement when we add, remove, or materially change a website technology, provider, purpose, cookie, retention period, or privacy control. We will update the date at the top when we publish a revised version.
+
+## 10. Contact
+
+Questions and rights requests can be sent to:
+
+- [contact@sesori.com](mailto:contact@sesori.com) for general privacy matters
+- [gdpr@sesori.com](mailto:gdpr@sesori.com) for GDPR and data-protection rights matters
+
+**Digitalblock Labs LTD**  
+Registered in the British Virgin Islands

--- a/assets/legal/privacy.md
+++ b/assets/legal/privacy.md
@@ -344,6 +344,8 @@ Where supported by our implementation, Singular controls can limit data sharing 
 
 You can accept, reject, or later change analytics and advertising choices through Cookie Settings. Where applicable, the website also provides a "Do Not Sell or Share My Personal Information" control and honors recognized opt-out preference signals such as Global Privacy Control for the browser or device that sends them. You can additionally block or delete cookies using browser controls, use [Google's Analytics opt-out tools](https://tools.google.com/dlpage/gaoptout), manage advertising preferences through [Meta's Ad Preferences](https://www.facebook.com/adpreferences/ad_settings), or submit a rights request using the contacts in Section 2. Rejecting these technologies may reduce the accuracy of campaign attribution but does not prevent access to Sesori's public website or core Service.
 
+The Sesori Cookie Statement provides the current website technology inventory, cookie categories, typical lifespans, provider controls, and additional details about changing or withdrawing website choices. It supplements this Privacy Policy.
+
 ## 15. Children's privacy
 
 The official Service is not directed to anyone under 16, except where applicable law in your jurisdiction allows valid consent to personal data processing at a lower age (in Bulgaria, the age is 14 under GDPR Article 8). If you are below the age at which you can validly consent to personal data processing under applicable law, you must not use the Service or submit personal data to us.

--- a/assets/legal/terms.md
+++ b/assets/legal/terms.md
@@ -1,8 +1,8 @@
 # Sesori Terms and Conditions
 
-_Last updated: April 18, 2026_
+_Last updated: August 25, 2026_
 
-These Sesori Terms and Conditions, together with any additional terms, policies, notices, or product-specific rules that we make available for the official Sesori services, form a legally binding agreement between you and **Digitalblock Labs LTD** ("**Sesori**," "**Company**," "we," "us," or "our"). These terms apply when you access, install, use, or interact with Sesori's official apps and services, including the Sesori mobile app, the official local bridge software, relay services, authentication and account services, push notification services, voice input and transcription features, `sesori.com`, and related hosted features that we provide (collectively, the "**Service**").
+These Sesori Terms and Conditions, together with any additional terms, policies, notices, or product-specific rules that we make available for the official Sesori services, form a legally binding agreement between you and **Digitalblock Labs LTD** ("**Sesori**," "**Company**," "we," "us," or "our"). These terms apply when you access, install, use, or interact with Sesori's official apps and services, including the Sesori mobile app, the official local bridge software, relay services, authentication and account services, push notification services, voice input and transcription features, `sesori.com`, website analytics and advertising technologies, mobile advertising attribution, advertising audience services, and related hosted features that we provide (collectively, the "**Service**").
 
 By accessing or using the Service, you agree to these Terms and Conditions. If you do not agree, do not access or use the Service.
 
@@ -20,7 +20,7 @@ By accessing or using the Service, you agree to these Terms and Conditions. If y
 
 2.1. The Service is designed to let you connect compatible AI coding assistants running on your own host system with your mobile device so that you can browse projects, review sessions, receive real-time updates, respond to prompts, use voice input, and use related official Sesori features.
 
-2.2. The Service may include, without limitation, local bridge software running on your host system, relay transport, account and authentication features, push notification delivery, mobile clients, websites, voice input and server-side transcription features, diagnostics, support tools, analytics, and related hosted components.
+2.2. The Service may include, without limitation, local bridge software running on your host system, relay transport, account and authentication features, push notification delivery, mobile clients, websites, voice input and server-side transcription features, diagnostics, support tools, product and website analytics, advertising technologies, mobile attribution, advertising audience services, and related hosted components.
 
 2.3. The Service may depend on your own devices, local host environment, internet connectivity, AI tools, operating systems, app stores, notification providers, and other third-party services. Those dependencies are outside our control.
 
@@ -52,7 +52,7 @@ By accessing or using the Service, you agree to these Terms and Conditions. If y
 
 1. In ordinary operation, Sesori infrastructure may route encrypted relay traffic between your devices and does not ordinarily have plaintext access to that relay payload in transit.
 2. Certain features, including voice input, require Sesori and its sub-processors to receive, process, and transcribe audio recordings you submit through the Service. Voice recordings and generated transcripts are not retained by Sesori after processing completes, except to the limited extent reasonably necessary for service operation, abuse prevention, security, diagnostics, incident response, or as required by law. Transcription and related processing may be performed by one or more third-party providers acting as Sesori's sub-processors. A current list of sub-processors is maintained in or linked from our Privacy Policy.
-3. Limited additional data may be processed in connection with notifications, account and authentication, device and app metadata, analytics, diagnostics, support, and limited feature processing that you invoke.
+3. Limited additional data may be processed in connection with notifications, account and authentication, device and app metadata, product and website analytics, advertising attribution, campaign measurement, advertising audience matching, diagnostics, support, and limited feature processing that you invoke.
 4. No networked system is risk free, and some data exposure, loss, corruption, delay, or misdelivery may still occur.
 
 4.7. You are responsible for deciding whether the Service is appropriate for your workflow, data sensitivity, compliance obligations, and operational risk tolerance.
@@ -81,17 +81,17 @@ By accessing or using the Service, you agree to these Terms and Conditions. If y
 
 ## 7. Privacy and data handling
 
-7.1. The Service is designed so that ordinary routing of encrypted relay traffic between your devices does not ordinarily require Sesori to have plaintext access to that traffic in transit. However, certain features, including voice input, require Sesori and its sub-processors to receive and process your data in readable form. In particular, voice recordings submitted through the Service are transmitted to Sesori servers and processed by a third-party transcription sub-processor. Voice recordings and generated transcripts are not retained by Sesori after processing completes, except as described in Section 4.6. Additional limited data may be processed in connection with notifications, metadata, diagnostics, support flows, analytics, and other service operations you invoke.
+7.1. The Service is designed so that ordinary routing of encrypted relay traffic between your devices does not ordinarily require Sesori to have plaintext access to that traffic in transit. However, certain features, including voice input, require Sesori and its sub-processors to receive and process your data in readable form. In particular, voice recordings submitted through the Service are transmitted to Sesori servers and processed by a third-party transcription sub-processor. Voice recordings and generated transcripts are not retained by Sesori after processing completes, except as described in Section 4.6. Additional limited data may be processed in connection with notifications, metadata, diagnostics, support flows, analytics, advertising attribution, campaign measurement, advertising audience matching, and other Service operations described in the Privacy Policy.
 
-7.2. Sesori may process account details, authentication data, connection metadata, device and app metadata, analytics, diagnostic information, support information, notification payloads, limited session metadata, voice and transcription data as described above, limited feature processing inputs and outputs, and other data reasonably necessary to provide, secure, support, maintain, and enforce the Service.
+7.2. Sesori may process account details, authentication data, connection metadata, device and app metadata, website activity, online and advertising identifiers, campaign and attribution information, analytics, diagnostic information, support information, notification payloads, limited session metadata, voice and transcription data as described above, limited feature processing inputs and outputs, account contact information used for advertising audience matching where permitted, and other data reasonably necessary to provide, secure, support, maintain, measure, market, and enforce the Service.
 
 7.3. Push notifications may contain limited session metadata, partial content, sender information, project information, or other snippets depending on your settings, platform behavior, notification routing, lock-screen visibility, or operating system controls. We cannot guarantee that notification content will remain hidden from device-level surfaces or other people with access to your device.
 
 7.4. Manual review of limited accessible data may occur when reasonably necessary for support, abuse prevention, security investigation, incident response, trust and safety review, or legal compliance.
 
-7.5. Third-party providers such as hosting, analytics, crash reporting, authentication, messaging, notification, infrastructure, customer support, app distribution, transcription, providers supporting limited feature processing you invoke, and security vendors may store, receive, or access limited data while providing their services to us. A current list of sub-processors is maintained in or linked from our Privacy Policy.
+7.5. Third-party recipients such as hosting, analytics, advertising, attribution, audience-matching, crash-reporting, authentication, messaging, notification, infrastructure, customer-support, app-distribution, transcription, limited feature-processing, and security providers may store, receive, or access limited data while providing services to us or under their own applicable terms. Some act solely on Sesori's behalf, while others may have separate responsibilities under applicable law.
 
-7.6. Our Privacy Policy, available at `sesori.com`, contains additional detail about what data we collect, how we use it, our sub-processors, data retention, international transfers, and your rights under applicable data protection law. The Privacy Policy is incorporated by reference into these Terms and Conditions.
+7.6. Our Privacy Policy and Cookie Statement, available at `sesori.com` or through the Service, contain additional detail about the data we collect, how we use it, service providers and technology recipients, cookies and similar technologies, consent controls, data retention, international transfers, and your rights under applicable data-protection law. The Privacy Policy and Cookie Statement are incorporated by reference into these Terms and Conditions.
 
 7.7. Although we take steps intended to protect the Service, we do not promise perfect privacy, perfect confidentiality, perfect end-to-end secrecy, or absolute security.
 
@@ -123,7 +123,7 @@ By accessing or using the Service, you agree to these Terms and Conditions. If y
 
 9.2. Sesori does not control, endorse, or assume responsibility for third-party products or services that you choose to connect or use, including any connected AI coding assistant or any output, action, failure, policy, or security issue arising from them.
 
-9.3. This Section 9 does not apply to sub-processors that Sesori itself engages to operate the Service, such as hosting, transcription, or analytics providers. Those sub-processors act on Sesori's behalf and are addressed in our Privacy Policy.
+9.3. This Section 9 does not limit processing by service providers, analytics providers, attribution providers, advertising platforms, or other technology recipients selected by Sesori to operate, measure, secure, or market the Service. Their respective roles and applicable terms are described in our Privacy Policy and Cookie Statement. Some act solely on Sesori's behalf, while others may have separate responsibilities under their own terms and applicable law.
 
 9.4. Your use of third-party services is at your own risk and may be subject to separate terms, privacy notices, and fees from those third parties.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,11 +234,12 @@ async function main() {
     model: config.OPENAI_METADATA_MODEL,
   });
   const installScriptService = new InstallScriptService();
-  const [termsText, privacyText] = await Promise.all([
+  const [termsText, privacyText, cookiesText] = await Promise.all([
     readFile(getLegalDocumentUrl(import.meta.url, "terms"), "utf8"),
     readFile(getLegalDocumentUrl(import.meta.url, "privacy"), "utf8"),
+    readFile(getLegalDocumentUrl(import.meta.url, "cookies"), "utf8"),
   ]);
-  const legalDocumentService = new LegalDocumentService(termsText, privacyText);
+  const legalDocumentService = new LegalDocumentService({ termsText, privacyText, cookiesText });
 
   const app = await buildApp({
     config,

--- a/src/lib/legal-document-paths.ts
+++ b/src/lib/legal-document-paths.ts
@@ -1,4 +1,5 @@
 const LEGAL_DOCUMENT_FILES = {
+  cookies: "cookies.md",
   privacy: "privacy.md",
   terms: "terms.md",
 } as const;

--- a/src/routes/legal.ts
+++ b/src/routes/legal.ts
@@ -15,4 +15,8 @@ export const legalRoutes: FastifyPluginAsync<LegalRouteOptions> = async (fastify
   fastify.get<{ Reply: string }>("/privacy", async (_request, reply) => {
     reply.type("text/plain; charset=utf-8").send(legalDocumentService.getPrivacy());
   });
+
+  fastify.get<{ Reply: string }>("/cookies", async (_request, reply) => {
+    reply.type("text/plain; charset=utf-8").send(legalDocumentService.getCookies());
+  });
 };

--- a/src/services/legal-document-service.ts
+++ b/src/services/legal-document-service.ts
@@ -1,10 +1,18 @@
+type LegalDocumentServiceArgs = {
+  termsText: string;
+  privacyText: string;
+  cookiesText: string;
+};
+
 export class LegalDocumentService {
   readonly #termsText: string;
   readonly #privacyText: string;
+  readonly #cookiesText: string;
 
-  constructor(termsText: string, privacyText: string) {
-    this.#termsText = termsText;
-    this.#privacyText = privacyText;
+  constructor(args: LegalDocumentServiceArgs) {
+    this.#termsText = args.termsText;
+    this.#privacyText = args.privacyText;
+    this.#cookiesText = args.cookiesText;
   }
 
   getTerms(): string {
@@ -13,5 +21,9 @@ export class LegalDocumentService {
 
   getPrivacy(): string {
     return this.#privacyText;
+  }
+
+  getCookies(): string {
+    return this.#cookiesText;
   }
 }

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -226,7 +226,12 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
     overrides?.sessionMetadataService ?? new SessionMetadataService({ openai, dailyUsageRepo, model: "gpt-4o-mini" });
   const installScriptService = overrides?.installScriptService ?? new InstallScriptService();
   const legalDocumentService =
-    overrides?.legalDocumentService ?? new LegalDocumentService("# Test Terms\n", "# Test Privacy\n");
+    overrides?.legalDocumentService ??
+    new LegalDocumentService({
+      termsText: "# Test Terms\n",
+      privacyText: "# Test Privacy\n",
+      cookiesText: "# Test Cookies\n",
+    });
 
   const app = await buildApp({
     config: effectiveConfig,

--- a/tests/legal/document-paths.test.ts
+++ b/tests/legal/document-paths.test.ts
@@ -11,9 +11,11 @@ describe("legal document path resolution", () => {
     const distModuleUrl = pathToFileURL(path.join(repoRoot, "dist/index.js")).href;
 
     const expectedTermsPath = path.join(repoRoot, "assets/legal/terms.md");
+    const expectedCookiesPath = path.join(repoRoot, "assets/legal/cookies.md");
     const expectedPrivacyPath = path.join(repoRoot, "assets/legal/privacy.md");
 
     for (const moduleUrl of [srcModuleUrl, distModuleUrl]) {
+      assert.equal(fileURLToPath(getLegalDocumentUrl(moduleUrl, "cookies")), expectedCookiesPath);
       assert.equal(fileURLToPath(getLegalDocumentUrl(moduleUrl, "terms")), expectedTermsPath);
       assert.equal(fileURLToPath(getLegalDocumentUrl(moduleUrl, "privacy")), expectedPrivacyPath);
     }

--- a/tests/legal/routes.test.ts
+++ b/tests/legal/routes.test.ts
@@ -28,7 +28,11 @@ describe("Legal routes", () => {
   async function createRouteTestApp(t: NodeTestContext): Promise<TestContext> {
     mockMongoHarness(t);
     return createTestApp({
-      legalDocumentService: new LegalDocumentService("# Terms\n\nTerms body\n", "# Privacy\n\nПоверителност body\n"),
+      legalDocumentService: new LegalDocumentService({
+        termsText: "# Terms\n\nTerms body\n",
+        privacyText: "# Privacy\n\nПоверителност body\n",
+        cookiesText: "# Cookies\n\nCookie body\n",
+      }),
     });
   }
 
@@ -64,6 +68,22 @@ describe("Legal routes", () => {
     }
   });
 
+  it("GET /cookies returns the Cookie Statement as plain text without auth", async (t) => {
+    const ctx = await createRouteTestApp(t);
+    try {
+      const res = await ctx.app.inject({
+        method: "GET",
+        url: "/cookies",
+      });
+
+      assert.equal(res.statusCode, 200);
+      assert.match(res.headers["content-type"] ?? "", /^text\/plain;\s*charset=utf-8\b/i);
+      assert.equal(res.body, "# Cookies\n\nCookie body\n");
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
   it("POST /terms remains unregistered", async (t) => {
     const ctx = await createRouteTestApp(t);
     try {
@@ -92,23 +112,46 @@ describe("Legal routes", () => {
     }
   });
 
-  it("serves the real privacy asset with current external data disclosures", async (t) => {
+  it("POST /cookies remains unregistered", async (t) => {
+    const ctx = await createRouteTestApp(t);
+    try {
+      const res = await ctx.app.inject({
+        method: "POST",
+        url: "/cookies",
+      });
+
+      assert.equal(res.statusCode, 404);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it("serves the real legal assets with current advertising disclosures", async (t) => {
     // The other route tests inject synthetic text, so this is the contract for
-    // every provider and advertising use disclosed by the shipped policy.
+    // every provider, advertising use, cookie, and legal cross-reference shipped in production.
     mockMongoHarness(t);
     const compositionRootUrl = new URL("../../src/index.ts", import.meta.url).href;
-    const [termsText, privacyText] = await Promise.all([
+    const [termsText, privacyText, cookiesText] = await Promise.all([
       readFile(getLegalDocumentUrl(compositionRootUrl, "terms"), "utf8"),
       readFile(getLegalDocumentUrl(compositionRootUrl, "privacy"), "utf8"),
+      readFile(getLegalDocumentUrl(compositionRootUrl, "cookies"), "utf8"),
     ]);
     const ctx = await createTestApp({
-      legalDocumentService: new LegalDocumentService(termsText, privacyText),
+      legalDocumentService: new LegalDocumentService({ termsText, privacyText, cookiesText }),
     });
 
     try {
-      const res = await ctx.app.inject({ method: "GET", url: "/privacy" });
+      const [termsRes, privacyRes, cookiesRes] = await Promise.all([
+        ctx.app.inject({ method: "GET", url: "/terms" }),
+        ctx.app.inject({ method: "GET", url: "/privacy" }),
+        ctx.app.inject({ method: "GET", url: "/cookies" }),
+      ]);
 
-      assert.equal(res.statusCode, 200);
+      assert.equal(termsRes.statusCode, 200);
+      assert.ok(termsRes.body.includes("Cookie Statement"));
+      assert.ok(termsRes.body.includes("advertising audience matching"));
+
+      assert.equal(privacyRes.statusCode, 200);
       for (const disclosure of [
         "OpenAI",
         "Soniox",
@@ -119,20 +162,34 @@ describe("Legal routes", () => {
         "Meta Customer List Custom Audiences",
         "Lookalike Audience",
       ]) {
-        assert.ok(res.body.includes(disclosure), `privacy policy must disclose ${disclosure}`);
+        assert.ok(privacyRes.body.includes(disclosure), `privacy policy must disclose ${disclosure}`);
       }
-      assert.ok(res.body.includes("G-5R35L8J3NT"));
-      assert.ok(res.body.includes("1619146889579169"));
-      assert.ok(res.body.includes("cryptographically hash the email address"));
-      assert.doesNotMatch(res.body, /currently does \*\*not\*\* use cookies or website analytics/i);
-      assert.ok(res.body.includes("email address associated with your Sesori account"));
-      assert.ok(res.body.includes("non-essential analytics and advertising tags remain disabled"));
-      assert.ok(res.body.includes("Global Privacy Control"));
-      assert.ok(res.body.includes("Official mobile release builds for which Sesori enables advertising attribution"));
-      assert.ok(res.body.includes("United States (US regional project)"));
+      assert.ok(privacyRes.body.includes("G-5R35L8J3NT"));
+      assert.ok(privacyRes.body.includes("1619146889579169"));
+      assert.ok(privacyRes.body.includes("cryptographically hash the email address"));
+      assert.doesNotMatch(privacyRes.body, /currently does \*\*not\*\* use cookies or website analytics/i);
+      assert.ok(privacyRes.body.includes("email address associated with your Sesori account"));
+      assert.ok(privacyRes.body.includes("non-essential analytics and advertising tags remain disabled"));
+      assert.ok(privacyRes.body.includes("Global Privacy Control"));
       assert.ok(
-        res.body.includes("audio is processed and temporarily stored in Soniox's United States regional project"),
+        privacyRes.body.includes("Official mobile release builds for which Sesori enables advertising attribution"),
       );
+      assert.ok(privacyRes.body.includes("United States (US regional project)"));
+      assert.ok(
+        privacyRes.body.includes(
+          "audio is processed and temporarily stored in Soniox's United States regional project",
+        ),
+      );
+
+      assert.equal(cookiesRes.statusCode, 200);
+      assert.ok(cookiesRes.body.includes("G-5R35L8J3NT"));
+      assert.ok(cookiesRes.body.includes("1619146889579169"));
+      for (const cookie of ["_ga", "_ga_*", "_fbp", "_fbc"]) {
+        assert.ok(cookiesRes.body.includes(`\`${cookie}\``), `Cookie Statement must disclose ${cookie}`);
+      }
+      assert.ok(cookiesRes.body.includes("Global Privacy Control"));
+      assert.ok(cookiesRes.body.includes("Meta Pixel and its `<noscript>` image fallback"));
+      assert.ok(cookiesRes.body.includes("Google Analytics and Meta Pixel do not load until"));
     } finally {
       await ctx.cleanup();
     }


### PR DESCRIPTION
Publish a detailed Cookie Statement for GA4, Meta Pixel, consent categories, Do Not Sell or Share, and GPC controls. Expose it through GET /cookies, incorporate it into the Privacy Policy and Terms, and align third-party advertising and attribution clauses.

Extend the legal document service and route contracts for the new asset.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Cookie Statement and serves it at GET /cookies, and updates Privacy Policy and Terms to cover advertising, attribution, and consent controls. Previously there was no Cookie Statement endpoint and the policies lacked full coverage; now they clarify GA4/Meta Pixel use, Do Not Sell or Share, and Global Privacy Control, with a small breaking change to `LegalDocumentService`.

- New Features
  - Adds `assets/legal/cookies.md` detailing categories, measurement IDs, provider controls, and consent behavior.
  - Cross-links the Cookie Statement from Privacy Policy and Terms and clarifies advertising audience matching and attribution.
  - Documents Meta Pixel `<noscript>` fallback handling and GPC/Do Not Sell or Share controls.

- Migration
  - `LegalDocumentService` now takes an object: `{ termsText, privacyText, cookiesText }`.
  - Ensure `cookies.md` is bundled and loaded via `getLegalDocumentUrl(..., "cookies")` so GET /cookies returns the statement.

<sup>Written for commit af6ac6bc55557f950fb3aada1d8c08abf6ca0c21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

