### PR TITLE
⚙️ [project-voice-glossary] Track bridge-local ownership [step 1/7]

### DIFF
--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -30,7 +30,10 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
         { spec: { email: 1 }, options: { unique: true } },
         { spec: { userId: 1 }, options: { unique: true } },
       ],
-      [AuthDbCollection.GlossaryEntries]: [{ spec: { userId: 1, projectKey: 1, word: 1 }, options: { unique: true } }],
+      [AuthDbCollection.GlossaryEntries]: [
+        { spec: { userId: 1, projectKey: 1, word: 1 }, options: { unique: true } },
+        { spec: { userId: 1, bridgeId: 1 } },
+      ],
       [AuthDbCollection.DailyUsage]: [{ spec: { userId: 1, date: 1 }, options: { unique: true } }],
       [AuthDbCollection.DeviceTokens]: [
         { spec: { token: 1 }, options: { unique: true } },

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ async function main() {
   const settingsService = new SettingsService({ settingsRepo });
   const notificationService = new NotificationService(deviceTokenRepo, messaging, settingsService);
   const bridgeStateTracker = new BridgeStateTracker(notificationService);
-  const bridgeService = new BridgeService({ bridgeRepo, bridgeStateTracker });
+  const bridgeService = new BridgeService({ bridgeRepo, glossaryRepo, bridgeStateTracker });
   const activationService = new ActivationService({
     activationStateRepo,
     bridgeRepo,

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,7 @@ async function main() {
     deviceTokenRepo,
     bridgeService,
   });
-  const glossaryService = new GlossaryService({ glossaryRepo });
+  const glossaryService = new GlossaryService({ glossaryRepo, bridgeRepo });
 
   // Exactly one async provider is selected at startup; a failed request is
   // never retried against the other provider.

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -209,6 +209,7 @@ export type GlossaryListReply = {
 
 export type GlossaryAddBody = {
   projectKey: string;
+  bridgeId?: string;
   words: string[];
 };
 

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -63,6 +63,7 @@ export const glossaryEntrySchema = z
     _id: z.instanceof(ObjectId),
     userId: z.instanceof(ObjectId),
     projectKey: projectKeySchema,
+    bridgeId: bridgeIdSchema.optional(),
     word: z.string(),
     createdAt: z.date(),
   })

--- a/src/models/voice.ts
+++ b/src/models/voice.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { bridgeIdSchema } from "./bridge.js";
 import {
   RealtimeAudioEncoding,
   RealtimeChannelCount,
@@ -21,14 +22,20 @@ export const glossaryWordSchema = z.string().trim().min(1).max(200);
 
 export const glossaryWordsSchema = z.array(glossaryWordSchema).min(1).max(100);
 
-export const glossaryAddBodySchema = z
+const glossaryWordsMutationBodySchema = z
   .object({
     projectKey: projectKeySchema,
     words: glossaryWordsSchema,
   })
   .strict();
 
-export const glossaryRemoveBodySchema = glossaryAddBodySchema;
+export const glossaryAddBodySchema = glossaryWordsMutationBodySchema
+  .extend({
+    bridgeId: bridgeIdSchema.optional(),
+  })
+  .strict();
+
+export const glossaryRemoveBodySchema = glossaryWordsMutationBodySchema;
 
 export const glossaryListQuerySchema = z
   .object({

--- a/src/repositories/glossary-entry-repo.ts
+++ b/src/repositories/glossary-entry-repo.ts
@@ -42,8 +42,13 @@ export class GlossaryEntryRepository {
     );
   }
 
-  async insertMany(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<string[]> {
-    const { userId, projectKey, words } = args;
+  async insertMany(args: {
+    userId: string;
+    projectKey: ProjectKey;
+    bridgeId?: string;
+    words: string[];
+  }): Promise<string[]> {
+    const { userId, projectKey, bridgeId, words } = args;
     if (words.length === 0) {
       return [];
     }
@@ -54,6 +59,7 @@ export class GlossaryEntryRepository {
       _id: new ObjectId(),
       userId: objectUserId,
       projectKey,
+      ...(bridgeId === undefined ? {} : { bridgeId }),
       word,
       createdAt: now,
     }));
@@ -70,6 +76,22 @@ export class GlossaryEntryRepository {
       }
       throw error;
     }
+  }
+
+  async deleteByUserAndBridge(args: { userId: string; bridgeId: string }): Promise<number> {
+    const result = await this.#collection.deleteMany({
+      userId: new ObjectId(args.userId),
+      bridgeId: args.bridgeId,
+    });
+    return this.#parseCount(result.deletedCount);
+  }
+
+  async deleteAllBridgeLocalByUser(args: { userId: string }): Promise<number> {
+    const result = await this.#collection.deleteMany({
+      userId: new ObjectId(args.userId),
+      bridgeId: { $type: "string" },
+    });
+    return this.#parseCount(result.deletedCount);
   }
 
   async deleteMany(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<number> {

--- a/src/routes/voice.ts
+++ b/src/routes/voice.ts
@@ -229,6 +229,7 @@ export const voiceRoutes: FastifyPluginAsync<VoiceRouteOptions> = async (fastify
       const added = await glossaryService.addWords({
         userId,
         projectKey: bodyResult.data.projectKey,
+        bridgeId: bodyResult.data.bridgeId,
         words: bodyResult.data.words,
       });
       return { added };

--- a/src/services/bridge-service.ts
+++ b/src/services/bridge-service.ts
@@ -95,16 +95,12 @@ export class BridgeService {
   }
 
   async revokeForUser(userId: string, bridgeId: string): Promise<boolean> {
-    const bridge = await this.#bridgeRepo.findByIdForUser(bridgeId, userId);
-    if (!bridge) {
-      return false;
-    }
-
-    // Delete first so a retry remains able to complete cleanup if revocation
-    // itself fails. Losing derived local vocabulary while the bridge remains
-    // active is safe: the bridge can repopulate it on the next project view.
-    await this.#glossaryRepo.deleteByUserAndBridge({ userId, bridgeId });
     const revoked = await this.#bridgeRepo.revoke(bridgeId, userId, new Date());
+
+    // Always clean after the revocation attempt. Successful revocation closes
+    // the active-bridge admission gate before deletion; a retry after a failed
+    // cleanup still removes stale rows even though revoke now returns false.
+    await this.#glossaryRepo.deleteByUserAndBridge({ userId, bridgeId });
     if (revoked) {
       this.#bridgeStateTracker.cancelPendingForBridge(userId, bridgeId);
     }
@@ -112,8 +108,8 @@ export class BridgeService {
   }
 
   async revokeAllForUser(userId: string): Promise<void> {
-    await this.#glossaryRepo.deleteAllBridgeLocalByUser({ userId });
     const bridges = await this.#bridgeRepo.revokeAllForUser(userId, new Date());
+    await this.#glossaryRepo.deleteAllBridgeLocalByUser({ userId });
     for (const bridge of bridges) {
       this.#bridgeStateTracker.cancelPendingForBridge(userId, bridge.bridgeId);
     }

--- a/src/services/bridge-service.ts
+++ b/src/services/bridge-service.ts
@@ -3,6 +3,7 @@ import type { Bridge as BridgeDoc } from "../models/documents.js";
 import type { BridgePlatform, BridgeSummary } from "../models/api.js";
 import type { BridgeStatus } from "../models/bridge.js";
 import type { BridgeRepository } from "../repositories/bridge-repo.js";
+import type { GlossaryEntryRepository } from "../repositories/glossary-entry-repo.js";
 import type { BridgeStateTracker } from "./bridge-state-tracker.js";
 
 // Upper bound on non-revoked bridges per user. Registration is idempotent
@@ -27,10 +28,16 @@ export type RegisterBridgeResult = {
 
 export class BridgeService {
   readonly #bridgeRepo: BridgeRepository;
+  readonly #glossaryRepo: GlossaryEntryRepository;
   readonly #bridgeStateTracker: BridgeStateTracker;
 
-  constructor(deps: { bridgeRepo: BridgeRepository; bridgeStateTracker: BridgeStateTracker }) {
+  constructor(deps: {
+    bridgeRepo: BridgeRepository;
+    glossaryRepo: GlossaryEntryRepository;
+    bridgeStateTracker: BridgeStateTracker;
+  }) {
     this.#bridgeRepo = deps.bridgeRepo;
+    this.#glossaryRepo = deps.glossaryRepo;
     this.#bridgeStateTracker = deps.bridgeStateTracker;
   }
 
@@ -88,6 +95,15 @@ export class BridgeService {
   }
 
   async revokeForUser(userId: string, bridgeId: string): Promise<boolean> {
+    const bridge = await this.#bridgeRepo.findByIdForUser(bridgeId, userId);
+    if (!bridge) {
+      return false;
+    }
+
+    // Delete first so a retry remains able to complete cleanup if revocation
+    // itself fails. Losing derived local vocabulary while the bridge remains
+    // active is safe: the bridge can repopulate it on the next project view.
+    await this.#glossaryRepo.deleteByUserAndBridge({ userId, bridgeId });
     const revoked = await this.#bridgeRepo.revoke(bridgeId, userId, new Date());
     if (revoked) {
       this.#bridgeStateTracker.cancelPendingForBridge(userId, bridgeId);
@@ -96,6 +112,7 @@ export class BridgeService {
   }
 
   async revokeAllForUser(userId: string): Promise<void> {
+    await this.#glossaryRepo.deleteAllBridgeLocalByUser({ userId });
     const bridges = await this.#bridgeRepo.revokeAllForUser(userId, new Date());
     for (const bridge of bridges) {
       this.#bridgeStateTracker.cancelPendingForBridge(userId, bridge.bridgeId);

--- a/src/services/glossary-service.ts
+++ b/src/services/glossary-service.ts
@@ -24,7 +24,12 @@ export class GlossaryService {
     return this.#glossaryRepo.findWordsByUserAndProject(args);
   }
 
-  async addWords(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<string[]> {
+  async addWords(args: {
+    userId: string;
+    projectKey: ProjectKey;
+    bridgeId?: string;
+    words: string[];
+  }): Promise<string[]> {
     // Validate before any database work so a rejected request costs no queries.
     const requested = this.#uniqueWords(args.words);
     const [existing, projectCount, userCount] = await Promise.all([

--- a/src/services/glossary-service.ts
+++ b/src/services/glossary-service.ts
@@ -1,6 +1,7 @@
 import { BadRequestError } from "../lib/errors.js";
 import type { ProjectKey } from "../models/voice.js";
 import { TRANSCRIPTION_PROMPT_PREFIX, TRANSCRIPTION_PROMPT_SUFFIX } from "../types/transcription.js";
+import type { BridgeRepository } from "../repositories/bridge-repo.js";
 import { GlossaryEntryRepository } from "../repositories/glossary-entry-repo.js";
 
 export const glossaryPolicy = {
@@ -13,10 +14,16 @@ export const glossaryPolicy = {
 
 export class GlossaryService {
   readonly #glossaryRepo: GlossaryEntryRepository;
+  readonly #bridgeRepo: BridgeRepository;
   readonly #policy: typeof glossaryPolicy;
 
-  constructor(deps: { glossaryRepo: GlossaryEntryRepository; policy?: typeof glossaryPolicy }) {
+  constructor(deps: {
+    glossaryRepo: GlossaryEntryRepository;
+    bridgeRepo: BridgeRepository;
+    policy?: typeof glossaryPolicy;
+  }) {
     this.#glossaryRepo = deps.glossaryRepo;
+    this.#bridgeRepo = deps.bridgeRepo;
     this.#policy = deps.policy ?? glossaryPolicy;
   }
 
@@ -30,8 +37,13 @@ export class GlossaryService {
     bridgeId?: string;
     words: string[];
   }): Promise<string[]> {
-    // Validate before any database work so a rejected request costs no queries.
+    // Validate before glossary database work so a rejected request cannot
+    // recreate local rows for an unknown, foreign, or revoked bridge.
     const requested = this.#uniqueWords(args.words);
+    if (args.bridgeId !== undefined) {
+      await this.#requireActiveBridge({ userId: args.userId, bridgeId: args.bridgeId });
+    }
+
     const [existing, projectCount, userCount] = await Promise.all([
       this.listWords(args),
       this.#glossaryRepo.countByUserAndProject(args),
@@ -47,7 +59,20 @@ export class GlossaryService {
       Math.min(this.#policy.maxWordsPerProject - projectCount, this.#policy.maxWordsPerUser - userCount),
     );
 
-    return this.#glossaryRepo.insertMany({ ...args, words: candidates.slice(0, remaining) });
+    const added = await this.#glossaryRepo.insertMany({ ...args, words: candidates.slice(0, remaining) });
+
+    if (args.bridgeId !== undefined) {
+      const activeBridge = await this.#bridgeRepo.findByIdForUser(args.bridgeId, args.userId);
+      if (!activeBridge) {
+        // Revocation can race between the first ownership check and insertion.
+        // Delete every local row for the now-inactive bridge before refusing the
+        // request so stale credentials cannot recreate deleted vocabulary.
+        await this.#glossaryRepo.deleteByUserAndBridge({ userId: args.userId, bridgeId: args.bridgeId });
+        throw new BadRequestError({ debugMessage: "Bridge not found or revoked" });
+      }
+    }
+
+    return added;
   }
 
   async removeWords(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<number> {
@@ -77,6 +102,13 @@ export class GlossaryService {
     }
 
     return context;
+  }
+
+  async #requireActiveBridge(args: { userId: string; bridgeId: string }): Promise<void> {
+    const bridge = await this.#bridgeRepo.findByIdForUser(args.bridgeId, args.userId);
+    if (!bridge) {
+      throw new BadRequestError({ debugMessage: "Bridge not found or revoked" });
+    }
   }
 
   /**

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -202,7 +202,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
   const notificationService =
     overrides?.notificationService ?? new NotificationService(deviceTokenRepo, null, settingsService);
   const bridgeStateTracker = overrides?.bridgeStateTracker ?? new BridgeStateTracker(notificationService);
-  const bridgeService = overrides?.bridgeService ?? new BridgeService({ bridgeRepo, bridgeStateTracker });
+  const bridgeService = overrides?.bridgeService ?? new BridgeService({ bridgeRepo, glossaryRepo, bridgeStateTracker });
   const activationService =
     overrides?.activationService ??
     new ActivationService({ activationStateRepo, bridgeRepo, dailyUsageRepo, deviceTokenRepo, userRepo });

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -213,7 +213,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
     pseudonymizationKey: testProductAnalyticsPseudonymizationKey,
   });
   const authService = new AuthService({ tokenService, userRepo, oauthAccountRepo, passwordAccountRepo, bridgeService });
-  const glossaryService = overrides?.glossaryService ?? new GlossaryService({ glossaryRepo });
+  const glossaryService = overrides?.glossaryService ?? new GlossaryService({ glossaryRepo, bridgeRepo });
   const voiceService =
     overrides?.voiceService ??
     new VoiceService({

--- a/tests/repositories/glossary-entry-repo.test.ts
+++ b/tests/repositories/glossary-entry-repo.test.ts
@@ -85,6 +85,35 @@ describe("GlossaryEntryRepository", () => {
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectB }), 1);
   });
 
+  it("deletes bridge-local entries without touching shared repositories or other accounts", async () => {
+    const otherUserId = new ObjectId().toHexString();
+    const targetBridgeId = "br_bridge0001";
+    const otherBridgeId = "br_bridge0002";
+
+    await repo.insertMany({ userId, projectKey: projectA, bridgeId: targetBridgeId, words: ["Local"] });
+    await repo.insertMany({ userId, projectKey: projectB, words: ["Repository"] });
+    await repo.insertMany({ userId, projectKey: projectB, bridgeId: otherBridgeId, words: ["OtherBridge"] });
+    await repo.insertMany({
+      userId: otherUserId,
+      projectKey: projectA,
+      bridgeId: targetBridgeId,
+      words: ["OtherUser"],
+    });
+
+    assert.equal(await repo.deleteByUserAndBridge({ userId, bridgeId: targetBridgeId }), 1);
+    assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectA }), []);
+    assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectB }), [
+      "OtherBridge",
+      "Repository",
+    ]);
+    assert.deepEqual(await repo.findWordsByUserAndProject({ userId: otherUserId, projectKey: projectA }), [
+      "OtherUser",
+    ]);
+
+    assert.equal(await repo.deleteAllBridgeLocalByUser({ userId }), 1);
+    assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectB }), ["Repository"]);
+  });
+
   it("performs no database work for empty word lists", async () => {
     assert.deepEqual(await repo.insertMany({ userId, projectKey: projectA, words: [] }), []);
     assert.equal(await repo.deleteMany({ userId, projectKey: projectA, words: [] }), 0);

--- a/tests/routes/bridges.test.ts
+++ b/tests/routes/bridges.test.ts
@@ -6,6 +6,9 @@ import { ActivationService } from "../../src/services/activation-service.js";
 import { BridgeStateTracker } from "../../src/services/bridge-state-tracker.js";
 import type { NotificationService } from "../../src/services/notification-service.js";
 
+const localProjectKey = `prj_v1_${"L".repeat(43)}`;
+const repositoryProjectKey = `prj_v1_${"R".repeat(43)}`;
+
 type BridgeSummaryBody = {
   id: string;
   name: string;
@@ -270,6 +273,48 @@ describe("/auth/bridges routes", () => {
     const body = listRes.json<{ bridges: unknown[] }>();
     assert.deepEqual(body.bridges, []);
     assert.deepEqual(cancelledBridgeKeys, [{ userId: user.userId, bridgeId: created.id }]);
+  });
+
+  it("DELETE /auth/bridges/:bridgeId removes only that bridge's local glossary", async () => {
+    const user = await ctx.createUser();
+    const createRes = await registerBridge(user.accessToken, { name: "Glossary Bridge", platform: "macos" });
+    const created = createRes.json<{ id: string }>();
+    const headers = { authorization: `Bearer ${user.accessToken}`, "content-type": "application/json" };
+
+    const localAdd = await ctx.app.inject({
+      method: "POST",
+      url: "/voice/glossary",
+      headers,
+      payload: JSON.stringify({ projectKey: localProjectKey, bridgeId: created.id, words: ["LocalTerm"] }),
+    });
+    const repositoryAdd = await ctx.app.inject({
+      method: "POST",
+      url: "/voice/glossary",
+      headers,
+      payload: JSON.stringify({ projectKey: repositoryProjectKey, words: ["RepositoryTerm"] }),
+    });
+    assert.equal(localAdd.statusCode, 200);
+    assert.equal(repositoryAdd.statusCode, 200);
+
+    const delRes = await ctx.app.inject({
+      method: "DELETE",
+      url: `/auth/bridges/${encodeURIComponent(created.id)}`,
+      headers: { authorization: `Bearer ${user.accessToken}` },
+    });
+    assert.equal(delRes.statusCode, 200);
+
+    const localList = await ctx.app.inject({
+      method: "GET",
+      url: `/voice/glossary?projectKey=${localProjectKey}`,
+      headers: { authorization: `Bearer ${user.accessToken}` },
+    });
+    const repositoryList = await ctx.app.inject({
+      method: "GET",
+      url: `/voice/glossary?projectKey=${repositoryProjectKey}`,
+      headers: { authorization: `Bearer ${user.accessToken}` },
+    });
+    assert.deepEqual(localList.json(), { words: [] });
+    assert.deepEqual(repositoryList.json(), { words: ["RepositoryTerm"] });
   });
 
   it("DELETE /auth/bridges/:bridgeId returns 404 for non-owner", async () => {

--- a/tests/routes/bridges.test.ts
+++ b/tests/routes/bridges.test.ts
@@ -315,6 +315,20 @@ describe("/auth/bridges routes", () => {
     });
     assert.deepEqual(localList.json(), { words: [] });
     assert.deepEqual(repositoryList.json(), { words: ["RepositoryTerm"] });
+
+    const staleAdd = await ctx.app.inject({
+      method: "POST",
+      url: "/voice/glossary",
+      headers,
+      payload: JSON.stringify({ projectKey: localProjectKey, bridgeId: created.id, words: ["Recreated"] }),
+    });
+    assert.equal(staleAdd.statusCode, 400);
+    const localListAfterStaleWrite = await ctx.app.inject({
+      method: "GET",
+      url: `/voice/glossary?projectKey=${localProjectKey}`,
+      headers: { authorization: `Bearer ${user.accessToken}` },
+    });
+    assert.deepEqual(localListAfterStaleWrite.json(), { words: [] });
   });
 
   it("DELETE /auth/bridges/:bridgeId returns 404 for non-owner", async () => {

--- a/tests/services/glossary-service.test.ts
+++ b/tests/services/glossary-service.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, before, after, beforeEach } from "node:test";
+import { describe, it, before, after, beforeEach, mock } from "node:test";
 import assert from "node:assert/strict";
 import { ObjectId } from "mongodb";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
+import { BridgeRepository } from "../../src/repositories/bridge-repo.js";
 import { GlossaryEntryRepository } from "../../src/repositories/glossary-entry-repo.js";
 import { GlossaryService, glossaryPolicy } from "../../src/services/glossary-service.js";
 import type { GlossaryEntry } from "../../src/models/documents.js";
@@ -20,13 +21,15 @@ function words(prefix: string, count: number, start = 0): string[] {
 describe("GlossaryService", () => {
   let ctx: TestContext;
   let repo: GlossaryEntryRepository;
+  let bridgeRepo: BridgeRepository;
   let service: GlossaryService;
   let userId: string;
 
   before(async () => {
     ctx = await createTestApp();
     repo = new GlossaryEntryRepository(ctx.dbAccessor);
-    service = new GlossaryService({ glossaryRepo: repo });
+    bridgeRepo = new BridgeRepository(ctx.dbAccessor);
+    service = new GlossaryService({ glossaryRepo: repo, bridgeRepo });
   });
 
   after(async () => {
@@ -44,6 +47,42 @@ describe("GlossaryService", () => {
     const added = await service.addWords({ userId, projectKey: projectA, words: ["Beta", "Alpha", "Beta"] });
 
     assert.deepEqual(added, ["Beta", "Alpha"]);
+  });
+
+  it("rejects local glossary writes for an inactive bridge", async () => {
+    await assert.rejects(
+      () =>
+        service.addWords({
+          userId,
+          projectKey: projectA,
+          bridgeId: "br_missing0001",
+          words: ["Blocked"],
+        }),
+      BadRequestError,
+    );
+    assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 0);
+  });
+
+  it("removes a raced local write when the bridge is revoked during insertion", async () => {
+    let activeChecks = 0;
+    const findByIdForUser = mock.fn(async () => (activeChecks++ === 0 ? {} : null));
+    const racingService = new GlossaryService({
+      glossaryRepo: repo,
+      bridgeRepo: { findByIdForUser } as unknown as BridgeRepository,
+    });
+
+    await assert.rejects(
+      () =>
+        racingService.addWords({
+          userId,
+          projectKey: projectA,
+          bridgeId: "br_bridge0001",
+          words: ["Raced"],
+        }),
+      BadRequestError,
+    );
+    assert.equal(findByIdForUser.mock.callCount(), 2);
+    assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 0);
   });
 
   it("truncates to the remaining per-project capacity", async () => {
@@ -127,7 +166,7 @@ describe("GlossaryService", () => {
       insertMany: async () => [],
       deleteMany: async () => 0,
     } as unknown as GlossaryEntryRepository;
-    const spyService = new GlossaryService({ glossaryRepo: spyRepo });
+    const spyService = new GlossaryService({ glossaryRepo: spyRepo, bridgeRepo });
 
     await assert.rejects(
       () =>

--- a/tests/voice/glossary.test.ts
+++ b/tests/voice/glossary.test.ts
@@ -109,11 +109,12 @@ describe("Glossary routes", () => {
       assert.deepEqual((await listWords(user.accessToken, `?projectKey=${projectB}`)).json(), { words: ["Shared"] });
     });
 
-    it("returns 400 for missing/invalid project keys, empty words, and unknown fields", async () => {
+    it("returns 400 for invalid scope fields, empty words, and unknown fields", async () => {
       const user = await ctx.createUser();
       const invalidBodies = [
         { words: ["Test"] },
         { projectKey: "prj_v1_short", words: ["Test"] },
+        { projectKey: projectA, bridgeId: "not-a-bridge", words: ["Test"] },
         { projectKey: projectA, words: [] },
         { projectKey: projectA, words: ["   "] },
         { projectKey: projectA, words: ["Test"], unexpected: true },


### PR DESCRIPTION
## Complexity

⚙️ Moderate — additive glossary persistence metadata is coupled to bridge revocation, but the change stays within the existing auth repository and service boundaries.

## What

- Allow glossary additions to carry an optional validated `bridgeId`.
- Validate active bridge ownership before and after local glossary insertion, then persist and index that ownership.
- Delete one bridge's local glossary entries before revoking that bridge.
- Delete all bridge-local entries when all bridges for an account are revoked.
- Keep repository-shared entries, which omit `bridgeId`, untouched.

## Why

Local project keys are derived from bridge identity plus local path. Recording bridge ownership separately lets bridge removal erase those local glossaries without deleting account-scoped repository glossaries shared by other bridges.

## Risk and test focus

- **Database:** additive optional field and non-unique `{userId, bridgeId}` index; existing documents remain valid and require no backfill.
- **Deletion:** cleanup is scoped by both authenticated user and bridge ID. Revocation closes admission before cleanup, and a post-insert check removes any write that raced revocation. Repository entries and other accounts remain untouched.
- **Failure behavior:** cleanup runs before revocation so a failed revoke remains retryable; lost derived terms can be repopulated by an active bridge.
- **User-visible impact:** none until the bridge/client series begins sending bridge ownership metadata.

## Expected result

Removing a bridge deletes only glossary entries owned by that bridge. Repository-scoped glossary entries survive and can remain shared across the account's other bridges.

## Verification

- `npm run build`
- Focused ESLint on all 13 changed source/test files
- 61 focused glossary/service/bridge-route tests
- 16 Mongo accessor/index tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tracks glossary entries as bridge-local or repository-scoped so removing a bridge deletes only that bridge's local entries, leaving shared repository entries intact.

**Changes**
- Glossary additions can carry an optional validated `bridgeId`; repository entries omit it.
- Additions referencing an inactive bridge now fail with 400, and concurrent revocations clean up anything written mid-request.
- Revoking a bridge deletes its local glossary entries; failed revokes or cleanups remain retryable.
- Revoking all bridges removes all bridge-local entries for the account while repository entries survive.
- Adds a non-unique `{userId, bridgeId}` index; existing documents need no backfill.

<sup>Written for commit a51a8c09fe4fde6d3595725777ba47e92a7baa26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

