### PR TITLE
Report account creation status from login endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,12 @@ npm run start:prod
 | `POST` | `/auth/google/callback` | No   | Exchange Google auth code for JWT tokens                                                                   |
 | `GET`  | `/auth/apple`           | No   | Get Apple OAuth URL (requires `redirect_uri`, `code_challenge` query params). HTTPS redirect URI required. |
 | `POST` | `/auth/apple/callback`  | No   | Exchange Apple auth code for JWT tokens                                                                    |
-| `POST` | `/auth/apple/native`    | No   | Verify Apple native id_token and return JWT tokens (requires `idToken`, `nonce`)                           |
-| `POST` | `/auth/email`           | No   | Login with email and password for existing admin-provisioned accounts                                      |
+| `POST` | `/auth/apple/native`    | No   | Verify Apple native id_token and return JWT tokens plus `accountStatus` (requires `idToken`, `nonce`)      |
+| `POST` | `/auth/email`           | No   | Login with email/password and return JWT tokens plus `accountStatus` for an existing provisioned account   |
+
+Successful responses from these two login endpoints include top-level `accountStatus: "created" | "existing"`.
+Apple reports `created` only when that request creates the Sesori account; email/password accounts are provisioned
+before login and therefore report `existing`. Token refresh responses do not include `accountStatus`.
 
 ### OAuth (anti-phishing confirmation flow)
 
@@ -76,7 +80,10 @@ The newer flow keeps the client in control of when tokens are issued. The client
 | `POST` | `/auth/google/init`             | No   | (same shape as github)                                                                                       |
 | `GET`  | `/auth/google/callback`         | No   | (same)                                                                                                       |
 | `POST` | `/auth/google/callback/confirm` | No   | (same)                                                                                                       |
-| `GET`  | `/auth/session/status`          | No   | Long-poll status (requires `X-Sesori-Session-Token`) — returns pending / complete / denied / expired / error, or `503 service_restarting` during shutdown |
+| `GET`  | `/auth/session/status`          | No   | Long-poll status (requires `X-Sesori-Session-Token`) — complete responses include `accountStatus`; may return pending / denied / expired / error, or `503 service_restarting` during shutdown |
+
+A complete `/auth/session/status` response includes top-level `accountStatus: "created" | "existing"`; repeated polls
+return the same value until the completion is acknowledged.
 
 `/auth/session/status` answers `503` with `{"status":"error","message":"service_restarting"}` once shutdown has released its
 waiters. It is a refusal, not a verdict: the pending session was neither

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -3,6 +3,7 @@ import { BridgePlatform, bridgeIdSchema, bridgePlatformSchema } from "./bridge.j
 import { devicePlatformSchema } from "./device.js";
 import { CLIENT_SENDABLE_NOTIFICATION_CATEGORIES } from "./notification.js";
 import { deviceIdSchema } from "./settings.js";
+import type { AccountStatus } from "../types/account.js";
 import {
   productAnalyticsExpectedRevisionSchema,
   productAnalyticsOperationIdSchema,
@@ -126,6 +127,7 @@ export type AuthSessionStatusCompleteReply = {
   accessToken: string;
   refreshToken: string;
   user: UserProfile;
+  accountStatus: AccountStatus;
 };
 
 export type AuthSessionStatusDeniedReply = {
@@ -152,6 +154,10 @@ export type AuthTokensReply = {
   accessToken: string;
   refreshToken: string;
   user: UserProfile;
+};
+
+export type AuthLoginReply = AuthTokensReply & {
+  accountStatus: AccountStatus;
 };
 
 export type MeReply = {

--- a/src/routes/auth/apple-native.ts
+++ b/src/routes/auth/apple-native.ts
@@ -1,7 +1,7 @@
 import { FastifyPluginAsync } from "fastify";
 import { z } from "zod";
 import { BadRequestError } from "../../lib/errors.js";
-import type { AppleNativeBody, AuthTokensReply } from "../../models/api.js";
+import type { AppleNativeBody, AuthLoginReply } from "../../models/api.js";
 import type { AuthService } from "../../services/auth-service.js";
 import type { AppleNativeVerifier } from "../../services/apple-native-verifier.js";
 import type { Config } from "../../config.js";
@@ -20,7 +20,7 @@ export type AppleNativeRouteOptions = {
 export const appleNativeRoutes: FastifyPluginAsync<AppleNativeRouteOptions> = async (fastify, opts) => {
   const { authService, appleNativeVerifier, config } = opts;
 
-  fastify.post<{ Body: AppleNativeBody; Reply: AuthTokensReply }>("/auth/apple/native", async (request) => {
+  fastify.post<{ Body: AppleNativeBody; Reply: AuthLoginReply }>("/auth/apple/native", async (request) => {
     const bodyResult = appleNativeBodySchema.safeParse(request.body);
     if (!bodyResult.success) {
       throw new BadRequestError({ debugMessage: "Invalid request body", nestedError: bodyResult.error.issues });

--- a/src/routes/auth/apple.ts
+++ b/src/routes/auth/apple.ts
@@ -139,12 +139,18 @@ export const appleRoutes: FastifyPluginAsync<AppleRouteOptions> = async (fastify
       if (!stateStore.validateState(state)) {
         throw new BadRequestError({ debugMessage: "Invalid or expired state" });
       }
-      return await authService.authenticateOAuth(OAuthProviderName.Apple, appleClient, {
+      const result = await authService.authenticateOAuth(OAuthProviderName.Apple, appleClient, {
         code,
         codeVerifier,
         redirectUri,
         clientId: config.APPLE_CLIENT_ID,
       });
+
+      return {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        user: result.user,
+      };
     }
 
     const formResult = appleFormPostSchema.safeParse(request.body);

--- a/src/routes/auth/email.ts
+++ b/src/routes/auth/email.ts
@@ -1,7 +1,7 @@
 import { FastifyPluginAsync } from "fastify";
 import { z } from "zod";
 import { BadRequestError } from "../../lib/errors.js";
-import type { PasswordLoginBody, AuthTokensReply } from "../../models/api.js";
+import type { PasswordLoginBody, AuthLoginReply } from "../../models/api.js";
 import type { AuthService } from "../../services/auth-service.js";
 
 const passwordLoginBodySchema = z.object({
@@ -16,7 +16,7 @@ export type PasswordRouteOptions = {
 export const passwordRoutes: FastifyPluginAsync<PasswordRouteOptions> = async (fastify, opts) => {
   const { authService } = opts;
 
-  fastify.post<{ Body: PasswordLoginBody; Reply: AuthTokensReply }>(
+  fastify.post<{ Body: PasswordLoginBody; Reply: AuthLoginReply }>(
     "/auth/email",
     {
       config: {

--- a/src/routes/auth/github.ts
+++ b/src/routes/auth/github.ts
@@ -115,13 +115,19 @@ export const githubRoutes: FastifyPluginAsync<GithubRouteOptions> = async (fasti
       throw new BadRequestError({ debugMessage: "Invalid or expired state" });
     }
 
-    return await authService.authenticateOAuth(OAuthProviderName.Github, githubClient, {
+    const result = await authService.authenticateOAuth(OAuthProviderName.Github, githubClient, {
       code,
       codeVerifier,
       redirectUri,
       clientId: config.GITHUB_CLIENT_ID,
       clientSecret: config.GITHUB_CLIENT_SECRET,
     });
+
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      user: result.user,
+    };
   });
 
   fastify.get("/auth/github/callback", async (request, reply) => {

--- a/src/routes/auth/google.ts
+++ b/src/routes/auth/google.ts
@@ -121,13 +121,19 @@ export const googleRoutes: FastifyPluginAsync<GoogleRouteOptions> = async (fasti
       throw new BadRequestError({ debugMessage: "Invalid or expired state" });
     }
 
-    return await authService.authenticateOAuth(OAuthProviderName.Google, googleClient, {
+    const result = await authService.authenticateOAuth(OAuthProviderName.Google, googleClient, {
       code,
       codeVerifier,
       redirectUri,
       clientId: config.GOOGLE_CLIENT_ID,
       clientSecret: config.GOOGLE_CLIENT_SECRET,
     });
+
+    return {
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      user: result.user,
+    };
   });
 
   fastify.get("/auth/google/callback", async (request, reply) => {

--- a/src/routes/auth/provider-callback.ts
+++ b/src/routes/auth/provider-callback.ts
@@ -192,6 +192,7 @@ export async function handleProviderCallbackRedirect<TClient extends OAuthClient
         refreshToken: result.refreshToken,
       },
       user: result.user,
+      accountStatus: result.accountStatus,
     });
 
     if (!stagedSession) {

--- a/src/routes/auth/session-status.ts
+++ b/src/routes/auth/session-status.ts
@@ -6,7 +6,7 @@
  *
  * Responses:
  *   200 { status: "pending" }                                  — long-poll timed out, still pending
- *   200 { status: "complete", accessToken, refreshToken, user } — tokens ready; repeated polls return the same payload until ACK
+ *   200 { status: "complete", accessToken, refreshToken, user, accountStatus } — tokens ready; repeated polls return the same payload until ACK
  *   200 { status: "denied" }
  *   200 { status: "error", message }
  *   400 { error: "bad_request" }                                — missing/invalid session-token header
@@ -178,6 +178,7 @@ function createCompleteReply(params: {
     accessToken: completion.tokens.accessToken,
     refreshToken: completion.tokens.refreshToken,
     user: completion.user,
+    accountStatus: completion.accountStatus,
   };
 }
 

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,4 +1,5 @@
 import type { OAuthClient } from "../clients/auth/oauth-client.js";
+import { AccountStatus } from "../types/account.js";
 import {
   AUTH_PROVIDER_EMAIL,
   OAuthProviderName,
@@ -15,7 +16,7 @@ import type { BridgeService } from "./bridge-service.js";
 import { TokenService } from "./token-service.js";
 import argon2 from "argon2";
 
-type AuthResult = {
+type AuthTokensResult = {
   accessToken: string;
   refreshToken: string;
   user: {
@@ -24,6 +25,10 @@ type AuthResult = {
     providerUserId: string;
     providerUsername: string | null;
   };
+};
+
+type AuthResult = AuthTokensResult & {
+  accountStatus: AccountStatus;
 };
 
 export class AuthService {
@@ -115,13 +120,16 @@ export class AuthService {
       throw new UnauthenticatedError({ debugMessage: "Invalid email or password" });
     }
 
-    return this.#signTokensForUser({
-      userId: account.userId.toHexString(),
-      provider: AUTH_PROVIDER_EMAIL,
-      providerUserId: account.userId.toHexString(),
-      providerUsername: account.email,
-      tokenVersion: user.tokenVersion ?? 0,
-    });
+    return {
+      ...this.#signTokensForUser({
+        userId: account.userId.toHexString(),
+        provider: AUTH_PROVIDER_EMAIL,
+        providerUserId: account.userId.toHexString(),
+        providerUsername: account.email,
+        tokenVersion: user.tokenVersion ?? 0,
+      }),
+      accountStatus: AccountStatus.Existing,
+    };
   }
 
   async #upsertFromOAuth(params: {
@@ -148,13 +156,16 @@ export class AuthService {
       tokenVersion = user?.tokenVersion ?? 0;
     }
 
-    return this.#signTokensForUser({
-      userId: accountUserId,
-      provider: params.provider,
-      providerUserId: params.providerUserId,
-      providerUsername: account.providerUsername,
-      tokenVersion,
-    });
+    return {
+      ...this.#signTokensForUser({
+        userId: accountUserId,
+        provider: params.provider,
+        providerUserId: params.providerUserId,
+        providerUsername: account.providerUsername,
+        tokenVersion,
+      }),
+      accountStatus: isNewUser ? AccountStatus.Created : AccountStatus.Existing,
+    };
   }
 
   #signTokensForUser(params: {
@@ -163,7 +174,7 @@ export class AuthService {
     providerUserId: string;
     providerUsername: string | null;
     tokenVersion: number;
-  }): AuthResult {
+  }): AuthTokensResult {
     const accessToken = this.#tokenService.signAccessToken({
       userId: params.userId,
       provider: params.provider,
@@ -186,7 +197,7 @@ export class AuthService {
     };
   }
 
-  async refreshAuthTokens(refreshToken: string): Promise<AuthResult> {
+  async refreshAuthTokens(refreshToken: string): Promise<AuthTokensResult> {
     let userId: string;
     let tokenVersion: number;
     try {

--- a/src/services/pending-auth-store.ts
+++ b/src/services/pending-auth-store.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import { LRUCache } from "lru-cache";
 import type { DeviceInfo, OAuthClientType, UserProfile } from "../models/api.js";
+import type { AccountStatus } from "../types/account.js";
 import { OAuthProviderName } from "../types/oauth.js";
 
 /**
@@ -64,9 +65,10 @@ export type PendingAuthSession = {
   status: PendingAuthStatus;
   createdAt: Date;
   expiresAt: Date;
-  /** Tokens delivered to the client on `consumeCompletion`. Only present when `status === "complete"`. */
+  /** Completion data delivered to the client. Only present when `status === "complete"`. */
   tokens?: PendingAuthTokens;
   user?: UserProfile;
+  accountStatus?: AccountStatus;
   /** Provider error message when `status === "error"`. */
   errorMessage?: string;
   /** Client type (bridge / app / per-platform). Recorded at init for audit. */
@@ -83,9 +85,10 @@ type PendingAuthStoreEntry = {
 };
 
 type PendingAuthSessionRecord = PendingAuthSession & {
-  /** Tokens held during `awaiting_confirmation`; promoted to `tokens` on confirm. */
+  /** Completion data held during `awaiting_confirmation`; promoted on confirm. */
   stagedTokens?: PendingAuthTokens;
   stagedUser?: UserProfile;
+  stagedAccountStatus?: AccountStatus;
 };
 
 type StatusWaiter = {
@@ -228,6 +231,7 @@ export class PendingAuthStore {
     tokenHash: string;
     tokens: PendingAuthTokens;
     user: UserProfile;
+    accountStatus: AccountStatus;
   }): PendingAuthSession | null {
     const entry = this.#getActiveEntry(params.tokenHash);
     if (!entry) {
@@ -248,8 +252,10 @@ export class PendingAuthStore {
       status: PendingAuthStatus.AwaitingConfirmation,
       stagedTokens: params.tokens,
       stagedUser: params.user,
+      stagedAccountStatus: params.accountStatus,
       tokens: undefined,
       user: undefined,
+      accountStatus: undefined,
       errorMessage: undefined,
     });
   }
@@ -264,8 +270,8 @@ export class PendingAuthStore {
       return null;
     }
 
-    const { stagedTokens, stagedUser } = entry.session;
-    if (!stagedTokens || !stagedUser) {
+    const { stagedTokens, stagedUser, stagedAccountStatus } = entry.session;
+    if (!stagedTokens || !stagedUser || !stagedAccountStatus) {
       return null;
     }
 
@@ -274,8 +280,10 @@ export class PendingAuthStore {
       status: PendingAuthStatus.Complete,
       tokens: stagedTokens,
       user: stagedUser,
+      accountStatus: stagedAccountStatus,
       stagedTokens: undefined,
       stagedUser: undefined,
+      stagedAccountStatus: undefined,
       errorMessage: undefined,
     });
   }
@@ -291,6 +299,7 @@ export class PendingAuthStore {
     tokenHash: string;
     tokens: PendingAuthTokens;
     user: UserProfile;
+    accountStatus: AccountStatus;
   }): PendingAuthSession | null {
     const entry = this.#getActiveEntry(params.tokenHash);
     if (!entry) {
@@ -304,6 +313,7 @@ export class PendingAuthStore {
       status: PendingAuthStatus.Complete,
       tokens: params.tokens,
       user: params.user,
+      accountStatus: params.accountStatus,
       errorMessage: undefined,
     });
   }
@@ -371,15 +381,24 @@ export class PendingAuthStore {
   }
 
   /** Read a completed session without consuming it. The client must ACK before deletion. */
-  getCompletion(tokenHash: string): { tokens: PendingAuthTokens; user: UserProfile } | null {
+  getCompletion(
+    tokenHash: string,
+  ): { tokens: PendingAuthTokens; user: UserProfile; accountStatus: AccountStatus } | null {
     const entry = this.#getActiveEntry(tokenHash);
-    if (!entry || entry.session.status !== PendingAuthStatus.Complete || !entry.session.tokens || !entry.session.user) {
+    if (
+      !entry ||
+      entry.session.status !== PendingAuthStatus.Complete ||
+      !entry.session.tokens ||
+      !entry.session.user ||
+      !entry.session.accountStatus
+    ) {
       return null;
     }
 
     return {
       tokens: { ...entry.session.tokens },
       user: { ...entry.session.user },
+      accountStatus: entry.session.accountStatus,
     };
   }
 
@@ -389,15 +408,24 @@ export class PendingAuthStore {
    * Subsequent calls return null (the LRU entry is gone,
    * `getSessionByTokenHash` returns null too).
    */
-  consumeCompletion(tokenHash: string): { tokens: PendingAuthTokens; user: UserProfile } | null {
+  consumeCompletion(
+    tokenHash: string,
+  ): { tokens: PendingAuthTokens; user: UserProfile; accountStatus: AccountStatus } | null {
     const entry = this.#getActiveEntry(tokenHash);
-    if (!entry || entry.session.status !== PendingAuthStatus.Complete || !entry.session.tokens || !entry.session.user) {
+    if (
+      !entry ||
+      entry.session.status !== PendingAuthStatus.Complete ||
+      !entry.session.tokens ||
+      !entry.session.user ||
+      !entry.session.accountStatus
+    ) {
       return null;
     }
 
     const completion = {
       tokens: { ...entry.session.tokens },
       user: { ...entry.session.user },
+      accountStatus: entry.session.accountStatus,
     };
 
     // Notify any pollers with a "consumed" status, then delete the entry.
@@ -408,8 +436,10 @@ export class PendingAuthStore {
       status: PendingAuthStatus.Consumed,
       stagedTokens: undefined,
       stagedUser: undefined,
+      stagedAccountStatus: undefined,
       tokens: undefined,
       user: undefined,
+      accountStatus: undefined,
       errorMessage: undefined,
     };
     this.#notifyWaiters(tokenHash, consumedSession, { includeSameStatus: true });
@@ -545,8 +575,10 @@ export class PendingAuthStore {
     status: PendingAuthStatus;
     stagedTokens?: PendingAuthTokens;
     stagedUser?: UserProfile;
+    stagedAccountStatus?: AccountStatus;
     tokens?: PendingAuthTokens;
     user?: UserProfile;
+    accountStatus?: AccountStatus;
     errorMessage?: string;
   }): PendingAuthSession | null {
     const entry = this.#getActiveEntry(params.tokenHash);
@@ -557,8 +589,10 @@ export class PendingAuthStore {
     entry.session.status = params.status;
     entry.session.stagedTokens = params.stagedTokens ? { ...params.stagedTokens } : params.stagedTokens;
     entry.session.stagedUser = params.stagedUser ? { ...params.stagedUser } : params.stagedUser;
+    entry.session.stagedAccountStatus = params.stagedAccountStatus;
     entry.session.tokens = params.tokens ? { ...params.tokens } : params.tokens;
     entry.session.user = params.user ? { ...params.user } : params.user;
+    entry.session.accountStatus = params.accountStatus;
     entry.session.errorMessage = params.errorMessage;
     this.#notifyWaiters(params.tokenHash, entry.session);
 
@@ -601,8 +635,10 @@ export class PendingAuthStore {
       status: PendingAuthStatus.Expired,
       stagedTokens: undefined,
       stagedUser: undefined,
+      stagedAccountStatus: undefined,
       tokens: undefined,
       user: undefined,
+      accountStatus: undefined,
       errorMessage: undefined,
     };
 
@@ -690,6 +726,7 @@ export class PendingAuthStore {
       expiresAt: new Date(session.expiresAt),
       tokens: session.tokens ? { ...session.tokens } : undefined,
       user: session.user ? { ...session.user } : undefined,
+      accountStatus: session.accountStatus,
       errorMessage: session.errorMessage,
       clientType: session.clientType,
       device: session.device ? { ...session.device } : undefined,

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -1,0 +1,4 @@
+export enum AccountStatus {
+  Created = "created",
+  Existing = "existing",
+}

--- a/tests/auth/apple-native.test.ts
+++ b/tests/auth/apple-native.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
 import type { AppleNativeVerifier } from "../../src/services/apple-native-verifier.js";
 import { BadGatewayError } from "../../src/lib/errors.js";
+import { AccountStatus } from "../../src/types/account.js";
 
 const FAKE_IDENTITY = {
   providerUserId: "apple-user-123",
@@ -67,6 +68,7 @@ describe("Apple Native OAuth routes", () => {
         accessToken: string;
         refreshToken: string;
         user: { id: string; provider: string; providerUserId: string; providerUsername: string | null };
+        accountStatus: AccountStatus;
       }>();
       assert.ok(body.accessToken, "Should return access token");
       assert.ok(body.refreshToken, "Should return refresh token");
@@ -74,6 +76,7 @@ describe("Apple Native OAuth routes", () => {
       assert.equal(body.user.provider, "apple");
       assert.equal(body.user.providerUserId, FAKE_IDENTITY.providerUserId);
       assert.equal(body.user.providerUsername, FAKE_IDENTITY.providerUsername);
+      assert.equal(body.accountStatus, AccountStatus.Created);
     });
 
     it("returns same user on repeat login with same Apple account", async () => {
@@ -87,7 +90,7 @@ describe("Apple Native OAuth routes", () => {
         }),
       });
       assert.equal(res1.statusCode, 200);
-      const firstUserId = res1.json<{ user: { id: string } }>().user.id;
+      const firstBody = res1.json<{ user: { id: string } }>();
 
       const res2 = await ctx.app.inject({
         method: "POST",
@@ -99,9 +102,10 @@ describe("Apple Native OAuth routes", () => {
         }),
       });
       assert.equal(res2.statusCode, 200);
-      const secondUserId = res2.json<{ user: { id: string } }>().user.id;
+      const secondBody = res2.json<{ user: { id: string }; accountStatus: AccountStatus }>();
 
-      assert.equal(secondUserId, firstUserId, "Same Apple user should get same Sesori user");
+      assert.equal(secondBody.user.id, firstBody.user.id, "Same Apple user should get same Sesori user");
+      assert.equal(secondBody.accountStatus, AccountStatus.Existing);
     });
 
     it("returns 400 when idToken is missing", async () => {

--- a/tests/auth/github.test.ts
+++ b/tests/auth/github.test.ts
@@ -7,6 +7,7 @@ import { FakeOAuthClient } from "../helpers/fake-oauth-client.js";
 import { PendingAuthStore } from "../../src/services/pending-auth-store.js";
 import { MongoDbDatabase, AuthDbCollection } from "../../src/types/mongo.js";
 import type { OAuthAccount, User } from "../../src/models/documents.js";
+import { AccountStatus } from "../../src/types/account.js";
 import { ProductAnalyticsPreference } from "../../src/types/product-analytics.js";
 
 // A valid 43-character PKCE code_challenge (URL-safe base64, no padding)
@@ -237,8 +238,13 @@ describe("GitHub OAuth routes", () => {
         headers: { "x-sesori-session-token": confirmedToken },
       });
       assert.equal(statusRes.statusCode, 200);
-      const statusBody = statusRes.json<{ status: string; user: { id: string } }>();
+      const statusBody = statusRes.json<{
+        status: string;
+        user: { id: string };
+        accountStatus: AccountStatus;
+      }>();
       assert.equal(statusBody.status, "complete");
+      assert.equal(statusBody.accountStatus, AccountStatus.Created);
       assert.ok(ObjectId.isValid(statusBody.user.id), "user id should be a valid ObjectId");
       assert.equal(await countOAuthAccountsForProviderUserId(FAKE_IDENTITY.providerUserId), 1);
 

--- a/tests/auth/oauth-callback-confirmation.test.ts
+++ b/tests/auth/oauth-callback-confirmation.test.ts
@@ -7,6 +7,7 @@ import { StateStore } from "../../src/lib/state-store.js";
 import { buildApp, type AppServices } from "../../src/server.js";
 import { OAuthClientType } from "../../src/models/api.js";
 import { PendingAuthStore } from "../../src/services/pending-auth-store.js";
+import { AccountStatus } from "../../src/types/account.js";
 import { ClientIpSource } from "../../src/types/client-ip.js";
 import { OAuthProviderName, type OAuthExchangeParams, type OAuthIdentity } from "../../src/types/oauth.js";
 import { AsyncTranscriptionProvider } from "../../src/types/transcription.js";
@@ -123,6 +124,7 @@ function createTestServices(params: {
 
       return {
         ...TEST_TOKENS,
+        accountStatus: AccountStatus.Created,
         user: {
           id: `${providerName}-user-123`,
           provider: providerName,
@@ -272,6 +274,7 @@ describe("OAuth callback confirmation flow", () => {
         providerUserId: TEST_IDENTITY.providerUserId,
         providerUsername: TEST_IDENTITY.providerUsername,
       },
+      accountStatus: AccountStatus.Created,
     });
   });
 

--- a/tests/auth/password.test.ts
+++ b/tests/auth/password.test.ts
@@ -5,6 +5,7 @@ import argon2 from "argon2";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
 import { MongoDbDatabase, AuthDbCollection } from "../../src/types/mongo.js";
 import type { User, PasswordAccount } from "../../src/models/documents.js";
+import { AccountStatus } from "../../src/types/account.js";
 import { ProductAnalyticsPreference } from "../../src/types/product-analytics.js";
 
 describe("Password authentication", () => {
@@ -65,12 +66,18 @@ describe("Password authentication", () => {
       });
 
       assert.equal(res.statusCode, 200);
-      const body = res.json<{ accessToken: string; refreshToken: string; user: { id: string; provider: string } }>();
+      const body = res.json<{
+        accessToken: string;
+        refreshToken: string;
+        user: { id: string; provider: string };
+        accountStatus: AccountStatus;
+      }>();
       assert.ok(body.accessToken, "Should return access token");
       assert.ok(body.refreshToken, "Should return refresh token");
       assert.ok(body.user.id, "Should return user id");
       assert.equal(body.user.provider, "email");
-      assert.deepEqual(Object.keys(body).sort(), ["accessToken", "refreshToken", "user"]);
+      assert.equal(body.accountStatus, AccountStatus.Existing);
+      assert.deepEqual(Object.keys(body).sort(), ["accessToken", "accountStatus", "refreshToken", "user"]);
       assert.deepEqual(Object.keys(body.user).sort(), ["id", "provider", "providerUserId", "providerUsername"]);
     });
 

--- a/tests/auth/session-status.test.ts
+++ b/tests/auth/session-status.test.ts
@@ -5,6 +5,7 @@ import Fastify, { type FastifyInstance, type InjectOptions, type LightMyRequestR
 import { ApiError } from "../../src/lib/errors.js";
 import { sessionStatusRoutes } from "../../src/routes/auth/session-status.js";
 import { PendingAuthStore } from "../../src/services/pending-auth-store.js";
+import { AccountStatus } from "../../src/types/account.js";
 import { OAuthProviderName } from "../../src/types/oauth.js";
 
 const VALID_SESSION_TOKEN = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
@@ -64,7 +65,12 @@ describe("GET /auth/session/status", () => {
 
   it("returns a completed auth payload immediately without consuming before ACK", async () => {
     const tokenHash = createPendingSession({ sessionToken: VALID_SESSION_TOKEN });
-    pendingAuthStore.completeSession({ tokenHash, tokens: TEST_TOKENS, user: TEST_USER });
+    pendingAuthStore.completeSession({
+      tokenHash,
+      tokens: TEST_TOKENS,
+      user: TEST_USER,
+      accountStatus: AccountStatus.Created,
+    });
 
     const res = await injectWithKeepAlive({
       method: "GET",
@@ -78,13 +84,19 @@ describe("GET /auth/session/status", () => {
       accessToken: TEST_TOKENS.accessToken,
       refreshToken: TEST_TOKENS.refreshToken,
       user: TEST_USER,
+      accountStatus: AccountStatus.Created,
     });
     assert.equal(pendingAuthStore.getSessionByTokenHash(tokenHash)?.status, "complete");
   });
 
   it("returns the same completion until ACK, then returns 404", async () => {
     const tokenHash = createPendingSession({ sessionToken: VALID_SESSION_TOKEN });
-    pendingAuthStore.completeSession({ tokenHash, tokens: TEST_TOKENS, user: TEST_USER });
+    pendingAuthStore.completeSession({
+      tokenHash,
+      tokens: TEST_TOKENS,
+      user: TEST_USER,
+      accountStatus: AccountStatus.Existing,
+    });
 
     const firstResponse = await injectWithKeepAlive({
       method: "GET",
@@ -108,6 +120,7 @@ describe("GET /auth/session/status", () => {
     });
 
     assert.equal(firstResponse.statusCode, 200);
+    assert.equal(firstResponse.json<{ accountStatus: AccountStatus }>().accountStatus, AccountStatus.Existing);
     assert.deepEqual(secondResponse.json(), firstResponse.json());
     assert.equal(ackResponse.statusCode, 200);
     assert.deepEqual(ackResponse.json(), { success: true });
@@ -125,7 +138,12 @@ describe("GET /auth/session/status", () => {
     pendingRequest.destroy();
     await pendingRequest.closed;
 
-    pendingAuthStore.completeSession({ tokenHash, tokens: TEST_TOKENS, user: TEST_USER });
+    pendingAuthStore.completeSession({
+      tokenHash,
+      tokens: TEST_TOKENS,
+      user: TEST_USER,
+      accountStatus: AccountStatus.Created,
+    });
     await delay(10);
 
     assert.equal(pendingAuthStore.getSessionByTokenHash(tokenHash)?.status, "complete");
@@ -147,6 +165,7 @@ describe("GET /auth/session/status", () => {
       accessToken: TEST_TOKENS.accessToken,
       refreshToken: TEST_TOKENS.refreshToken,
       user: TEST_USER,
+      accountStatus: AccountStatus.Created,
     });
     assert.equal(replayResponse.statusCode, 200);
     assert.deepEqual(replayResponse.json(), retryResponse.json());
@@ -283,7 +302,12 @@ describe("GET /auth/session/status", () => {
 
   it("lets concurrent completed pollers receive the same payload before ACK", async () => {
     const tokenHash = createPendingSession({ sessionToken: VALID_SESSION_TOKEN });
-    pendingAuthStore.completeSession({ tokenHash, tokens: TEST_TOKENS, user: TEST_USER });
+    pendingAuthStore.completeSession({
+      tokenHash,
+      tokens: TEST_TOKENS,
+      user: TEST_USER,
+      accountStatus: AccountStatus.Created,
+    });
 
     const [a, b] = await Promise.all([
       injectWithKeepAlive({

--- a/tests/services/pending-auth-store.test.ts
+++ b/tests/services/pending-auth-store.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it, mock } from "node:test";
 import { PendingAuthStore } from "../../src/services/pending-auth-store.js";
+import { AccountStatus } from "../../src/types/account.js";
 import { OAuthProviderName } from "../../src/types/oauth.js";
 
 function createSessionTokenHash(token = "session-token"): string {
@@ -79,6 +80,7 @@ describe("PendingAuthStore", () => {
           providerUserId: "provider-user-1",
           providerUsername: "octocat",
         },
+        accountStatus: AccountStatus.Created,
       });
 
       const waited = await waitPromise;
@@ -141,6 +143,7 @@ describe("PendingAuthStore", () => {
         providerUserId: "provider-user-1",
         providerUsername: "octocat",
       },
+      accountStatus: AccountStatus.Existing,
     });
 
     assert.equal(waited, null);
@@ -180,6 +183,7 @@ describe("PendingAuthStore", () => {
         providerUserId: "provider-b",
         providerUsername: "user-b",
       },
+      accountStatus: AccountStatus.Created,
     });
     const waitedB = await waitB;
 
@@ -275,6 +279,7 @@ describe("PendingAuthStore", () => {
         providerUserId: "provider-user-1",
         providerUsername: "octocat",
       },
+      accountStatus: AccountStatus.Existing,
     });
 
     const firstConsume = store.consumeCompletion(tokenHash);
@@ -292,6 +297,7 @@ describe("PendingAuthStore", () => {
         providerUserId: "provider-user-1",
         providerUsername: "octocat",
       },
+      accountStatus: AccountStatus.Existing,
     });
     assert.equal(secondConsume, null);
     assert.equal(afterConsume, null);


### PR DESCRIPTION
## Summary
- add top-level `accountStatus: "created" | "existing"` to completed `GET /auth/session/status`, `POST /auth/apple/native`, and `POST /auth/email` responses
- derive OAuth status from the atomic account upsert and preserve it through pending-session confirmation, replay, and acknowledgement
- report password logins as `existing` while keeping refresh and legacy direct-exchange response contracts unchanged
- document and test the response contract

## Validation
- `npm test` (921 passed, 1 skipped)
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run circular-dependencies`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds account creation status to login responses and session-status completions so clients know if a login created a new account or used an existing one. Previously these responses didn’t include this signal; now they return accountStatus: "created" | "existing" without changing token refresh or direct OAuth callback responses.

**New Features**
- GET /auth/session/status returns accountStatus in complete responses and preserves it across replays until ACK.
- POST /auth/apple/native returns accountStatus; it is "created" only if that request created the Sesori account.
- POST /auth/email returns accountStatus and always reports "existing" for provisioned accounts.
- OAuth confirmation flow stages and delivers accountStatus through pending, confirm, replay, and ACK.
- Adds AccountStatus enum and updates docs and tests to cover the new contract.

**Migration**
- No rollout changes required; clients can start reading the new top-level accountStatus.
- Token refresh responses do not include accountStatus.

<sup>Written for commit 2bb145649dbcbde6c1f96ba93894743e344d3d02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

