### PR TITLE
🚧 [project-voice-glossary] Enforce strong glossary scopes [step 2/8]

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,9 +552,9 @@ fallback shape. The server validates active bridge ownership before and after a
 bridge-local insertion so revocation cannot race vocabulary back into storage.
 Repository rows survive bridge removal; bridge-local rows do not.
 
-Glossary CRUD requires a project key: `GET /voice/glossary?projectKey=…`, `POST
-/voice/glossary` with `{ scope, words }`, and `DELETE /voice/glossary` with
-`{ projectKey, words }`. `POST /voice/transcribe` accepts an optional
+Glossary CRUD requires a project key: `GET /voice/glossary?projectKey=…`, while
+`POST` and `DELETE /voice/glossary` use the exact `{ scope, words }` ownership
+variant. `POST /voice/transcribe` accepts an optional
 `projectKey` multipart field; omission means no glossary context is applied and
 never falls back to a global glossary.
 Safety caps are 100 words per request, 500 per project, 5,000 per user, 200

--- a/README.md
+++ b/README.md
@@ -536,29 +536,27 @@ fatal, as does the hard deadline. Treat a nonzero exit on shutdown as a real
 fault to investigate; treat a `disposal degraded` log line on an otherwise clean
 exit as informational.
 
-## Project-scoped glossary migration
+## Project-scoped glossary
 
-Glossary ownership uses an opaque, stable client-derived project key rather than
-a filesystem path or raw bridge project ID:
+The bridge derives opaque `prj_v1_` keys without sending repository origins or
+local paths to auth. A project with a network `origin` hashes the canonical
+origin and uses an account-scoped `repository` variant shared by that account's
+bridges. Other projects hash bridge identity plus normalized local path and use
+a `bridge_local` variant whose required `bridgeId` enables deletion when that
+bridge is removed.
 
-```text
-digestInput = "sesori-project-glossary-v1\0" + projectId
-projectKey = "prj_v1_" + base64url(sha256(utf8(digestInput)))
-```
+Persisted and mutation scopes are discriminated variants: repository scope has
+only `{ type, projectKey }`, while bridge-local scope requires
+`{ type, projectKey, bridgeId }`. There is no nullable ownership field or
+fallback shape. The server validates active bridge ownership before and after a
+bridge-local insertion so revocation cannot race vocabulary back into storage.
+Repository rows survive bridge removal; bridge-local rows do not.
 
-The result is exactly `prj_v1_` plus a 43-character unpadded base64url digest.
-The canonical cross-repository vector is project ID `project-123` →
-`prj_v1_xgjNDm_yyduAKisFHr498ZgcjIU1FACdyEj68wSmbhc`. Using stable `Project.id`
-keeps the key unchanged when a directory moves. The server validates only this
-opaque shape and scopes it to the authenticated user; the key is not an
-authorization credential. It never accepts or persists a raw path for glossary
-ownership. Equal project IDs on two bridges deliberately share one glossary for
-that user, because the composer flow does not carry bridge identity.
-
-Glossary CRUD requires a project key: `GET /voice/glossary?projectKey=…` and
-`POST`/`DELETE /voice/glossary` with `{ projectKey, words }`. `POST
-/voice/transcribe` accepts an optional `projectKey` multipart field; omission
-means no glossary context is applied and never falls back to a global glossary.
+Glossary CRUD requires a project key: `GET /voice/glossary?projectKey=…`, `POST
+/voice/glossary` with `{ scope, words }`, and `DELETE /voice/glossary` with
+`{ projectKey, words }`. `POST /voice/transcribe` accepts an optional
+`projectKey` multipart field; omission means no glossary context is applied and
+never falls back to a global glossary.
 Safety caps are 100 words per request, 500 per project, 5,000 per user, 200
 characters per word, and an 8,000-character provider context. Caps are checked
 per request rather than serialized, so concurrent requests may narrowly exceed

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -30,7 +30,10 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
         { spec: { email: 1 }, options: { unique: true } },
         { spec: { userId: 1 }, options: { unique: true } },
       ],
-      [AuthDbCollection.GlossaryEntries]: [{ spec: { userId: 1, projectKey: 1, word: 1 }, options: { unique: true } }],
+      [AuthDbCollection.GlossaryEntries]: [
+        { spec: { userId: 1, projectKey: 1, word: 1 }, options: { unique: true } },
+        { spec: { userId: 1, bridgeId: 1 } },
+      ],
       [AuthDbCollection.DailyUsage]: [{ spec: { userId: 1, date: 1 }, options: { unique: true } }],
       [AuthDbCollection.DeviceTokens]: [
         { spec: { token: 1 }, options: { unique: true } },

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -31,8 +31,8 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
         { spec: { userId: 1 }, options: { unique: true } },
       ],
       [AuthDbCollection.GlossaryEntries]: [
-        { spec: { userId: 1, projectKey: 1, word: 1 }, options: { unique: true } },
-        { spec: { userId: 1, bridgeId: 1 } },
+        { spec: { userId: 1, "scope.projectKey": 1, word: 1 }, options: { unique: true } },
+        { spec: { userId: 1, "scope.type": 1, "scope.bridgeId": 1 } },
       ],
       [AuthDbCollection.DailyUsage]: [{ spec: { userId: 1, date: 1 }, options: { unique: true } }],
       [AuthDbCollection.DeviceTokens]: [

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -31,7 +31,16 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
         { spec: { userId: 1 }, options: { unique: true } },
       ],
       [AuthDbCollection.GlossaryEntries]: [
-        { spec: { userId: 1, "scope.projectKey": 1, word: 1 }, options: { unique: true } },
+        {
+          spec: {
+            userId: 1,
+            "scope.projectKey": 1,
+            "scope.type": 1,
+            "scope.bridgeId": 1,
+            word: 1,
+          },
+          options: { unique: true },
+        },
         { spec: { userId: 1, "scope.type": 1, "scope.bridgeId": 1 } },
       ],
       [AuthDbCollection.DailyUsage]: [{ spec: { userId: 1, date: 1 }, options: { unique: true } }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,7 @@ async function main() {
   const settingsService = new SettingsService({ settingsRepo });
   const notificationService = new NotificationService(deviceTokenRepo, messaging, settingsService);
   const bridgeStateTracker = new BridgeStateTracker(notificationService);
-  const bridgeService = new BridgeService({ bridgeRepo, bridgeStateTracker });
+  const bridgeService = new BridgeService({ bridgeRepo, glossaryRepo, bridgeStateTracker });
   const activationService = new ActivationService({
     activationStateRepo,
     bridgeRepo,

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ async function main() {
     deviceTokenRepo,
     bridgeService,
   });
-  const glossaryService = new GlossaryService({ glossaryRepo });
+  const glossaryService = new GlossaryService({ glossaryRepo, bridgeRepo });
 
   // Exactly one async provider is selected at startup; a failed request is
   // never retried against the other provider.

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -209,6 +209,7 @@ export type GlossaryListReply = {
 
 export type GlossaryAddBody = {
   projectKey: string;
+  bridgeId?: string;
   words: string[];
 };
 

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -3,6 +3,7 @@ import { BridgePlatform, bridgeIdSchema, bridgePlatformSchema } from "./bridge.j
 import { devicePlatformSchema } from "./device.js";
 import { CLIENT_SENDABLE_NOTIFICATION_CATEGORIES } from "./notification.js";
 import { deviceIdSchema } from "./settings.js";
+import type { ProjectGlossaryScope } from "./voice.js";
 import type { AccountStatus } from "../types/account.js";
 import {
   productAnalyticsExpectedRevisionSchema,
@@ -208,8 +209,7 @@ export type GlossaryListReply = {
 };
 
 export type GlossaryAddBody = {
-  projectKey: string;
-  bridgeId?: string;
+  scope: ProjectGlossaryScope;
   words: string[];
 };
 

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -218,7 +218,7 @@ export type GlossaryAddReply = {
 };
 
 export type GlossaryRemoveBody = {
-  projectKey: string;
+  scope: ProjectGlossaryScope;
   words: string[];
 };
 

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -8,7 +8,7 @@ import {
   productAnalyticsPreferenceRevisionSchema,
   productAnalyticsPreferenceSchema,
 } from "../types/product-analytics.js";
-import { projectKeySchema } from "./voice.js";
+import { projectGlossaryScopeSchema } from "./voice.js";
 
 export const userSchema = z.object({
   _id: z.instanceof(ObjectId),
@@ -62,8 +62,7 @@ export const glossaryEntrySchema = z
   .object({
     _id: z.instanceof(ObjectId),
     userId: z.instanceof(ObjectId),
-    projectKey: projectKeySchema,
-    bridgeId: bridgeIdSchema.optional(),
+    scope: projectGlossaryScopeSchema,
     word: z.string(),
     createdAt: z.date(),
   })

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -63,6 +63,7 @@ export const glossaryEntrySchema = z
     _id: z.instanceof(ObjectId),
     userId: z.instanceof(ObjectId),
     projectKey: projectKeySchema,
+    bridgeId: bridgeIdSchema.optional(),
     word: z.string(),
     createdAt: z.date(),
   })

--- a/src/models/voice.ts
+++ b/src/models/voice.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { bridgeIdSchema } from "./bridge.js";
 import {
   RealtimeAudioEncoding,
   RealtimeChannelCount,
@@ -21,14 +22,20 @@ export const glossaryWordSchema = z.string().trim().min(1).max(200);
 
 export const glossaryWordsSchema = z.array(glossaryWordSchema).min(1).max(100);
 
-export const glossaryAddBodySchema = z
+const glossaryWordsMutationBodySchema = z
   .object({
     projectKey: projectKeySchema,
     words: glossaryWordsSchema,
   })
   .strict();
 
-export const glossaryRemoveBodySchema = glossaryAddBodySchema;
+export const glossaryAddBodySchema = glossaryWordsMutationBodySchema
+  .extend({
+    bridgeId: bridgeIdSchema.optional(),
+  })
+  .strict();
+
+export const glossaryRemoveBodySchema = glossaryWordsMutationBodySchema;
 
 export const glossaryListQuerySchema = z
   .object({

--- a/src/models/voice.ts
+++ b/src/models/voice.ts
@@ -18,24 +18,50 @@ export const projectKeySchema = z
 
 export type ProjectKey = z.infer<typeof projectKeySchema>;
 
+export enum ProjectGlossaryScopeType {
+  repository = "repository",
+  bridgeLocal = "bridge_local",
+}
+
+const repositoryProjectGlossaryScopeSchema = z
+  .object({
+    type: z.literal(ProjectGlossaryScopeType.repository),
+    projectKey: projectKeySchema,
+  })
+  .strict();
+
+const bridgeLocalProjectGlossaryScopeSchema = z
+  .object({
+    type: z.literal(ProjectGlossaryScopeType.bridgeLocal),
+    projectKey: projectKeySchema,
+    bridgeId: bridgeIdSchema,
+  })
+  .strict();
+
+export const projectGlossaryScopeSchema = z.discriminatedUnion("type", [
+  repositoryProjectGlossaryScopeSchema,
+  bridgeLocalProjectGlossaryScopeSchema,
+]);
+
+export type ProjectGlossaryScope = z.infer<typeof projectGlossaryScopeSchema>;
+
 export const glossaryWordSchema = z.string().trim().min(1).max(200);
 
 export const glossaryWordsSchema = z.array(glossaryWordSchema).min(1).max(100);
 
-const glossaryWordsMutationBodySchema = z
+export const glossaryAddBodySchema = z
+  .object({
+    scope: projectGlossaryScopeSchema,
+    words: glossaryWordsSchema,
+  })
+  .strict();
+
+export const glossaryRemoveBodySchema = z
   .object({
     projectKey: projectKeySchema,
     words: glossaryWordsSchema,
   })
   .strict();
-
-export const glossaryAddBodySchema = glossaryWordsMutationBodySchema
-  .extend({
-    bridgeId: bridgeIdSchema.optional(),
-  })
-  .strict();
-
-export const glossaryRemoveBodySchema = glossaryWordsMutationBodySchema;
 
 export const glossaryListQuerySchema = z
   .object({

--- a/src/models/voice.ts
+++ b/src/models/voice.ts
@@ -58,7 +58,7 @@ export const glossaryAddBodySchema = z
 
 export const glossaryRemoveBodySchema = z
   .object({
-    projectKey: projectKeySchema,
+    scope: projectGlossaryScopeSchema,
     words: glossaryWordsSchema,
   })
   .strict();

--- a/src/repositories/bridge-repo.ts
+++ b/src/repositories/bridge-repo.ts
@@ -46,6 +46,22 @@ export class BridgeRepository {
     });
   }
 
+  async findRevokedIdsForUser(args: { userId: string; bridgeIds: string[] }): Promise<string[]> {
+    if (!ObjectId.isValid(args.userId) || args.bridgeIds.length === 0) {
+      return [];
+    }
+
+    const bridges = await this.#collection
+      .find({
+        userId: new ObjectId(args.userId),
+        bridgeId: { $in: args.bridgeIds },
+        revokedAt: { $ne: null },
+      })
+      .sort({ bridgeId: 1 })
+      .toArray();
+    return bridges.map((bridge) => bridge.bridgeId);
+  }
+
   async findByUserId(userId: string): Promise<Bridge[]> {
     if (!ObjectId.isValid(userId)) {
       return [];
@@ -185,16 +201,13 @@ export class BridgeRepository {
       return [];
     }
 
-    // Flip first, then return every revoked bridge for retryable lifecycle
-    // cleanup. A bridge registered between the two queries remains active and
-    // is excluded, while a retry can still clean residue for an older revoke.
+    // Flip first, then snapshot by the exact revocation timestamp: a bridge
+    // registered between the two queries remains active and is excluded.
     const objectUserId = new ObjectId(userId);
     await this.#collection.updateMany(
       { userId: objectUserId, revokedAt: null },
-      {
-        $set: { status: BridgeStatus.inactive, revokedAt: at, updatedAt: at },
-      },
+      { $set: { status: BridgeStatus.inactive, revokedAt: at, updatedAt: at } },
     );
-    return this.#collection.find({ userId: objectUserId, revokedAt: { $ne: null } }).toArray();
+    return this.#collection.find({ userId: objectUserId, revokedAt: at }).toArray();
   }
 }

--- a/src/repositories/bridge-repo.ts
+++ b/src/repositories/bridge-repo.ts
@@ -185,15 +185,16 @@ export class BridgeRepository {
       return [];
     }
 
-    // Flip first, then snapshot by the exact revocation timestamp: a bridge
-    // registered between the two queries is simply not part of this revoke,
-    // and every bridge this call DID revoke is guaranteed to be in the
-    // returned set — so its tracker timer gets cancelled (no ghost
-    // notifications after account revoke).
-    const filter = { userId: new ObjectId(userId), revokedAt: null };
-    await this.#collection.updateMany(filter, {
-      $set: { status: BridgeStatus.inactive, revokedAt: at, updatedAt: at },
-    });
-    return this.#collection.find({ userId: new ObjectId(userId), revokedAt: at }).toArray();
+    // Flip first, then return every revoked bridge for retryable lifecycle
+    // cleanup. A bridge registered between the two queries remains active and
+    // is excluded, while a retry can still clean residue for an older revoke.
+    const objectUserId = new ObjectId(userId);
+    await this.#collection.updateMany(
+      { userId: objectUserId, revokedAt: null },
+      {
+        $set: { status: BridgeStatus.inactive, revokedAt: at, updatedAt: at },
+      },
+    );
+    return this.#collection.find({ userId: objectUserId, revokedAt: { $ne: null } }).toArray();
   }
 }

--- a/src/repositories/glossary-entry-repo.ts
+++ b/src/repositories/glossary-entry-repo.ts
@@ -8,6 +8,20 @@ import { MongoDbDatabase, AuthDbCollection } from "../types/mongo.js";
 
 const countSchema = z.number().int().nonnegative().safe();
 
+type ProjectGlossaryScopeFilter = {
+  "scope.type": ProjectGlossaryScopeType;
+  "scope.projectKey": ProjectKey;
+  "scope.bridgeId"?: string;
+};
+
+function scopeFilter(scope: ProjectGlossaryScope): ProjectGlossaryScopeFilter {
+  const base = {
+    "scope.type": scope.type,
+    "scope.projectKey": scope.projectKey,
+  };
+  return scope.type === ProjectGlossaryScopeType.bridgeLocal ? { ...base, "scope.bridgeId": scope.bridgeId } : base;
+}
+
 export class GlossaryEntryRepository {
   readonly #collection: Collection<GlossaryEntry>;
 
@@ -19,6 +33,15 @@ export class GlossaryEntryRepository {
   async findWordsByUserAndProject(args: { userId: string; projectKey: ProjectKey }): Promise<string[]> {
     const entries = await this.#collection
       .find({ userId: new ObjectId(args.userId), "scope.projectKey": args.projectKey })
+      .sort({ word: 1 })
+      .toArray();
+
+    return [...new Set(entries.map((entry) => this.#parseEntry(entry).word))];
+  }
+
+  async findWordsByUserAndScope(args: { userId: string; scope: ProjectGlossaryScope }): Promise<string[]> {
+    const entries = await this.#collection
+      .find({ userId: new ObjectId(args.userId), ...scopeFilter(args.scope) })
       .sort({ word: 1 })
       .toArray();
 
@@ -85,15 +108,15 @@ export class GlossaryEntryRepository {
     return this.#parseCount(result.deletedCount);
   }
 
-  async deleteMany(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<number> {
-    const { userId, projectKey, words } = args;
+  async deleteMany(args: { userId: string; scope: ProjectGlossaryScope; words: string[] }): Promise<number> {
+    const { userId, scope, words } = args;
     if (words.length === 0) {
       return 0;
     }
 
     const result = await this.#collection.deleteMany({
       userId: new ObjectId(userId),
-      "scope.projectKey": projectKey,
+      ...scopeFilter(scope),
       word: { $in: words },
     });
     return this.#parseCount(result.deletedCount);

--- a/src/repositories/glossary-entry-repo.ts
+++ b/src/repositories/glossary-entry-repo.ts
@@ -42,8 +42,13 @@ export class GlossaryEntryRepository {
     );
   }
 
-  async insertMany(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<string[]> {
-    const { userId, projectKey, words } = args;
+  async insertMany(args: {
+    userId: string;
+    projectKey: ProjectKey;
+    bridgeId?: string;
+    words: string[];
+  }): Promise<string[]> {
+    const { userId, projectKey, bridgeId, words } = args;
     if (words.length === 0) {
       return [];
     }
@@ -54,6 +59,7 @@ export class GlossaryEntryRepository {
       _id: new ObjectId(),
       userId: objectUserId,
       projectKey,
+      ...(bridgeId === undefined ? {} : { bridgeId }),
       word,
       createdAt: now,
     }));
@@ -70,6 +76,22 @@ export class GlossaryEntryRepository {
       }
       throw error;
     }
+  }
+
+  async deleteByUserAndBridge(args: { userId: string; bridgeId: string }): Promise<number> {
+    const result = await this.#collection.deleteMany({
+      userId: new ObjectId(args.userId),
+      bridgeId: args.bridgeId,
+    });
+    return this.#parseCount(result.deletedCount);
+  }
+
+  async deleteAllBridgeLocalByUser(args: { userId: string }): Promise<number> {
+    const result = await this.#collection.deleteMany({
+      userId: new ObjectId(args.userId),
+      bridgeId: { $type: "string" },
+    });
+    return this.#parseCount(result.deletedCount);
   }
 
   async deleteMany(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<number> {

--- a/src/repositories/glossary-entry-repo.ts
+++ b/src/repositories/glossary-entry-repo.ts
@@ -100,14 +100,6 @@ export class GlossaryEntryRepository {
     return this.#parseCount(result.deletedCount);
   }
 
-  async deleteAllBridgeLocalByUser(args: { userId: string }): Promise<number> {
-    const result = await this.#collection.deleteMany({
-      userId: new ObjectId(args.userId),
-      "scope.type": ProjectGlossaryScopeType.bridgeLocal,
-    });
-    return this.#parseCount(result.deletedCount);
-  }
-
   async deleteMany(args: { userId: string; scope: ProjectGlossaryScope; words: string[] }): Promise<number> {
     const { userId, scope, words } = args;
     if (words.length === 0) {

--- a/src/repositories/glossary-entry-repo.ts
+++ b/src/repositories/glossary-entry-repo.ts
@@ -2,7 +2,7 @@ import { Collection, MongoBulkWriteError, ObjectId } from "mongodb";
 import { z } from "zod";
 import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
 import { glossaryEntrySchema, type GlossaryEntry } from "../models/documents.js";
-import type { ProjectKey } from "../models/voice.js";
+import { ProjectGlossaryScopeType, type ProjectGlossaryScope, type ProjectKey } from "../models/voice.js";
 import { InternalServerError } from "../lib/errors.js";
 import { MongoDbDatabase, AuthDbCollection } from "../types/mongo.js";
 
@@ -18,7 +18,7 @@ export class GlossaryEntryRepository {
   /** Returns the project's words. Documents stay inside the repository boundary. */
   async findWordsByUserAndProject(args: { userId: string; projectKey: ProjectKey }): Promise<string[]> {
     const entries = await this.#collection
-      .find({ userId: new ObjectId(args.userId), projectKey: args.projectKey })
+      .find({ userId: new ObjectId(args.userId), "scope.projectKey": args.projectKey })
       .sort({ word: 1 })
       .toArray();
 
@@ -27,28 +27,19 @@ export class GlossaryEntryRepository {
 
   async countByUserAndProject(args: { userId: string; projectKey: ProjectKey }): Promise<number> {
     return this.#parseCount(
-      await this.#collection.countDocuments({ userId: new ObjectId(args.userId), projectKey: args.projectKey }),
+      await this.#collection.countDocuments({
+        userId: new ObjectId(args.userId),
+        "scope.projectKey": args.projectKey,
+      }),
     );
   }
 
-  /**
-   * Counts a user's project-scoped terms. Unscoped legacy documents are excluded
-   * because scoped CRUD cannot list or delete them, so they must not permanently
-   * consume the per-user capacity.
-   */
   async countScopedByUserId(userId: string): Promise<number> {
-    return this.#parseCount(
-      await this.#collection.countDocuments({ userId: new ObjectId(userId), projectKey: { $type: "string" } }),
-    );
+    return this.#parseCount(await this.#collection.countDocuments({ userId: new ObjectId(userId) }));
   }
 
-  async insertMany(args: {
-    userId: string;
-    projectKey: ProjectKey;
-    bridgeId?: string;
-    words: string[];
-  }): Promise<string[]> {
-    const { userId, projectKey, bridgeId, words } = args;
+  async insertMany(args: { userId: string; scope: ProjectGlossaryScope; words: string[] }): Promise<string[]> {
+    const { userId, scope, words } = args;
     if (words.length === 0) {
       return [];
     }
@@ -58,8 +49,7 @@ export class GlossaryEntryRepository {
     const docs: GlossaryEntry[] = words.map((word) => ({
       _id: new ObjectId(),
       userId: objectUserId,
-      projectKey,
-      ...(bridgeId === undefined ? {} : { bridgeId }),
+      scope,
       word,
       createdAt: now,
     }));
@@ -81,7 +71,8 @@ export class GlossaryEntryRepository {
   async deleteByUserAndBridge(args: { userId: string; bridgeId: string }): Promise<number> {
     const result = await this.#collection.deleteMany({
       userId: new ObjectId(args.userId),
-      bridgeId: args.bridgeId,
+      "scope.type": ProjectGlossaryScopeType.bridgeLocal,
+      "scope.bridgeId": args.bridgeId,
     });
     return this.#parseCount(result.deletedCount);
   }
@@ -89,7 +80,7 @@ export class GlossaryEntryRepository {
   async deleteAllBridgeLocalByUser(args: { userId: string }): Promise<number> {
     const result = await this.#collection.deleteMany({
       userId: new ObjectId(args.userId),
-      bridgeId: { $type: "string" },
+      "scope.type": ProjectGlossaryScopeType.bridgeLocal,
     });
     return this.#parseCount(result.deletedCount);
   }
@@ -102,7 +93,7 @@ export class GlossaryEntryRepository {
 
     const result = await this.#collection.deleteMany({
       userId: new ObjectId(userId),
-      projectKey,
+      "scope.projectKey": projectKey,
       word: { $in: words },
     });
     return this.#parseCount(result.deletedCount);

--- a/src/repositories/glossary-entry-repo.ts
+++ b/src/repositories/glossary-entry-repo.ts
@@ -4,9 +4,11 @@ import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
 import { glossaryEntrySchema, type GlossaryEntry } from "../models/documents.js";
 import { ProjectGlossaryScopeType, type ProjectGlossaryScope, type ProjectKey } from "../models/voice.js";
 import { InternalServerError } from "../lib/errors.js";
+import { bridgeIdSchema } from "../models/bridge.js";
 import { MongoDbDatabase, AuthDbCollection } from "../types/mongo.js";
 
 const countSchema = z.number().int().nonnegative().safe();
+const bridgeIdsSchema = z.array(bridgeIdSchema);
 
 type ProjectGlossaryScopeFilter = {
   "scope.type": ProjectGlossaryScopeType;
@@ -91,11 +93,31 @@ export class GlossaryEntryRepository {
     }
   }
 
+  async findBridgeLocalOwnerIdsByUser(args: { userId: string }): Promise<string[]> {
+    const values = await this.#collection.distinct("scope.bridgeId", {
+      userId: new ObjectId(args.userId),
+      "scope.type": ProjectGlossaryScopeType.bridgeLocal,
+    });
+    const parsed = bridgeIdsSchema.safeParse(values);
+    if (!parsed.success) {
+      throw new InternalServerError({ debugMessage: "Invalid bridge-local glossary ownership persistence" });
+    }
+    return parsed.data;
+  }
+
   async deleteByUserAndBridge(args: { userId: string; bridgeId: string }): Promise<number> {
+    return this.deleteByUserAndBridges({ userId: args.userId, bridgeIds: [args.bridgeId] });
+  }
+
+  async deleteByUserAndBridges(args: { userId: string; bridgeIds: string[] }): Promise<number> {
+    if (args.bridgeIds.length === 0) {
+      return 0;
+    }
+
     const result = await this.#collection.deleteMany({
       userId: new ObjectId(args.userId),
       "scope.type": ProjectGlossaryScopeType.bridgeLocal,
-      "scope.bridgeId": args.bridgeId,
+      "scope.bridgeId": { $in: args.bridgeIds },
     });
     return this.#parseCount(result.deletedCount);
   }

--- a/src/routes/voice.ts
+++ b/src/routes/voice.ts
@@ -254,8 +254,7 @@ export const voiceRoutes: FastifyPluginAsync<VoiceRouteOptions> = async (fastify
       const userId = getUserId(request);
       const added = await glossaryService.addWords({
         userId,
-        projectKey: bodyResult.data.projectKey,
-        bridgeId: bodyResult.data.bridgeId,
+        scope: bodyResult.data.scope,
         words: bodyResult.data.words,
       });
       return { added };

--- a/src/routes/voice.ts
+++ b/src/routes/voice.ts
@@ -255,6 +255,7 @@ export const voiceRoutes: FastifyPluginAsync<VoiceRouteOptions> = async (fastify
       const added = await glossaryService.addWords({
         userId,
         projectKey: bodyResult.data.projectKey,
+        bridgeId: bodyResult.data.bridgeId,
         words: bodyResult.data.words,
       });
       return { added };

--- a/src/routes/voice.ts
+++ b/src/routes/voice.ts
@@ -273,7 +273,7 @@ export const voiceRoutes: FastifyPluginAsync<VoiceRouteOptions> = async (fastify
       const userId = getUserId(request);
       const removed = await glossaryService.removeWords({
         userId,
-        projectKey: bodyResult.data.projectKey,
+        scope: bodyResult.data.scope,
         words: bodyResult.data.words,
       });
       return { removed };

--- a/src/services/bridge-service.ts
+++ b/src/services/bridge-service.ts
@@ -95,16 +95,12 @@ export class BridgeService {
   }
 
   async revokeForUser(userId: string, bridgeId: string): Promise<boolean> {
-    const bridge = await this.#bridgeRepo.findByIdForUser(bridgeId, userId);
-    if (!bridge) {
-      return false;
-    }
-
-    // Delete first so a retry remains able to complete cleanup if revocation
-    // itself fails. Losing derived local vocabulary while the bridge remains
-    // active is safe: the bridge can repopulate it on the next project view.
-    await this.#glossaryRepo.deleteByUserAndBridge({ userId, bridgeId });
     const revoked = await this.#bridgeRepo.revoke(bridgeId, userId, new Date());
+
+    // Always clean after the revocation attempt. Successful revocation closes
+    // the active-bridge admission gate before deletion; a retry after a failed
+    // cleanup still removes stale rows even though revoke now returns false.
+    await this.#glossaryRepo.deleteByUserAndBridge({ userId, bridgeId });
     if (revoked) {
       this.#bridgeStateTracker.cancelPendingForBridge(userId, bridgeId);
     }
@@ -112,8 +108,8 @@ export class BridgeService {
   }
 
   async revokeAllForUser(userId: string): Promise<void> {
-    await this.#glossaryRepo.deleteAllBridgeLocalByUser({ userId });
     const bridges = await this.#bridgeRepo.revokeAllForUser(userId, new Date());
+    await this.#glossaryRepo.deleteAllBridgeLocalByUser({ userId });
     for (const bridge of bridges) {
       this.#bridgeStateTracker.cancelPendingForBridge(userId, bridge.bridgeId);
     }

--- a/src/services/bridge-service.ts
+++ b/src/services/bridge-service.ts
@@ -96,22 +96,31 @@ export class BridgeService {
 
   async revokeForUser(userId: string, bridgeId: string): Promise<boolean> {
     const revoked = await this.#bridgeRepo.revoke(bridgeId, userId, new Date());
+    if (revoked) {
+      // Revocation owns timer cancellation; glossary cleanup failure must not
+      // leave a notification queued for a bridge that is already inactive.
+      this.#bridgeStateTracker.cancelPendingForBridge(userId, bridgeId);
+    }
 
     // Always clean after the revocation attempt. Successful revocation closes
     // the active-bridge admission gate before deletion; a retry after a failed
     // cleanup still removes stale rows even though revoke now returns false.
     await this.#glossaryRepo.deleteByUserAndBridge({ userId, bridgeId });
-    if (revoked) {
-      this.#bridgeStateTracker.cancelPendingForBridge(userId, bridgeId);
-    }
     return revoked;
   }
 
   async revokeAllForUser(userId: string): Promise<void> {
     const bridges = await this.#bridgeRepo.revokeAllForUser(userId, new Date());
-    await this.#glossaryRepo.deleteAllBridgeLocalByUser({ userId });
     for (const bridge of bridges) {
+      // Cancel every timer before persistence cleanup so a cleanup failure
+      // cannot emit a notification for an already-revoked bridge.
       this.#bridgeStateTracker.cancelPendingForBridge(userId, bridge.bridgeId);
+    }
+    for (const bridge of bridges) {
+      // Delete only rows whose owning bridge is confirmed revoked. A bridge
+      // registered concurrently remains active and keeps its local glossary;
+      // returning older revoked bridges makes cleanup retryable.
+      await this.#glossaryRepo.deleteByUserAndBridge({ userId, bridgeId: bridge.bridgeId });
     }
   }
 

--- a/src/services/bridge-service.ts
+++ b/src/services/bridge-service.ts
@@ -3,6 +3,7 @@ import type { Bridge as BridgeDoc } from "../models/documents.js";
 import type { BridgePlatform, BridgeSummary } from "../models/api.js";
 import type { BridgeStatus } from "../models/bridge.js";
 import type { BridgeRepository } from "../repositories/bridge-repo.js";
+import type { GlossaryEntryRepository } from "../repositories/glossary-entry-repo.js";
 import type { BridgeStateTracker } from "./bridge-state-tracker.js";
 
 // Upper bound on non-revoked bridges per user. Registration is idempotent
@@ -27,10 +28,16 @@ export type RegisterBridgeResult = {
 
 export class BridgeService {
   readonly #bridgeRepo: BridgeRepository;
+  readonly #glossaryRepo: GlossaryEntryRepository;
   readonly #bridgeStateTracker: BridgeStateTracker;
 
-  constructor(deps: { bridgeRepo: BridgeRepository; bridgeStateTracker: BridgeStateTracker }) {
+  constructor(deps: {
+    bridgeRepo: BridgeRepository;
+    glossaryRepo: GlossaryEntryRepository;
+    bridgeStateTracker: BridgeStateTracker;
+  }) {
     this.#bridgeRepo = deps.bridgeRepo;
+    this.#glossaryRepo = deps.glossaryRepo;
     this.#bridgeStateTracker = deps.bridgeStateTracker;
   }
 
@@ -88,6 +95,15 @@ export class BridgeService {
   }
 
   async revokeForUser(userId: string, bridgeId: string): Promise<boolean> {
+    const bridge = await this.#bridgeRepo.findByIdForUser(bridgeId, userId);
+    if (!bridge) {
+      return false;
+    }
+
+    // Delete first so a retry remains able to complete cleanup if revocation
+    // itself fails. Losing derived local vocabulary while the bridge remains
+    // active is safe: the bridge can repopulate it on the next project view.
+    await this.#glossaryRepo.deleteByUserAndBridge({ userId, bridgeId });
     const revoked = await this.#bridgeRepo.revoke(bridgeId, userId, new Date());
     if (revoked) {
       this.#bridgeStateTracker.cancelPendingForBridge(userId, bridgeId);
@@ -96,6 +112,7 @@ export class BridgeService {
   }
 
   async revokeAllForUser(userId: string): Promise<void> {
+    await this.#glossaryRepo.deleteAllBridgeLocalByUser({ userId });
     const bridges = await this.#bridgeRepo.revokeAllForUser(userId, new Date());
     for (const bridge of bridges) {
       this.#bridgeStateTracker.cancelPendingForBridge(userId, bridge.bridgeId);

--- a/src/services/bridge-service.ts
+++ b/src/services/bridge-service.ts
@@ -116,12 +116,13 @@ export class BridgeService {
       // cannot emit a notification for an already-revoked bridge.
       this.#bridgeStateTracker.cancelPendingForBridge(userId, bridge.bridgeId);
     }
-    for (const bridge of bridges) {
-      // Delete only rows whose owning bridge is confirmed revoked. A bridge
-      // registered concurrently remains active and keeps its local glossary;
-      // returning older revoked bridges makes cleanup retryable.
-      await this.#glossaryRepo.deleteByUserAndBridge({ userId, bridgeId: bridge.bridgeId });
-    }
+
+    // Candidate IDs come from bounded glossary storage, not unbounded bridge
+    // history. Rechecking revocation protects a bridge registered concurrently,
+    // while including older revoked candidates makes failed cleanup retryable.
+    const candidateIds = await this.#glossaryRepo.findBridgeLocalOwnerIdsByUser({ userId });
+    const revokedIds = await this.#bridgeRepo.findRevokedIdsForUser({ userId, bridgeIds: candidateIds });
+    await this.#glossaryRepo.deleteByUserAndBridges({ userId, bridgeIds: revokedIds });
   }
 
   // Atomically records a relay-reported status event. found=false means the

--- a/src/services/glossary-service.ts
+++ b/src/services/glossary-service.ts
@@ -24,7 +24,12 @@ export class GlossaryService {
     return this.#glossaryRepo.findWordsByUserAndProject(args);
   }
 
-  async addWords(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<string[]> {
+  async addWords(args: {
+    userId: string;
+    projectKey: ProjectKey;
+    bridgeId?: string;
+    words: string[];
+  }): Promise<string[]> {
     // Validate before any database work so a rejected request costs no queries.
     const requested = this.#uniqueWords(args.words);
     const [existing, projectCount, userCount] = await Promise.all([

--- a/src/services/glossary-service.ts
+++ b/src/services/glossary-service.ts
@@ -1,6 +1,7 @@
 import { BadRequestError } from "../lib/errors.js";
 import type { ProjectKey } from "../models/voice.js";
 import { TRANSCRIPTION_PROMPT_PREFIX, TRANSCRIPTION_PROMPT_SUFFIX } from "../types/transcription.js";
+import type { BridgeRepository } from "../repositories/bridge-repo.js";
 import { GlossaryEntryRepository } from "../repositories/glossary-entry-repo.js";
 
 export const glossaryPolicy = {
@@ -13,10 +14,16 @@ export const glossaryPolicy = {
 
 export class GlossaryService {
   readonly #glossaryRepo: GlossaryEntryRepository;
+  readonly #bridgeRepo: BridgeRepository;
   readonly #policy: typeof glossaryPolicy;
 
-  constructor(deps: { glossaryRepo: GlossaryEntryRepository; policy?: typeof glossaryPolicy }) {
+  constructor(deps: {
+    glossaryRepo: GlossaryEntryRepository;
+    bridgeRepo: BridgeRepository;
+    policy?: typeof glossaryPolicy;
+  }) {
     this.#glossaryRepo = deps.glossaryRepo;
+    this.#bridgeRepo = deps.bridgeRepo;
     this.#policy = deps.policy ?? glossaryPolicy;
   }
 
@@ -30,8 +37,13 @@ export class GlossaryService {
     bridgeId?: string;
     words: string[];
   }): Promise<string[]> {
-    // Validate before any database work so a rejected request costs no queries.
+    // Validate before glossary database work so a rejected request cannot
+    // recreate local rows for an unknown, foreign, or revoked bridge.
     const requested = this.#uniqueWords(args.words);
+    if (args.bridgeId !== undefined) {
+      await this.#requireActiveBridge({ userId: args.userId, bridgeId: args.bridgeId });
+    }
+
     const [existing, projectCount, userCount] = await Promise.all([
       this.listWords(args),
       this.#glossaryRepo.countByUserAndProject(args),
@@ -47,7 +59,20 @@ export class GlossaryService {
       Math.min(this.#policy.maxWordsPerProject - projectCount, this.#policy.maxWordsPerUser - userCount),
     );
 
-    return this.#glossaryRepo.insertMany({ ...args, words: candidates.slice(0, remaining) });
+    const added = await this.#glossaryRepo.insertMany({ ...args, words: candidates.slice(0, remaining) });
+
+    if (args.bridgeId !== undefined) {
+      const activeBridge = await this.#bridgeRepo.findByIdForUser(args.bridgeId, args.userId);
+      if (!activeBridge) {
+        // Revocation can race between the first ownership check and insertion.
+        // Delete every local row for the now-inactive bridge before refusing the
+        // request so stale credentials cannot recreate deleted vocabulary.
+        await this.#glossaryRepo.deleteByUserAndBridge({ userId: args.userId, bridgeId: args.bridgeId });
+        throw new BadRequestError({ debugMessage: "Bridge not found or revoked" });
+      }
+    }
+
+    return added;
   }
 
   async removeWords(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<number> {
@@ -77,6 +102,13 @@ export class GlossaryService {
     }
 
     return context;
+  }
+
+  async #requireActiveBridge(args: { userId: string; bridgeId: string }): Promise<void> {
+    const bridge = await this.#bridgeRepo.findByIdForUser(args.bridgeId, args.userId);
+    if (!bridge) {
+      throw new BadRequestError({ debugMessage: "Bridge not found or revoked" });
+    }
   }
 
   /**

--- a/src/services/glossary-service.ts
+++ b/src/services/glossary-service.ts
@@ -1,5 +1,5 @@
 import { BadRequestError } from "../lib/errors.js";
-import type { ProjectKey } from "../models/voice.js";
+import { ProjectGlossaryScopeType, type ProjectGlossaryScope, type ProjectKey } from "../models/voice.js";
 import { TRANSCRIPTION_PROMPT_PREFIX, TRANSCRIPTION_PROMPT_SUFFIX } from "../types/transcription.js";
 import type { BridgeRepository } from "../repositories/bridge-repo.js";
 import { GlossaryEntryRepository } from "../repositories/glossary-entry-repo.js";
@@ -31,22 +31,18 @@ export class GlossaryService {
     return this.#glossaryRepo.findWordsByUserAndProject(args);
   }
 
-  async addWords(args: {
-    userId: string;
-    projectKey: ProjectKey;
-    bridgeId?: string;
-    words: string[];
-  }): Promise<string[]> {
+  async addWords(args: { userId: string; scope: ProjectGlossaryScope; words: string[] }): Promise<string[]> {
     // Validate before glossary database work so a rejected request cannot
     // recreate local rows for an unknown, foreign, or revoked bridge.
     const requested = this.#uniqueWords(args.words);
-    if (args.bridgeId !== undefined) {
-      await this.#requireActiveBridge({ userId: args.userId, bridgeId: args.bridgeId });
+    if (args.scope.type === ProjectGlossaryScopeType.bridgeLocal) {
+      await this.#requireActiveBridge({ userId: args.userId, bridgeId: args.scope.bridgeId });
     }
 
+    const project = { userId: args.userId, projectKey: args.scope.projectKey };
     const [existing, projectCount, userCount] = await Promise.all([
-      this.listWords(args),
-      this.#glossaryRepo.countByUserAndProject(args),
+      this.listWords(project),
+      this.#glossaryRepo.countByUserAndProject(project),
       this.#glossaryRepo.countScopedByUserId(args.userId),
     ]);
 
@@ -59,15 +55,19 @@ export class GlossaryService {
       Math.min(this.#policy.maxWordsPerProject - projectCount, this.#policy.maxWordsPerUser - userCount),
     );
 
-    const added = await this.#glossaryRepo.insertMany({ ...args, words: candidates.slice(0, remaining) });
+    const added = await this.#glossaryRepo.insertMany({
+      userId: args.userId,
+      scope: args.scope,
+      words: candidates.slice(0, remaining),
+    });
 
-    if (args.bridgeId !== undefined) {
-      const activeBridge = await this.#bridgeRepo.findByIdForUser(args.bridgeId, args.userId);
+    if (args.scope.type === ProjectGlossaryScopeType.bridgeLocal) {
+      const activeBridge = await this.#bridgeRepo.findByIdForUser(args.scope.bridgeId, args.userId);
       if (!activeBridge) {
         // Revocation can race between the first ownership check and insertion.
         // Delete every local row for the now-inactive bridge before refusing the
         // request so stale credentials cannot recreate deleted vocabulary.
-        await this.#glossaryRepo.deleteByUserAndBridge({ userId: args.userId, bridgeId: args.bridgeId });
+        await this.#glossaryRepo.deleteByUserAndBridge({ userId: args.userId, bridgeId: args.scope.bridgeId });
         throw new BadRequestError({ debugMessage: "Bridge not found or revoked" });
       }
     }

--- a/src/services/glossary-service.ts
+++ b/src/services/glossary-service.ts
@@ -41,7 +41,7 @@ export class GlossaryService {
 
     const project = { userId: args.userId, projectKey: args.scope.projectKey };
     const [existing, projectCount, userCount] = await Promise.all([
-      this.listWords(project),
+      this.#glossaryRepo.findWordsByUserAndScope({ userId: args.userId, scope: args.scope }),
       this.#glossaryRepo.countByUserAndProject(project),
       this.#glossaryRepo.countScopedByUserId(args.userId),
     ]);
@@ -75,8 +75,13 @@ export class GlossaryService {
     return added;
   }
 
-  async removeWords(args: { userId: string; projectKey: ProjectKey; words: string[] }): Promise<number> {
-    return this.#glossaryRepo.deleteMany({ ...args, words: this.#uniqueWords(args.words) });
+  async removeWords(args: { userId: string; scope: ProjectGlossaryScope; words: string[] }): Promise<number> {
+    const requested = this.#uniqueWords(args.words);
+    if (args.scope.type === ProjectGlossaryScopeType.bridgeLocal) {
+      await this.#requireActiveBridge({ userId: args.userId, bridgeId: args.scope.bridgeId });
+    }
+
+    return this.#glossaryRepo.deleteMany({ userId: args.userId, scope: args.scope, words: requested });
   }
 
   async getContextWords(args: { userId: string; projectKey: ProjectKey | null }): Promise<string[]> {
@@ -85,7 +90,7 @@ export class GlossaryService {
     }
 
     const words = await this.listWords({ userId: args.userId, projectKey: args.projectKey });
-    const sorted = [...words].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+    const sorted = [...new Set(words)].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
     const budget =
       this.#policy.maxContextCharacters - TRANSCRIPTION_PROMPT_PREFIX.length - TRANSCRIPTION_PROMPT_SUFFIX.length;
     const context: string[] = [];

--- a/tests/db/mongo-db-accessor.test.ts
+++ b/tests/db/mongo-db-accessor.test.ts
@@ -36,12 +36,15 @@ describe("fresh glossary index normalization", () => {
     try {
       const collection = ctx.dbAccessor.getDb(MongoDbDatabase.Auth).collection(AuthDbCollection.GlossaryEntries);
       const target = (await collection.indexes()).find((index) =>
-        indexKeyMatches(index.key, { userId: 1, projectKey: 1, word: 1 }),
+        indexKeyMatches(index.key, { userId: 1, "scope.projectKey": 1, word: 1 }),
       );
       assert.ok(target?.name);
       await collection.dropIndex(target.name);
       await collection.createIndex({ userId: 1, word: 1 }, { unique: true });
-      await collection.createIndex({ userId: 1, projectKey: 1, word: 1 }, { unique: true, sparse: true });
+      await collection.createIndex(
+        { userId: 1, "scope.projectKey": 1, word: 1 },
+        { unique: true, sparse: true },
+      );
 
       await ctx.dbAccessor.ensureIndexes();
 
@@ -51,7 +54,7 @@ describe("fresh glossary index normalization", () => {
         false,
       );
       const normalizedTarget = indexes.find((index) =>
-        indexKeyMatches(index.key, { userId: 1, projectKey: 1, word: 1 }),
+        indexKeyMatches(index.key, { userId: 1, "scope.projectKey": 1, word: 1 }),
       );
       assert.ok(normalizedTarget);
       assert.notEqual(normalizedTarget.sparse, true);
@@ -65,7 +68,7 @@ describe("fresh glossary index normalization", () => {
     try {
       const collection = ctx.dbAccessor.getDb(MongoDbDatabase.Auth).collection(AuthDbCollection.GlossaryEntries);
       const target = (await collection.indexes()).find((index) =>
-        indexKeyMatches(index.key, { userId: 1, projectKey: 1, word: 1 }),
+        indexKeyMatches(index.key, { userId: 1, "scope.projectKey": 1, word: 1 }),
       );
       assert.ok(target?.name);
       await collection.dropIndex(target.name);

--- a/tests/db/mongo-db-accessor.test.ts
+++ b/tests/db/mongo-db-accessor.test.ts
@@ -41,10 +41,7 @@ describe("fresh glossary index normalization", () => {
       assert.ok(target?.name);
       await collection.dropIndex(target.name);
       await collection.createIndex({ userId: 1, word: 1 }, { unique: true });
-      await collection.createIndex(
-        { userId: 1, "scope.projectKey": 1, word: 1 },
-        { unique: true, sparse: true },
-      );
+      await collection.createIndex({ userId: 1, "scope.projectKey": 1, word: 1 }, { unique: true, sparse: true });
 
       await ctx.dbAccessor.ensureIndexes();
 

--- a/tests/db/mongo-db-accessor.test.ts
+++ b/tests/db/mongo-db-accessor.test.ts
@@ -36,12 +36,27 @@ describe("fresh glossary index normalization", () => {
     try {
       const collection = ctx.dbAccessor.getDb(MongoDbDatabase.Auth).collection(AuthDbCollection.GlossaryEntries);
       const target = (await collection.indexes()).find((index) =>
-        indexKeyMatches(index.key, { userId: 1, "scope.projectKey": 1, word: 1 }),
+        indexKeyMatches(index.key, {
+          userId: 1,
+          "scope.projectKey": 1,
+          "scope.type": 1,
+          "scope.bridgeId": 1,
+          word: 1,
+        }),
       );
       assert.ok(target?.name);
       await collection.dropIndex(target.name);
       await collection.createIndex({ userId: 1, word: 1 }, { unique: true });
-      await collection.createIndex({ userId: 1, "scope.projectKey": 1, word: 1 }, { unique: true, sparse: true });
+      await collection.createIndex(
+        {
+          userId: 1,
+          "scope.projectKey": 1,
+          "scope.type": 1,
+          "scope.bridgeId": 1,
+          word: 1,
+        },
+        { unique: true, sparse: true },
+      );
 
       await ctx.dbAccessor.ensureIndexes();
 
@@ -51,7 +66,13 @@ describe("fresh glossary index normalization", () => {
         false,
       );
       const normalizedTarget = indexes.find((index) =>
-        indexKeyMatches(index.key, { userId: 1, "scope.projectKey": 1, word: 1 }),
+        indexKeyMatches(index.key, {
+          userId: 1,
+          "scope.projectKey": 1,
+          "scope.type": 1,
+          "scope.bridgeId": 1,
+          word: 1,
+        }),
       );
       assert.ok(normalizedTarget);
       assert.notEqual(normalizedTarget.sparse, true);
@@ -65,7 +86,13 @@ describe("fresh glossary index normalization", () => {
     try {
       const collection = ctx.dbAccessor.getDb(MongoDbDatabase.Auth).collection(AuthDbCollection.GlossaryEntries);
       const target = (await collection.indexes()).find((index) =>
-        indexKeyMatches(index.key, { userId: 1, "scope.projectKey": 1, word: 1 }),
+        indexKeyMatches(index.key, {
+          userId: 1,
+          "scope.projectKey": 1,
+          "scope.type": 1,
+          "scope.bridgeId": 1,
+          word: 1,
+        }),
       );
       assert.ok(target?.name);
       await collection.dropIndex(target.name);

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -204,7 +204,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
   const notificationService =
     overrides?.notificationService ?? new NotificationService(deviceTokenRepo, null, settingsService);
   const bridgeStateTracker = overrides?.bridgeStateTracker ?? new BridgeStateTracker(notificationService);
-  const bridgeService = overrides?.bridgeService ?? new BridgeService({ bridgeRepo, bridgeStateTracker });
+  const bridgeService = overrides?.bridgeService ?? new BridgeService({ bridgeRepo, glossaryRepo, bridgeStateTracker });
   const activationService =
     overrides?.activationService ??
     new ActivationService({ activationStateRepo, bridgeRepo, dailyUsageRepo, deviceTokenRepo, userRepo });

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -215,7 +215,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
     pseudonymizationKey: testProductAnalyticsPseudonymizationKey,
   });
   const authService = new AuthService({ tokenService, userRepo, oauthAccountRepo, passwordAccountRepo, bridgeService });
-  const glossaryService = overrides?.glossaryService ?? new GlossaryService({ glossaryRepo });
+  const glossaryService = overrides?.glossaryService ?? new GlossaryService({ glossaryRepo, bridgeRepo });
   const voiceService =
     overrides?.voiceService ??
     new VoiceService({

--- a/tests/models/voice.test.ts
+++ b/tests/models/voice.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { ProjectGlossaryScopeType, projectGlossaryScopeSchema, projectKeySchema } from "../../src/models/voice.js";
+import {
+  ProjectGlossaryScopeType,
+  glossaryAddBodySchema,
+  glossaryRemoveBodySchema,
+  projectGlossaryScopeSchema,
+  projectKeySchema,
+} from "../../src/models/voice.js";
 
 const validProjectKey = `prj_v1_${"A".repeat(43)}`;
 
@@ -34,6 +40,20 @@ describe("projectGlossaryScopeSchema", () => {
     for (const scope of invalid) {
       assert.equal(projectGlossaryScopeSchema.safeParse(scope).success, false, JSON.stringify(scope));
     }
+  });
+});
+
+describe("glossary mutation schemas", () => {
+  it("requires the strong scope variant for add and remove", () => {
+    const request = {
+      scope: { type: ProjectGlossaryScopeType.repository, projectKey: validProjectKey },
+      words: ["Sesori"],
+    };
+
+    assert.equal(glossaryAddBodySchema.safeParse(request).success, true);
+    assert.equal(glossaryRemoveBodySchema.safeParse(request).success, true);
+    assert.equal(glossaryAddBodySchema.safeParse({ projectKey: validProjectKey, words: ["Sesori"] }).success, false);
+    assert.equal(glossaryRemoveBodySchema.safeParse({ projectKey: validProjectKey, words: ["Sesori"] }).success, false);
   });
 });
 

--- a/tests/models/voice.test.ts
+++ b/tests/models/voice.test.ts
@@ -1,8 +1,41 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { projectKeySchema } from "../../src/models/voice.js";
+import { ProjectGlossaryScopeType, projectGlossaryScopeSchema, projectKeySchema } from "../../src/models/voice.js";
 
 const validProjectKey = `prj_v1_${"A".repeat(43)}`;
+
+describe("projectGlossaryScopeSchema", () => {
+  it("accepts complete repository and bridge-local variants", () => {
+    assert.equal(
+      projectGlossaryScopeSchema.safeParse({
+        type: ProjectGlossaryScopeType.repository,
+        projectKey: validProjectKey,
+      }).success,
+      true,
+    );
+    assert.equal(
+      projectGlossaryScopeSchema.safeParse({
+        type: ProjectGlossaryScopeType.bridgeLocal,
+        projectKey: validProjectKey,
+        bridgeId: "br_bridge0001",
+      }).success,
+      true,
+    );
+  });
+
+  it("rejects missing, misplaced, and nullable bridge ownership", () => {
+    const invalid = [
+      { type: ProjectGlossaryScopeType.bridgeLocal, projectKey: validProjectKey },
+      { type: ProjectGlossaryScopeType.bridgeLocal, projectKey: validProjectKey, bridgeId: null },
+      { type: ProjectGlossaryScopeType.repository, projectKey: validProjectKey, bridgeId: "br_bridge0001" },
+      { type: "unknown", projectKey: validProjectKey },
+    ];
+
+    for (const scope of invalid) {
+      assert.equal(projectGlossaryScopeSchema.safeParse(scope).success, false, JSON.stringify(scope));
+    }
+  });
+});
 
 describe("projectKeySchema", () => {
   it("accepts exactly the versioned base64url SHA-256 shape", () => {

--- a/tests/repositories/bridge-repo.test.ts
+++ b/tests/repositories/bridge-repo.test.ts
@@ -298,7 +298,7 @@ describe("BridgeRepository", () => {
     assert.equal(result, false);
   });
 
-  it("revokeAllForUser returns all of the user's revoked bridges for cleanup retries", async () => {
+  it("revokeAllForUser returns only newly revoked bridges and filters cleanup candidates", async () => {
     const user = await ctx.createUser();
     const otherUser = await ctx.createUser();
     const repo = new BridgeRepository(ctx.dbAccessor);
@@ -307,12 +307,30 @@ describe("BridgeRepository", () => {
     const other = await repo.register({ userId: otherUser.userId, name: "Other", platform: "windows" });
     await repo.revoke(second.bridgeId, user.userId, new Date("2026-06-08T10:00:00Z"));
 
+    assert.deepEqual(
+      await repo.findRevokedIdsForUser({
+        userId: user.userId,
+        bridgeIds: [first.bridgeId, second.bridgeId, other.bridgeId],
+      }),
+      [second.bridgeId],
+    );
+
     const revoked = await repo.revokeAllForUser(user.userId, new Date("2026-06-08T10:01:00Z"));
     const afterFirst = await repo.findById(first.bridgeId);
     const afterSecond = await repo.findById(second.bridgeId);
     const afterOther = await repo.findById(other.bridgeId);
 
-    assert.deepEqual(revoked.map((bridge) => bridge.bridgeId).sort(), [first.bridgeId, second.bridgeId].sort());
+    assert.deepEqual(
+      revoked.map((bridge) => bridge.bridgeId),
+      [first.bridgeId],
+    );
+    assert.deepEqual(
+      await repo.findRevokedIdsForUser({
+        userId: user.userId,
+        bridgeIds: [first.bridgeId, second.bridgeId, other.bridgeId],
+      }),
+      [first.bridgeId, second.bridgeId].sort(),
+    );
     assert.equal(afterFirst?.status, "inactive");
     assert.ok(afterFirst?.revokedAt instanceof Date);
     assert.equal(afterSecond?.revokedAt?.toISOString(), "2026-06-08T10:00:00.000Z");

--- a/tests/repositories/bridge-repo.test.ts
+++ b/tests/repositories/bridge-repo.test.ts
@@ -298,7 +298,7 @@ describe("BridgeRepository", () => {
     assert.equal(result, false);
   });
 
-  it("revokeAllForUser revokes only the user's non-revoked bridges", async () => {
+  it("revokeAllForUser returns all of the user's revoked bridges for cleanup retries", async () => {
     const user = await ctx.createUser();
     const otherUser = await ctx.createUser();
     const repo = new BridgeRepository(ctx.dbAccessor);
@@ -312,10 +312,7 @@ describe("BridgeRepository", () => {
     const afterSecond = await repo.findById(second.bridgeId);
     const afterOther = await repo.findById(other.bridgeId);
 
-    assert.deepEqual(
-      revoked.map((bridge) => bridge.bridgeId),
-      [first.bridgeId],
-    );
+    assert.deepEqual(revoked.map((bridge) => bridge.bridgeId).sort(), [first.bridgeId, second.bridgeId].sort());
     assert.equal(afterFirst?.status, "inactive");
     assert.ok(afterFirst?.revokedAt instanceof Date);
     assert.equal(afterSecond?.revokedAt?.toISOString(), "2026-06-08T10:00:00.000Z");

--- a/tests/repositories/glossary-entry-repo.test.ts
+++ b/tests/repositories/glossary-entry-repo.test.ts
@@ -85,6 +85,35 @@ describe("GlossaryEntryRepository", () => {
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectB }), 1);
   });
 
+  it("deletes bridge-local entries without touching shared repositories or other accounts", async () => {
+    const otherUserId = new ObjectId().toHexString();
+    const targetBridgeId = "br_bridge0001";
+    const otherBridgeId = "br_bridge0002";
+
+    await repo.insertMany({ userId, projectKey: projectA, bridgeId: targetBridgeId, words: ["Local"] });
+    await repo.insertMany({ userId, projectKey: projectB, words: ["Repository"] });
+    await repo.insertMany({ userId, projectKey: projectB, bridgeId: otherBridgeId, words: ["OtherBridge"] });
+    await repo.insertMany({
+      userId: otherUserId,
+      projectKey: projectA,
+      bridgeId: targetBridgeId,
+      words: ["OtherUser"],
+    });
+
+    assert.equal(await repo.deleteByUserAndBridge({ userId, bridgeId: targetBridgeId }), 1);
+    assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectA }), []);
+    assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectB }), [
+      "OtherBridge",
+      "Repository",
+    ]);
+    assert.deepEqual(await repo.findWordsByUserAndProject({ userId: otherUserId, projectKey: projectA }), [
+      "OtherUser",
+    ]);
+
+    assert.equal(await repo.deleteAllBridgeLocalByUser({ userId }), 1);
+    assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectB }), ["Repository"]);
+  });
+
   it("performs no database work for empty word lists", async () => {
     assert.deepEqual(await repo.insertMany({ userId, projectKey: projectA, words: [] }), []);
     assert.equal(await repo.deleteMany({ userId, projectKey: projectA, words: [] }), 0);

--- a/tests/repositories/glossary-entry-repo.test.ts
+++ b/tests/repositories/glossary-entry-repo.test.ts
@@ -77,7 +77,29 @@ describe("GlossaryEntryRepository", () => {
     );
   });
 
-  it("treats a repeated word in the same project as an idempotent duplicate", async () => {
+  it("keeps the same word independent across exact ownership scopes", async () => {
+    const repository = repositoryScope(projectA);
+    const firstLocal = bridgeLocalScope({ projectKey: projectA, bridgeId: "br_bridge0001" });
+    const secondLocal = bridgeLocalScope({ projectKey: projectA, bridgeId: "br_bridge0002" });
+
+    assert.deepEqual(await repo.insertMany({ userId, scope: repository, words: ["Shared"] }), ["Shared"]);
+    assert.deepEqual(await repo.insertMany({ userId, scope: firstLocal, words: ["Shared"] }), ["Shared"]);
+    assert.deepEqual(await repo.insertMany({ userId, scope: secondLocal, words: ["Shared"] }), ["Shared"]);
+
+    assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectA }), ["Shared"]);
+    assert.deepEqual(await repo.findWordsByUserAndScope({ userId, scope: repository }), ["Shared"]);
+    assert.deepEqual(await repo.findWordsByUserAndScope({ userId, scope: firstLocal }), ["Shared"]);
+    assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 3);
+
+    assert.equal(await repo.deleteMany({ userId, scope: repository, words: ["Shared"] }), 1);
+    assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectA }), ["Shared"]);
+    assert.equal(await repo.deleteMany({ userId, scope: firstLocal, words: ["Shared"] }), 1);
+    assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectA }), ["Shared"]);
+    assert.equal(await repo.deleteMany({ userId, scope: secondLocal, words: ["Shared"] }), 1);
+    assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectA }), []);
+  });
+
+  it("treats a repeated word in the same exact scope as an idempotent duplicate", async () => {
     await repo.insertMany({ userId, scope: repositoryScope(projectA), words: ["Alpha"] });
 
     const inserted = await repo.insertMany({
@@ -98,11 +120,12 @@ describe("GlossaryEntryRepository", () => {
     assert.equal(await repo.countScopedByUserId(userId), 3);
   });
 
-  it("deletes only words within the requested project", async () => {
-    await repo.insertMany({ userId, scope: repositoryScope(projectA), words: ["Alpha", "Beta"] });
+  it("deletes only words within the requested scope", async () => {
+    const scopeA = repositoryScope(projectA);
+    await repo.insertMany({ userId, scope: scopeA, words: ["Alpha", "Beta"] });
     await repo.insertMany({ userId, scope: repositoryScope(projectB), words: ["Alpha"] });
 
-    assert.equal(await repo.deleteMany({ userId, projectKey: projectA, words: ["Alpha"] }), 1);
+    assert.equal(await repo.deleteMany({ userId, scope: scopeA, words: ["Alpha"] }), 1);
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 1);
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectB }), 1);
   });
@@ -144,8 +167,9 @@ describe("GlossaryEntryRepository", () => {
   });
 
   it("performs no database work for empty word lists", async () => {
-    assert.deepEqual(await repo.insertMany({ userId, scope: repositoryScope(projectA), words: [] }), []);
-    assert.equal(await repo.deleteMany({ userId, projectKey: projectA, words: [] }), 0);
+    const scope = repositoryScope(projectA);
+    assert.deepEqual(await repo.insertMany({ userId, scope, words: [] }), []);
+    assert.equal(await repo.deleteMany({ userId, scope, words: [] }), 0);
   });
 
   it("fails closed on a malformed persisted document without leaking its content", async () => {

--- a/tests/repositories/glossary-entry-repo.test.ts
+++ b/tests/repositories/glossary-entry-repo.test.ts
@@ -5,11 +5,24 @@ import { createTestApp, type TestContext } from "../helpers/setup.js";
 import { GlossaryEntryRepository } from "../../src/repositories/glossary-entry-repo.js";
 import { InternalServerError } from "../../src/lib/errors.js";
 import type { GlossaryEntry } from "../../src/models/documents.js";
-import { projectKeySchema } from "../../src/models/voice.js";
+import {
+  ProjectGlossaryScopeType,
+  projectKeySchema,
+  type ProjectGlossaryScope,
+  type ProjectKey,
+} from "../../src/models/voice.js";
 import { MongoDbDatabase, AuthDbCollection } from "../../src/types/mongo.js";
 
 const projectA = projectKeySchema.parse(`prj_v1_${"A".repeat(43)}`);
 const projectB = projectKeySchema.parse(`prj_v1_${"B".repeat(43)}`);
+
+function repositoryScope(projectKey: ProjectKey): ProjectGlossaryScope {
+  return { type: ProjectGlossaryScopeType.repository, projectKey };
+}
+
+function bridgeLocalScope(args: { projectKey: ProjectKey; bridgeId: string }): ProjectGlossaryScope {
+  return { type: ProjectGlossaryScopeType.bridgeLocal, ...args };
+}
 
 describe("GlossaryEntryRepository", () => {
   let ctx: TestContext;
@@ -37,8 +50,8 @@ describe("GlossaryEntryRepository", () => {
   }
 
   it("persists project scope and returns only the requested project's words", async () => {
-    await repo.insertMany({ userId, projectKey: projectA, words: ["Beta", "Alpha"] });
-    await repo.insertMany({ userId, projectKey: projectB, words: ["Gamma"] });
+    await repo.insertMany({ userId, scope: repositoryScope(projectA), words: ["Beta", "Alpha"] });
+    await repo.insertMany({ userId, scope: repositoryScope(projectB), words: ["Gamma"] });
 
     const words = await repo.findWordsByUserAndProject({ userId, projectKey: projectA });
 
@@ -52,33 +65,42 @@ describe("GlossaryEntryRepository", () => {
   it("keeps the same word independent across projects and users", async () => {
     const otherUserId = new ObjectId().toHexString();
 
-    assert.deepEqual(await repo.insertMany({ userId, projectKey: projectA, words: ["Shared"] }), ["Shared"]);
-    assert.deepEqual(await repo.insertMany({ userId, projectKey: projectB, words: ["Shared"] }), ["Shared"]);
-    assert.deepEqual(await repo.insertMany({ userId: otherUserId, projectKey: projectA, words: ["Shared"] }), [
+    assert.deepEqual(await repo.insertMany({ userId, scope: repositoryScope(projectA), words: ["Shared"] }), [
       "Shared",
     ]);
+    assert.deepEqual(await repo.insertMany({ userId, scope: repositoryScope(projectB), words: ["Shared"] }), [
+      "Shared",
+    ]);
+    assert.deepEqual(
+      await repo.insertMany({ userId: otherUserId, scope: repositoryScope(projectA), words: ["Shared"] }),
+      ["Shared"],
+    );
   });
 
   it("treats a repeated word in the same project as an idempotent duplicate", async () => {
-    await repo.insertMany({ userId, projectKey: projectA, words: ["Alpha"] });
+    await repo.insertMany({ userId, scope: repositoryScope(projectA), words: ["Alpha"] });
 
-    const inserted = await repo.insertMany({ userId, projectKey: projectA, words: ["Alpha", "Beta"] });
+    const inserted = await repo.insertMany({
+      userId,
+      scope: repositoryScope(projectA),
+      words: ["Alpha", "Beta"],
+    });
 
     assert.deepEqual(inserted, ["Beta"]);
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 2);
   });
 
   it("counts per project and per user", async () => {
-    await repo.insertMany({ userId, projectKey: projectA, words: ["Alpha", "Beta"] });
-    await repo.insertMany({ userId, projectKey: projectB, words: ["Gamma"] });
+    await repo.insertMany({ userId, scope: repositoryScope(projectA), words: ["Alpha", "Beta"] });
+    await repo.insertMany({ userId, scope: repositoryScope(projectB), words: ["Gamma"] });
 
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 2);
     assert.equal(await repo.countScopedByUserId(userId), 3);
   });
 
   it("deletes only words within the requested project", async () => {
-    await repo.insertMany({ userId, projectKey: projectA, words: ["Alpha", "Beta"] });
-    await repo.insertMany({ userId, projectKey: projectB, words: ["Alpha"] });
+    await repo.insertMany({ userId, scope: repositoryScope(projectA), words: ["Alpha", "Beta"] });
+    await repo.insertMany({ userId, scope: repositoryScope(projectB), words: ["Alpha"] });
 
     assert.equal(await repo.deleteMany({ userId, projectKey: projectA, words: ["Alpha"] }), 1);
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 1);
@@ -90,13 +112,20 @@ describe("GlossaryEntryRepository", () => {
     const targetBridgeId = "br_bridge0001";
     const otherBridgeId = "br_bridge0002";
 
-    await repo.insertMany({ userId, projectKey: projectA, bridgeId: targetBridgeId, words: ["Local"] });
-    await repo.insertMany({ userId, projectKey: projectB, words: ["Repository"] });
-    await repo.insertMany({ userId, projectKey: projectB, bridgeId: otherBridgeId, words: ["OtherBridge"] });
+    await repo.insertMany({
+      userId,
+      scope: bridgeLocalScope({ projectKey: projectA, bridgeId: targetBridgeId }),
+      words: ["Local"],
+    });
+    await repo.insertMany({ userId, scope: repositoryScope(projectB), words: ["Repository"] });
+    await repo.insertMany({
+      userId,
+      scope: bridgeLocalScope({ projectKey: projectB, bridgeId: otherBridgeId }),
+      words: ["OtherBridge"],
+    });
     await repo.insertMany({
       userId: otherUserId,
-      projectKey: projectA,
-      bridgeId: targetBridgeId,
+      scope: bridgeLocalScope({ projectKey: projectA, bridgeId: targetBridgeId }),
       words: ["OtherUser"],
     });
 
@@ -115,22 +144,15 @@ describe("GlossaryEntryRepository", () => {
   });
 
   it("performs no database work for empty word lists", async () => {
-    assert.deepEqual(await repo.insertMany({ userId, projectKey: projectA, words: [] }), []);
+    assert.deepEqual(await repo.insertMany({ userId, scope: repositoryScope(projectA), words: [] }), []);
     assert.equal(await repo.deleteMany({ userId, projectKey: projectA, words: [] }), 0);
-  });
-
-  it("never returns unscoped legacy documents through a scoped read", async () => {
-    await insertRaw({ _id: new ObjectId(), userId: new ObjectId(userId), word: "Legacy", createdAt: new Date() });
-
-    assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectA }), []);
-    assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 0);
   });
 
   it("fails closed on a malformed persisted document without leaking its content", async () => {
     await insertRaw({
       _id: new ObjectId(),
       userId: new ObjectId(userId),
-      projectKey: projectA,
+      scope: repositoryScope(projectA),
       word: "Broken",
       createdAt: new Date(),
       unexpected: "SecretValue",

--- a/tests/repositories/glossary-entry-repo.test.ts
+++ b/tests/repositories/glossary-entry-repo.test.ts
@@ -161,9 +161,6 @@ describe("GlossaryEntryRepository", () => {
     assert.deepEqual(await repo.findWordsByUserAndProject({ userId: otherUserId, projectKey: projectA }), [
       "OtherUser",
     ]);
-
-    assert.equal(await repo.deleteAllBridgeLocalByUser({ userId }), 1);
-    assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectB }), ["Repository"]);
   });
 
   it("performs no database work for empty word lists", async () => {

--- a/tests/repositories/glossary-entry-repo.test.ts
+++ b/tests/repositories/glossary-entry-repo.test.ts
@@ -152,7 +152,8 @@ describe("GlossaryEntryRepository", () => {
       words: ["OtherUser"],
     });
 
-    assert.equal(await repo.deleteByUserAndBridge({ userId, bridgeId: targetBridgeId }), 1);
+    assert.deepEqual((await repo.findBridgeLocalOwnerIdsByUser({ userId })).sort(), [targetBridgeId, otherBridgeId]);
+    assert.equal(await repo.deleteByUserAndBridges({ userId, bridgeIds: [targetBridgeId] }), 1);
     assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectA }), []);
     assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectB }), [
       "OtherBridge",
@@ -163,10 +164,11 @@ describe("GlossaryEntryRepository", () => {
     ]);
   });
 
-  it("performs no database work for empty word lists", async () => {
+  it("performs no database work for empty word or bridge lists", async () => {
     const scope = repositoryScope(projectA);
     assert.deepEqual(await repo.insertMany({ userId, scope, words: [] }), []);
     assert.equal(await repo.deleteMany({ userId, scope, words: [] }), 0);
+    assert.equal(await repo.deleteByUserAndBridges({ userId, bridgeIds: [] }), 0);
   });
 
   it("fails closed on a malformed persisted document without leaking its content", async () => {

--- a/tests/routes/bridges.test.ts
+++ b/tests/routes/bridges.test.ts
@@ -6,6 +6,9 @@ import { ActivationService } from "../../src/services/activation-service.js";
 import { BridgeStateTracker } from "../../src/services/bridge-state-tracker.js";
 import type { NotificationService } from "../../src/services/notification-service.js";
 
+const localProjectKey = `prj_v1_${"L".repeat(43)}`;
+const repositoryProjectKey = `prj_v1_${"R".repeat(43)}`;
+
 type BridgeSummaryBody = {
   id: string;
   name: string;
@@ -270,6 +273,48 @@ describe("/auth/bridges routes", () => {
     const body = listRes.json<{ bridges: unknown[] }>();
     assert.deepEqual(body.bridges, []);
     assert.deepEqual(cancelledBridgeKeys, [{ userId: user.userId, bridgeId: created.id }]);
+  });
+
+  it("DELETE /auth/bridges/:bridgeId removes only that bridge's local glossary", async () => {
+    const user = await ctx.createUser();
+    const createRes = await registerBridge(user.accessToken, { name: "Glossary Bridge", platform: "macos" });
+    const created = createRes.json<{ id: string }>();
+    const headers = { authorization: `Bearer ${user.accessToken}`, "content-type": "application/json" };
+
+    const localAdd = await ctx.app.inject({
+      method: "POST",
+      url: "/voice/glossary",
+      headers,
+      payload: JSON.stringify({ projectKey: localProjectKey, bridgeId: created.id, words: ["LocalTerm"] }),
+    });
+    const repositoryAdd = await ctx.app.inject({
+      method: "POST",
+      url: "/voice/glossary",
+      headers,
+      payload: JSON.stringify({ projectKey: repositoryProjectKey, words: ["RepositoryTerm"] }),
+    });
+    assert.equal(localAdd.statusCode, 200);
+    assert.equal(repositoryAdd.statusCode, 200);
+
+    const delRes = await ctx.app.inject({
+      method: "DELETE",
+      url: `/auth/bridges/${encodeURIComponent(created.id)}`,
+      headers: { authorization: `Bearer ${user.accessToken}` },
+    });
+    assert.equal(delRes.statusCode, 200);
+
+    const localList = await ctx.app.inject({
+      method: "GET",
+      url: `/voice/glossary?projectKey=${localProjectKey}`,
+      headers: { authorization: `Bearer ${user.accessToken}` },
+    });
+    const repositoryList = await ctx.app.inject({
+      method: "GET",
+      url: `/voice/glossary?projectKey=${repositoryProjectKey}`,
+      headers: { authorization: `Bearer ${user.accessToken}` },
+    });
+    assert.deepEqual(localList.json(), { words: [] });
+    assert.deepEqual(repositoryList.json(), { words: ["RepositoryTerm"] });
   });
 
   it("DELETE /auth/bridges/:bridgeId returns 404 for non-owner", async () => {

--- a/tests/routes/bridges.test.ts
+++ b/tests/routes/bridges.test.ts
@@ -5,6 +5,7 @@ import { ActivationStateRepository } from "../../src/repositories/activation-sta
 import { ActivationService } from "../../src/services/activation-service.js";
 import { BridgeStateTracker } from "../../src/services/bridge-state-tracker.js";
 import type { NotificationService } from "../../src/services/notification-service.js";
+import { ProjectGlossaryScopeType } from "../../src/models/voice.js";
 
 const localProjectKey = `prj_v1_${"L".repeat(43)}`;
 const repositoryProjectKey = `prj_v1_${"R".repeat(43)}`;
@@ -285,13 +286,23 @@ describe("/auth/bridges routes", () => {
       method: "POST",
       url: "/voice/glossary",
       headers,
-      payload: JSON.stringify({ projectKey: localProjectKey, bridgeId: created.id, words: ["LocalTerm"] }),
+      payload: JSON.stringify({
+        scope: {
+          type: ProjectGlossaryScopeType.bridgeLocal,
+          projectKey: localProjectKey,
+          bridgeId: created.id,
+        },
+        words: ["LocalTerm"],
+      }),
     });
     const repositoryAdd = await ctx.app.inject({
       method: "POST",
       url: "/voice/glossary",
       headers,
-      payload: JSON.stringify({ projectKey: repositoryProjectKey, words: ["RepositoryTerm"] }),
+      payload: JSON.stringify({
+        scope: { type: ProjectGlossaryScopeType.repository, projectKey: repositoryProjectKey },
+        words: ["RepositoryTerm"],
+      }),
     });
     assert.equal(localAdd.statusCode, 200);
     assert.equal(repositoryAdd.statusCode, 200);
@@ -320,7 +331,14 @@ describe("/auth/bridges routes", () => {
       method: "POST",
       url: "/voice/glossary",
       headers,
-      payload: JSON.stringify({ projectKey: localProjectKey, bridgeId: created.id, words: ["Recreated"] }),
+      payload: JSON.stringify({
+        scope: {
+          type: ProjectGlossaryScopeType.bridgeLocal,
+          projectKey: localProjectKey,
+          bridgeId: created.id,
+        },
+        words: ["Recreated"],
+      }),
     });
     assert.equal(staleAdd.statusCode, 400);
     const localListAfterStaleWrite = await ctx.app.inject({

--- a/tests/routes/bridges.test.ts
+++ b/tests/routes/bridges.test.ts
@@ -315,6 +315,20 @@ describe("/auth/bridges routes", () => {
     });
     assert.deepEqual(localList.json(), { words: [] });
     assert.deepEqual(repositoryList.json(), { words: ["RepositoryTerm"] });
+
+    const staleAdd = await ctx.app.inject({
+      method: "POST",
+      url: "/voice/glossary",
+      headers,
+      payload: JSON.stringify({ projectKey: localProjectKey, bridgeId: created.id, words: ["Recreated"] }),
+    });
+    assert.equal(staleAdd.statusCode, 400);
+    const localListAfterStaleWrite = await ctx.app.inject({
+      method: "GET",
+      url: `/voice/glossary?projectKey=${localProjectKey}`,
+      headers: { authorization: `Bearer ${user.accessToken}` },
+    });
+    assert.deepEqual(localListAfterStaleWrite.json(), { words: [] });
   });
 
   it("DELETE /auth/bridges/:bridgeId returns 404 for non-owner", async () => {

--- a/tests/services/bridge-service.test.ts
+++ b/tests/services/bridge-service.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { BridgeRepository } from "../../src/repositories/bridge-repo.js";
+import type { GlossaryEntryRepository } from "../../src/repositories/glossary-entry-repo.js";
+import { BridgeService } from "../../src/services/bridge-service.js";
+import type { BridgeStateTracker } from "../../src/services/bridge-state-tracker.js";
+
+function createService(args: { bridgeRepo: object; glossaryRepo: object; bridgeStateTracker: object }): BridgeService {
+  return new BridgeService({
+    bridgeRepo: args.bridgeRepo as unknown as BridgeRepository,
+    glossaryRepo: args.glossaryRepo as unknown as GlossaryEntryRepository,
+    bridgeStateTracker: args.bridgeStateTracker as unknown as BridgeStateTracker,
+  });
+}
+
+describe("BridgeService glossary cleanup", () => {
+  it("cancels an individually revoked bridge timer before cleanup can fail", async () => {
+    const events: string[] = [];
+    const service = createService({
+      bridgeRepo: {
+        revoke: async () => {
+          events.push("revoke");
+          return true;
+        },
+      },
+      glossaryRepo: {
+        deleteByUserAndBridge: async () => {
+          events.push("cleanup");
+          throw new Error("cleanup failed");
+        },
+      },
+      bridgeStateTracker: {
+        cancelPendingForBridge: () => events.push("cancel"),
+      },
+    });
+
+    await assert.rejects(() => service.revokeForUser("user", "br_bridge0001"), /cleanup failed/);
+    assert.deepEqual(events, ["revoke", "cancel", "cleanup"]);
+  });
+
+  it("cancels all revoked bridge timers before deleting only their local rows", async () => {
+    const events: string[] = [];
+    const service = createService({
+      bridgeRepo: {
+        revokeAllForUser: async () => [{ bridgeId: "br_bridge0001" }, { bridgeId: "br_bridge0002" }],
+      },
+      glossaryRepo: {
+        deleteByUserAndBridge: async (args: { bridgeId: string }) => {
+          events.push(`cleanup:${args.bridgeId}`);
+          return 1;
+        },
+      },
+      bridgeStateTracker: {
+        cancelPendingForBridge: (_userId: string, bridgeId: string) => events.push(`cancel:${bridgeId}`),
+      },
+    });
+
+    await service.revokeAllForUser("user");
+
+    assert.deepEqual(events, [
+      "cancel:br_bridge0001",
+      "cancel:br_bridge0002",
+      "cleanup:br_bridge0001",
+      "cleanup:br_bridge0002",
+    ]);
+  });
+});

--- a/tests/services/bridge-service.test.ts
+++ b/tests/services/bridge-service.test.ts
@@ -38,16 +38,24 @@ describe("BridgeService glossary cleanup", () => {
     assert.deepEqual(events, ["revoke", "cancel", "cleanup"]);
   });
 
-  it("cancels all revoked bridge timers before deleting only their local rows", async () => {
+  it("cancels new timers, filters bounded glossary owners, and bulk deletes only revoked rows", async () => {
     const events: string[] = [];
     const service = createService({
       bridgeRepo: {
         revokeAllForUser: async () => [{ bridgeId: "br_bridge0001" }, { bridgeId: "br_bridge0002" }],
+        findRevokedIdsForUser: async (args: { bridgeIds: string[] }) => {
+          events.push(`filter:${args.bridgeIds.join(",")}`);
+          return args.bridgeIds.filter((bridgeId) => bridgeId !== "br_concurrent");
+        },
       },
       glossaryRepo: {
-        deleteByUserAndBridge: async (args: { bridgeId: string }) => {
-          events.push(`cleanup:${args.bridgeId}`);
-          return 1;
+        findBridgeLocalOwnerIdsByUser: async () => {
+          events.push("candidates");
+          return ["br_bridge0001", "br_bridge0002", "br_concurrent"];
+        },
+        deleteByUserAndBridges: async (args: { bridgeIds: string[] }) => {
+          events.push(`cleanup:${args.bridgeIds.join(",")}`);
+          return 2;
         },
       },
       bridgeStateTracker: {
@@ -60,8 +68,9 @@ describe("BridgeService glossary cleanup", () => {
     assert.deepEqual(events, [
       "cancel:br_bridge0001",
       "cancel:br_bridge0002",
-      "cleanup:br_bridge0001",
-      "cleanup:br_bridge0002",
+      "candidates",
+      "filter:br_bridge0001,br_bridge0002,br_concurrent",
+      "cleanup:br_bridge0001,br_bridge0002",
     ]);
   });
 });

--- a/tests/services/glossary-service.test.ts
+++ b/tests/services/glossary-service.test.ts
@@ -13,6 +13,7 @@ import {
   type ProjectKey,
 } from "../../src/models/voice.js";
 import { BadRequestError } from "../../src/lib/errors.js";
+import { BridgePlatform } from "../../src/models/bridge.js";
 import { renderTranscriptionPrompt } from "../../src/types/transcription.js";
 import { MongoDbDatabase, AuthDbCollection } from "../../src/types/mongo.js";
 
@@ -66,16 +67,10 @@ describe("GlossaryService", () => {
     assert.deepEqual(added, ["Beta", "Alpha"]);
   });
 
-  it("rejects local glossary writes for an inactive bridge", async () => {
-    await assert.rejects(
-      () =>
-        service.addWords({
-          userId,
-          scope: bridgeLocalScope({ projectKey: projectA, bridgeId: "br_missing0001" }),
-          words: ["Blocked"],
-        }),
-      BadRequestError,
-    );
+  it("rejects local glossary mutations for an inactive bridge", async () => {
+    const scope = bridgeLocalScope({ projectKey: projectA, bridgeId: "br_missing0001" });
+    await assert.rejects(() => service.addWords({ userId, scope, words: ["Blocked"] }), BadRequestError);
+    await assert.rejects(() => service.removeWords({ userId, scope, words: ["Blocked"] }), BadRequestError);
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 0);
   });
 
@@ -98,6 +93,36 @@ describe("GlossaryService", () => {
     );
     assert.equal(findByIdForUser.mock.callCount(), 2);
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 0);
+  });
+
+  it("keeps idempotency and removal exact while aggregating shared vocabulary", async () => {
+    const firstBridge = await bridgeRepo.register({
+      userId,
+      name: "First",
+      platform: BridgePlatform.macos,
+    });
+    const secondBridge = await bridgeRepo.register({
+      userId,
+      name: "Second",
+      platform: BridgePlatform.linux,
+    });
+    const repository = repositoryScope(projectA);
+    const firstLocal = bridgeLocalScope({ projectKey: projectA, bridgeId: firstBridge.bridgeId });
+    const secondLocal = bridgeLocalScope({ projectKey: projectA, bridgeId: secondBridge.bridgeId });
+
+    assert.deepEqual(await service.addWords({ userId, scope: repository, words: ["Shared"] }), ["Shared"]);
+    assert.deepEqual(await service.addWords({ userId, scope: firstLocal, words: ["Shared"] }), ["Shared"]);
+    assert.deepEqual(await service.addWords({ userId, scope: firstLocal, words: ["Shared"] }), []);
+    assert.deepEqual(await service.addWords({ userId, scope: secondLocal, words: ["Shared"] }), ["Shared"]);
+    assert.deepEqual(await service.listWords({ userId, projectKey: projectA }), ["Shared"]);
+    assert.deepEqual(await service.getContextWords({ userId, projectKey: projectA }), ["Shared"]);
+
+    assert.equal(await service.removeWords({ userId, scope: repository, words: ["Shared"] }), 1);
+    assert.deepEqual(await service.listWords({ userId, projectKey: projectA }), ["Shared"]);
+    assert.equal(await service.removeWords({ userId, scope: firstLocal, words: ["Shared"] }), 1);
+    assert.deepEqual(await service.listWords({ userId, projectKey: projectA }), ["Shared"]);
+    assert.equal(await service.removeWords({ userId, scope: secondLocal, words: ["Shared"] }), 1);
+    assert.deepEqual(await service.listWords({ userId, projectKey: projectA }), []);
   });
 
   it("truncates to the remaining per-project capacity", async () => {
@@ -160,7 +185,7 @@ describe("GlossaryService", () => {
   it("rejects an invalid request before performing any database work", async () => {
     let queried = false;
     const spyRepo = {
-      findWordsByUserAndProject: async () => {
+      findWordsByUserAndScope: async () => {
         queried = true;
         return [];
       },
@@ -214,7 +239,11 @@ describe("GlossaryService", () => {
     );
     await assert.rejects(
       () =>
-        service.removeWords({ userId, projectKey: projectA, words: words("z", glossaryPolicy.maxWordsPerRequest + 1) }),
+        service.removeWords({
+          userId,
+          scope: repositoryScope(projectA),
+          words: words("z", glossaryPolicy.maxWordsPerRequest + 1),
+        }),
       BadRequestError,
     );
   });
@@ -241,12 +270,13 @@ describe("GlossaryService", () => {
     assert.equal(renderTranscriptionPrompt(await service.getContextWords({ userId, projectKey: projectA })), null);
   });
 
-  it("lists and removes only within one project", async () => {
-    await service.addWords({ userId, scope: repositoryScope(projectA), words: ["Alpha", "Beta"] });
+  it("lists by project and removes only within one exact scope", async () => {
+    const scopeA = repositoryScope(projectA);
+    await service.addWords({ userId, scope: scopeA, words: ["Alpha", "Beta"] });
     await service.addWords({ userId, scope: repositoryScope(projectB), words: ["Alpha"] });
 
     assert.deepEqual(await service.listWords({ userId, projectKey: projectA }), ["Alpha", "Beta"]);
-    assert.equal(await service.removeWords({ userId, projectKey: projectA, words: ["Alpha", "Alpha"] }), 1);
+    assert.equal(await service.removeWords({ userId, scope: scopeA, words: ["Alpha", "Alpha"] }), 1);
     assert.deepEqual(await service.listWords({ userId, projectKey: projectA }), ["Beta"]);
     assert.deepEqual(await service.listWords({ userId, projectKey: projectB }), ["Alpha"]);
   });

--- a/tests/services/glossary-service.test.ts
+++ b/tests/services/glossary-service.test.ts
@@ -6,13 +6,26 @@ import { BridgeRepository } from "../../src/repositories/bridge-repo.js";
 import { GlossaryEntryRepository } from "../../src/repositories/glossary-entry-repo.js";
 import { GlossaryService, glossaryPolicy } from "../../src/services/glossary-service.js";
 import type { GlossaryEntry } from "../../src/models/documents.js";
-import { projectKeySchema } from "../../src/models/voice.js";
+import {
+  ProjectGlossaryScopeType,
+  projectKeySchema,
+  type ProjectGlossaryScope,
+  type ProjectKey,
+} from "../../src/models/voice.js";
 import { BadRequestError } from "../../src/lib/errors.js";
 import { renderTranscriptionPrompt } from "../../src/types/transcription.js";
 import { MongoDbDatabase, AuthDbCollection } from "../../src/types/mongo.js";
 
 const projectA = projectKeySchema.parse(`prj_v1_${"A".repeat(43)}`);
 const projectB = projectKeySchema.parse(`prj_v1_${"B".repeat(43)}`);
+
+function repositoryScope(projectKey: ProjectKey): ProjectGlossaryScope {
+  return { type: ProjectGlossaryScopeType.repository, projectKey };
+}
+
+function bridgeLocalScope(args: { projectKey: ProjectKey; bridgeId: string }): ProjectGlossaryScope {
+  return { type: ProjectGlossaryScopeType.bridgeLocal, ...args };
+}
 
 function words(prefix: string, count: number, start = 0): string[] {
   return Array.from({ length: count }, (_, index) => `${prefix}${String(start + index).padStart(5, "0")}`);
@@ -44,7 +57,11 @@ describe("GlossaryService", () => {
   });
 
   it("deduplicates a request while preserving first occurrence order", async () => {
-    const added = await service.addWords({ userId, projectKey: projectA, words: ["Beta", "Alpha", "Beta"] });
+    const added = await service.addWords({
+      userId,
+      scope: repositoryScope(projectA),
+      words: ["Beta", "Alpha", "Beta"],
+    });
 
     assert.deepEqual(added, ["Beta", "Alpha"]);
   });
@@ -54,8 +71,7 @@ describe("GlossaryService", () => {
       () =>
         service.addWords({
           userId,
-          projectKey: projectA,
-          bridgeId: "br_missing0001",
+          scope: bridgeLocalScope({ projectKey: projectA, bridgeId: "br_missing0001" }),
           words: ["Blocked"],
         }),
       BadRequestError,
@@ -75,8 +91,7 @@ describe("GlossaryService", () => {
       () =>
         racingService.addWords({
           userId,
-          projectKey: projectA,
-          bridgeId: "br_bridge0001",
+          scope: bridgeLocalScope({ projectKey: projectA, bridgeId: "br_bridge0001" }),
           words: ["Raced"],
         }),
       BadRequestError,
@@ -86,9 +101,13 @@ describe("GlossaryService", () => {
   });
 
   it("truncates to the remaining per-project capacity", async () => {
-    await repo.insertMany({ userId, projectKey: projectA, words: words("p", glossaryPolicy.maxWordsPerProject - 2) });
+    await repo.insertMany({
+      userId,
+      scope: repositoryScope(projectA),
+      words: words("p", glossaryPolicy.maxWordsPerProject - 2),
+    });
 
-    const added = await service.addWords({ userId, projectKey: projectA, words: ["One", "Two", "Three"] });
+    const added = await service.addWords({ userId, scope: repositoryScope(projectA), words: ["One", "Two", "Three"] });
 
     assert.deepEqual(added, ["One", "Two"]);
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), glossaryPolicy.maxWordsPerProject);
@@ -100,11 +119,11 @@ describe("GlossaryService", () => {
       projectKeySchema.parse(`prj_v1_${String(index).repeat(43)}`),
     );
     for (const [index, projectKey] of projects.entries()) {
-      await repo.insertMany({ userId, projectKey, words: words(`u${index}_`, perProject) });
+      await repo.insertMany({ userId, scope: repositoryScope(projectKey), words: words(`u${index}_`, perProject) });
     }
-    await repo.insertMany({ userId, projectKey: projectA, words: words("tail_", 499) });
+    await repo.insertMany({ userId, scope: repositoryScope(projectA), words: words("tail_", 499) });
 
-    const added = await service.addWords({ userId, projectKey: projectA, words: ["Last", "Overflow"] });
+    const added = await service.addWords({ userId, scope: repositoryScope(projectA), words: ["Last", "Overflow"] });
 
     assert.deepEqual(added, ["Last"]);
     assert.equal(await repo.countScopedByUserId(userId), glossaryPolicy.maxWordsPerUser);
@@ -113,11 +132,11 @@ describe("GlossaryService", () => {
   it("adds nothing and never passes a negative limit when a cap is already exceeded", async () => {
     await repo.insertMany({
       userId,
-      projectKey: projectA,
+      scope: repositoryScope(projectA),
       words: words("over", glossaryPolicy.maxWordsPerProject + 5),
     });
 
-    const added = await service.addWords({ userId, projectKey: projectA, words: ["Blocked"] });
+    const added = await service.addWords({ userId, scope: repositoryScope(projectA), words: ["Blocked"] });
 
     assert.deepEqual(added, []);
     assert.equal(
@@ -129,23 +148,13 @@ describe("GlossaryService", () => {
   it("does not let an already-stored word consume the last free capacity slot", async () => {
     await repo.insertMany({
       userId,
-      projectKey: projectA,
+      scope: repositoryScope(projectA),
       words: [...words("w", glossaryPolicy.maxWordsPerProject - 2), "Dup"],
     });
 
-    const added = await service.addWords({ userId, projectKey: projectA, words: ["Dup", "BrandNew"] });
+    const added = await service.addWords({ userId, scope: repositoryScope(projectA), words: ["Dup", "BrandNew"] });
 
     assert.deepEqual(added, ["BrandNew"]);
-  });
-
-  it("excludes unscoped legacy rows from the per-user capacity", async () => {
-    await ctx.dbAccessor
-      .getDb(MongoDbDatabase.Auth)
-      .collection(AuthDbCollection.GlossaryEntries)
-      .insertOne({ _id: new ObjectId(), userId: new ObjectId(userId), word: "Legacy", createdAt: new Date() });
-
-    assert.equal(await repo.countScopedByUserId(userId), 0);
-    assert.deepEqual(await service.addWords({ userId, projectKey: projectA, words: ["Scoped"] }), ["Scoped"]);
   });
 
   it("rejects an invalid request before performing any database work", async () => {
@@ -172,7 +181,7 @@ describe("GlossaryService", () => {
       () =>
         spyService.addWords({
           userId,
-          projectKey: projectA,
+          scope: repositoryScope(projectA),
           words: words("x", glossaryPolicy.maxWordsPerRequest + 1),
         }),
       BadRequestError,
@@ -183,15 +192,26 @@ describe("GlossaryService", () => {
   it("enforces request and word-length caps for non-route callers", async () => {
     await assert.rejects(
       () =>
-        service.addWords({ userId, projectKey: projectA, words: words("x", glossaryPolicy.maxWordsPerRequest + 1) }),
+        service.addWords({
+          userId,
+          scope: repositoryScope(projectA),
+          words: words("x", glossaryPolicy.maxWordsPerRequest + 1),
+        }),
       BadRequestError,
     );
     await assert.rejects(
       () =>
-        service.addWords({ userId, projectKey: projectA, words: ["y".repeat(glossaryPolicy.maxWordCharacters + 1)] }),
+        service.addWords({
+          userId,
+          scope: repositoryScope(projectA),
+          words: ["y".repeat(glossaryPolicy.maxWordCharacters + 1)],
+        }),
       BadRequestError,
     );
-    await assert.rejects(() => service.addWords({ userId, projectKey: projectA, words: ["   "] }), BadRequestError);
+    await assert.rejects(
+      () => service.addWords({ userId, scope: repositoryScope(projectA), words: ["   "] }),
+      BadRequestError,
+    );
     await assert.rejects(
       () =>
         service.removeWords({ userId, projectKey: projectA, words: words("z", glossaryPolicy.maxWordsPerRequest + 1) }),
@@ -203,7 +223,7 @@ describe("GlossaryService", () => {
     const term = "x".repeat(glossaryPolicy.maxWordCharacters);
     await repo.insertMany({
       userId,
-      projectKey: projectA,
+      scope: repositoryScope(projectA),
       words: Array.from({ length: 90 }, (_, index) => `${String(index).padStart(3, "0")}${term}`),
     });
 
@@ -222,8 +242,8 @@ describe("GlossaryService", () => {
   });
 
   it("lists and removes only within one project", async () => {
-    await service.addWords({ userId, projectKey: projectA, words: ["Alpha", "Beta"] });
-    await service.addWords({ userId, projectKey: projectB, words: ["Alpha"] });
+    await service.addWords({ userId, scope: repositoryScope(projectA), words: ["Alpha", "Beta"] });
+    await service.addWords({ userId, scope: repositoryScope(projectB), words: ["Alpha"] });
 
     assert.deepEqual(await service.listWords({ userId, projectKey: projectA }), ["Alpha", "Beta"]);
     assert.equal(await service.removeWords({ userId, projectKey: projectA, words: ["Alpha", "Alpha"] }), 1);
@@ -232,13 +252,17 @@ describe("GlossaryService", () => {
   });
 
   it("returns no context when project scope is absent", async () => {
-    await service.addWords({ userId, projectKey: projectA, words: ["Alpha"] });
+    await service.addWords({ userId, scope: repositoryScope(projectA), words: ["Alpha"] });
 
     assert.deepEqual(await service.getContextWords({ userId, projectKey: null }), []);
   });
 
   it("selects context by code-unit order without locale collation", async () => {
-    await service.addWords({ userId, projectKey: projectA, words: ["Zebra", "apple", "Émile", "Apple"] });
+    await service.addWords({
+      userId,
+      scope: repositoryScope(projectA),
+      words: ["Zebra", "apple", "Émile", "Apple"],
+    });
 
     assert.deepEqual(await service.getContextWords({ userId, projectKey: projectA }), [
       "Apple",
@@ -253,7 +277,7 @@ describe("GlossaryService", () => {
     const stored = words("", 0).concat(
       Array.from({ length: 120 }, (_, index) => `${String(index).padStart(3, "0")}${term}`),
     );
-    await repo.insertMany({ userId, projectKey: projectA, words: stored });
+    await repo.insertMany({ userId, scope: repositoryScope(projectA), words: stored });
 
     const context = await service.getContextWords({ userId, projectKey: projectA });
 

--- a/tests/services/glossary-service.test.ts
+++ b/tests/services/glossary-service.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, before, after, beforeEach } from "node:test";
+import { describe, it, before, after, beforeEach, mock } from "node:test";
 import assert from "node:assert/strict";
 import { ObjectId } from "mongodb";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
+import { BridgeRepository } from "../../src/repositories/bridge-repo.js";
 import { GlossaryEntryRepository } from "../../src/repositories/glossary-entry-repo.js";
 import { GlossaryService, glossaryPolicy } from "../../src/services/glossary-service.js";
 import type { GlossaryEntry } from "../../src/models/documents.js";
@@ -20,13 +21,15 @@ function words(prefix: string, count: number, start = 0): string[] {
 describe("GlossaryService", () => {
   let ctx: TestContext;
   let repo: GlossaryEntryRepository;
+  let bridgeRepo: BridgeRepository;
   let service: GlossaryService;
   let userId: string;
 
   before(async () => {
     ctx = await createTestApp();
     repo = new GlossaryEntryRepository(ctx.dbAccessor);
-    service = new GlossaryService({ glossaryRepo: repo });
+    bridgeRepo = new BridgeRepository(ctx.dbAccessor);
+    service = new GlossaryService({ glossaryRepo: repo, bridgeRepo });
   });
 
   after(async () => {
@@ -44,6 +47,42 @@ describe("GlossaryService", () => {
     const added = await service.addWords({ userId, projectKey: projectA, words: ["Beta", "Alpha", "Beta"] });
 
     assert.deepEqual(added, ["Beta", "Alpha"]);
+  });
+
+  it("rejects local glossary writes for an inactive bridge", async () => {
+    await assert.rejects(
+      () =>
+        service.addWords({
+          userId,
+          projectKey: projectA,
+          bridgeId: "br_missing0001",
+          words: ["Blocked"],
+        }),
+      BadRequestError,
+    );
+    assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 0);
+  });
+
+  it("removes a raced local write when the bridge is revoked during insertion", async () => {
+    let activeChecks = 0;
+    const findByIdForUser = mock.fn(async () => (activeChecks++ === 0 ? {} : null));
+    const racingService = new GlossaryService({
+      glossaryRepo: repo,
+      bridgeRepo: { findByIdForUser } as unknown as BridgeRepository,
+    });
+
+    await assert.rejects(
+      () =>
+        racingService.addWords({
+          userId,
+          projectKey: projectA,
+          bridgeId: "br_bridge0001",
+          words: ["Raced"],
+        }),
+      BadRequestError,
+    );
+    assert.equal(findByIdForUser.mock.callCount(), 2);
+    assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 0);
   });
 
   it("truncates to the remaining per-project capacity", async () => {
@@ -127,7 +166,7 @@ describe("GlossaryService", () => {
       insertMany: async () => [],
       deleteMany: async () => 0,
     } as unknown as GlossaryEntryRepository;
-    const spyService = new GlossaryService({ glossaryRepo: spyRepo });
+    const spyService = new GlossaryService({ glossaryRepo: spyRepo, bridgeRepo });
 
     await assert.rejects(
       () =>

--- a/tests/services/voice-service.test.ts
+++ b/tests/services/voice-service.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { inspect } from "node:util";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
 import type { AsyncTranscriptionClient } from "../../src/clients/async-transcription-client.js";
+import { ProjectGlossaryScopeType } from "../../src/models/voice.js";
 import {
   AsyncTranscriptionPublicErrorPolicy,
   TranscriptionFailure,
@@ -270,7 +271,10 @@ describe("VoiceService provider failure mapping", () => {
       method: "POST",
       url: "/voice/glossary",
       headers: { authorization: `Bearer ${user.accessToken}`, "content-type": "application/json" },
-      payload: JSON.stringify({ projectKey, words: ["Sesori"] }),
+      payload: JSON.stringify({
+        scope: { type: ProjectGlossaryScopeType.repository, projectKey },
+        words: ["Sesori"],
+      }),
     });
 
     const { body, contentType } = multipart();

--- a/tests/voice/glossary.test.ts
+++ b/tests/voice/glossary.test.ts
@@ -1,10 +1,19 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
-import { ProjectGlossaryScopeType } from "../../src/models/voice.js";
+import {
+  ProjectGlossaryScopeType,
+  projectKeySchema,
+  type ProjectGlossaryScope,
+  type ProjectKey,
+} from "../../src/models/voice.js";
 
-const projectA = `prj_v1_${"A".repeat(43)}`;
-const projectB = `prj_v1_${"B".repeat(43)}`;
+const projectA = projectKeySchema.parse(`prj_v1_${"A".repeat(43)}`);
+const projectB = projectKeySchema.parse(`prj_v1_${"B".repeat(43)}`);
+
+function repositoryScope(projectKey: ProjectKey): ProjectGlossaryScope {
+  return { type: ProjectGlossaryScopeType.repository, projectKey };
+}
 
 describe("Glossary routes", () => {
   let ctx: TestContext;
@@ -17,13 +26,17 @@ describe("Glossary routes", () => {
     await ctx.cleanup();
   });
 
-  async function addWords(accessToken: string, projectKey: string, words: string[]) {
+  async function addScopedWords(accessToken: string, scope: ProjectGlossaryScope, words: string[]) {
     return ctx.app.inject({
       method: "POST",
       url: "/voice/glossary",
       headers: { authorization: `Bearer ${accessToken}`, "content-type": "application/json" },
-      payload: JSON.stringify({ scope: { type: ProjectGlossaryScopeType.repository, projectKey }, words }),
+      payload: JSON.stringify({ scope, words }),
     });
+  }
+
+  async function addWords(accessToken: string, projectKey: ProjectKey, words: string[]) {
+    return addScopedWords(accessToken, repositoryScope(projectKey), words);
   }
 
   async function listWords(accessToken: string, query: string) {
@@ -34,13 +47,24 @@ describe("Glossary routes", () => {
     });
   }
 
-  async function removeWords(accessToken: string, projectKey: string, words: string[]) {
+  async function removeWords(accessToken: string, scope: ProjectGlossaryScope, words: string[]) {
     return ctx.app.inject({
       method: "DELETE",
       url: "/voice/glossary",
       headers: { authorization: `Bearer ${accessToken}`, "content-type": "application/json" },
-      payload: JSON.stringify({ projectKey, words }),
+      payload: JSON.stringify({ scope, words }),
     });
+  }
+
+  async function registerBridge(accessToken: string): Promise<string> {
+    const response = await ctx.app.inject({
+      method: "POST",
+      url: "/auth/bridges",
+      headers: { authorization: `Bearer ${accessToken}`, "content-type": "application/json" },
+      payload: JSON.stringify({ name: "Glossary Bridge", platform: "macos" }),
+    });
+    assert.equal(response.statusCode, 201);
+    return response.json<{ id: string }>().id;
   }
 
   describe("GET /voice/glossary", () => {
@@ -152,7 +176,7 @@ describe("Glossary routes", () => {
         method: "POST",
         url: "/voice/glossary",
         headers: { "content-type": "application/json" },
-        payload: JSON.stringify({ projectKey: projectA, words: ["Test"] }),
+        payload: JSON.stringify({ scope: repositoryScope(projectA), words: ["Test"] }),
       });
 
       assert.equal(res.statusCode, 401);
@@ -165,7 +189,7 @@ describe("Glossary routes", () => {
       await addWords(user.accessToken, projectA, ["ToRemove", "ToKeep"]);
       await addWords(user.accessToken, projectB, ["ToRemove"]);
 
-      const res = await removeWords(user.accessToken, projectA, ["ToRemove"]);
+      const res = await removeWords(user.accessToken, repositoryScope(projectA), ["ToRemove"]);
 
       assert.equal(res.statusCode, 200);
       assert.deepEqual(res.json(), { removed: 1 });
@@ -173,16 +197,38 @@ describe("Glossary routes", () => {
       assert.deepEqual((await listWords(user.accessToken, `?projectKey=${projectB}`)).json(), { words: ["ToRemove"] });
     });
 
+    it("deletes only the exact ownership scope while project reads stay deduplicated", async () => {
+      const user = await ctx.createUser();
+      const bridgeId = await registerBridge(user.accessToken);
+      const repository = repositoryScope(projectA);
+      const local: ProjectGlossaryScope = {
+        type: ProjectGlossaryScopeType.bridgeLocal,
+        projectKey: projectA,
+        bridgeId,
+      };
+
+      assert.deepEqual((await addScopedWords(user.accessToken, repository, ["Shared"])).json(), {
+        added: ["Shared"],
+      });
+      assert.deepEqual((await addScopedWords(user.accessToken, local, ["Shared"])).json(), { added: ["Shared"] });
+      assert.deepEqual((await listWords(user.accessToken, `?projectKey=${projectA}`)).json(), { words: ["Shared"] });
+
+      assert.deepEqual((await removeWords(user.accessToken, repository, ["Shared"])).json(), { removed: 1 });
+      assert.deepEqual((await listWords(user.accessToken, `?projectKey=${projectA}`)).json(), { words: ["Shared"] });
+      assert.deepEqual((await removeWords(user.accessToken, local, ["Shared"])).json(), { removed: 1 });
+      assert.deepEqual((await listWords(user.accessToken, `?projectKey=${projectA}`)).json(), { words: [] });
+    });
+
     it("returns 0 when removing words that do not exist", async () => {
       const user = await ctx.createUser();
 
-      const res = await removeWords(user.accessToken, projectA, ["NonExistent"]);
+      const res = await removeWords(user.accessToken, repositoryScope(projectA), ["NonExistent"]);
 
       assert.equal(res.statusCode, 200);
       assert.deepEqual(res.json(), { removed: 0 });
     });
 
-    it("returns 400 when the project key is missing", async () => {
+    it("returns 400 when the scope is missing", async () => {
       const user = await ctx.createUser();
 
       const res = await ctx.app.inject({
@@ -200,7 +246,7 @@ describe("Glossary routes", () => {
         method: "DELETE",
         url: "/voice/glossary",
         headers: { "content-type": "application/json" },
-        payload: JSON.stringify({ projectKey: projectA, words: ["Test"] }),
+        payload: JSON.stringify({ scope: repositoryScope(projectA), words: ["Test"] }),
       });
 
       assert.equal(res.statusCode, 401);
@@ -231,7 +277,9 @@ describe("Glossary routes", () => {
         words: ["Fastify", "MongoDB", "Zod"],
       });
 
-      assert.deepEqual((await removeWords(user.accessToken, projectA, ["MongoDB"])).json(), { removed: 1 });
+      assert.deepEqual((await removeWords(user.accessToken, repositoryScope(projectA), ["MongoDB"])).json(), {
+        removed: 1,
+      });
       assert.deepEqual((await listWords(user.accessToken, `?projectKey=${projectA}`)).json(), {
         words: ["Fastify", "Zod"],
       });

--- a/tests/voice/glossary.test.ts
+++ b/tests/voice/glossary.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
+import { ProjectGlossaryScopeType } from "../../src/models/voice.js";
 
 const projectA = `prj_v1_${"A".repeat(43)}`;
 const projectB = `prj_v1_${"B".repeat(43)}`;
@@ -21,7 +22,7 @@ describe("Glossary routes", () => {
       method: "POST",
       url: "/voice/glossary",
       headers: { authorization: `Bearer ${accessToken}`, "content-type": "application/json" },
-      payload: JSON.stringify({ projectKey, words }),
+      payload: JSON.stringify({ scope: { type: ProjectGlossaryScopeType.repository, projectKey }, words }),
     });
   }
 
@@ -113,12 +114,26 @@ describe("Glossary routes", () => {
       const user = await ctx.createUser();
       const invalidBodies = [
         { words: ["Test"] },
-        { projectKey: "prj_v1_short", words: ["Test"] },
-        { projectKey: projectA, bridgeId: "not-a-bridge", words: ["Test"] },
-        { projectKey: projectA, words: [] },
-        { projectKey: projectA, words: ["   "] },
-        { projectKey: projectA, words: ["Test"], unexpected: true },
-        { projectKey: projectA, words: [`${"x".repeat(201)}`] },
+        { scope: { type: ProjectGlossaryScopeType.repository, projectKey: "prj_v1_short" }, words: ["Test"] },
+        {
+          scope: { type: ProjectGlossaryScopeType.bridgeLocal, projectKey: projectA },
+          words: ["Test"],
+        },
+        {
+          scope: { type: ProjectGlossaryScopeType.bridgeLocal, projectKey: projectA, bridgeId: "not-a-bridge" },
+          words: ["Test"],
+        },
+        { scope: { type: ProjectGlossaryScopeType.repository, projectKey: projectA }, words: [] },
+        { scope: { type: ProjectGlossaryScopeType.repository, projectKey: projectA }, words: ["   "] },
+        {
+          scope: { type: ProjectGlossaryScopeType.repository, projectKey: projectA },
+          words: ["Test"],
+          unexpected: true,
+        },
+        {
+          scope: { type: ProjectGlossaryScopeType.repository, projectKey: projectA },
+          words: [`${"x".repeat(201)}`],
+        },
       ];
 
       for (const body of invalidBodies) {

--- a/tests/voice/glossary.test.ts
+++ b/tests/voice/glossary.test.ts
@@ -109,11 +109,12 @@ describe("Glossary routes", () => {
       assert.deepEqual((await listWords(user.accessToken, `?projectKey=${projectB}`)).json(), { words: ["Shared"] });
     });
 
-    it("returns 400 for missing/invalid project keys, empty words, and unknown fields", async () => {
+    it("returns 400 for invalid scope fields, empty words, and unknown fields", async () => {
       const user = await ctx.createUser();
       const invalidBodies = [
         { words: ["Test"] },
         { projectKey: "prj_v1_short", words: ["Test"] },
+        { projectKey: projectA, bridgeId: "not-a-bridge", words: ["Test"] },
         { projectKey: projectA, words: [] },
         { projectKey: projectA, words: ["   "] },
         { projectKey: projectA, words: ["Test"], unexpected: true },

--- a/tests/voice/transcribe.test.ts
+++ b/tests/voice/transcribe.test.ts
@@ -7,6 +7,7 @@ import { VoiceService } from "../../src/services/voice-service.js";
 import { BadGatewayError } from "../../src/lib/errors.js";
 import { todayUtcDateKey, DailyUsageRepository } from "../../src/repositories/daily-usage-repo.js";
 import type { DailyUsage } from "../../src/models/documents.js";
+import { ProjectGlossaryScopeType } from "../../src/models/voice.js";
 import { MongoDbDatabase, AuthDbCollection } from "../../src/types/mongo.js";
 
 const BOUNDARY = "----TestBoundary9876543210";
@@ -290,7 +291,7 @@ describe("POST /voice/transcribe", () => {
       method: "POST",
       url: "/voice/glossary",
       headers: { authorization: `Bearer ${accessToken}`, "content-type": "application/json" },
-      payload: JSON.stringify({ projectKey, words }),
+      payload: JSON.stringify({ scope: { type: ProjectGlossaryScopeType.repository, projectKey }, words }),
     });
     assert.equal(res.statusCode, 200);
   }


### PR DESCRIPTION
## Complexity

🚧 Complex — this changes a persisted and wire-level ownership contract and coordinates bridge revocation with glossary lifecycle cleanup.

## What

- Model glossary ownership as required discriminated variants:
  - `repository { type, projectKey }`
  - `bridge_local { type, projectKey, bridgeId }`
- Require the exact scope on both add and remove mutations.
- Preserve full scope identity in the unique MongoDB index so repository and multiple bridge-local owners may independently own the same term.
- Keep project-level reads provider-friendly by aggregating and deduplicating terms across valid owners.
- Require an active bridge owned by the account for bridge-local mutations and clean bridge-local rows during bridge revocation, including the insertion/revocation race.

## Why

Repository glossaries must survive bridge removal and be shared across that account's bridges, while local projects must be owned and deleted by one bridge. A nullable ownership field or project-key-only mutation would collapse those lifecycles and could delete vocabulary still owned by another scope.

## Risk and test focus

Moderate-to-high internal risk around exact MongoDB uniqueness, mutation isolation, revocation races, and preserving repository rows during bridge cleanup. The glossary endpoints still have no deployed caller or persisted glossary data, so this intentionally uses a fresh strong schema with no compatibility migration. Review should focus on exact-scope add/remove behavior, active bridge admission, bridge deletion, duplicate ownership, and deduplicated transcription context.

## Expected result

No immediate user-visible change. The auth database uses the new strong scope shape and full-scope unique index; unexpected pre-existing glossary data still fails startup rather than being migrated. Future bridge population can safely share repository vocabulary while local vocabulary is removed with its owning bridge.

## Verification

- `npm run build`
- Focused ESLint across changed TypeScript files
- 138 focused auth tests covering glossary schemas, indexes, repository/service/routes, bridge revocation, transcription, and revoke behavior
- Follow-up bridge cleanup fix: build, focused ESLint, and 76 bridge/glossary/revoke tests
- Architecture implementation review: **APPROVED** after exact-scope findings were addressed
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces strong glossary scopes so repository vocabulary survives bridge removal while bridge-local vocabulary is deleted with its bridge. Glossary mutations now require exact `scope` variants, and the full-scope unique index lets multiple owners share the same term.

**Breaking changes**
- The glossary add/remove API now expects a `scope` object instead of `projectKey`; there is no migration, so unexpected pre-existing data fails startup.

**Bridge cleanup**
- Bridge-local mutations require the owning bridge to stay active across insertion, so revocation cannot race vocabulary back into storage.
- Revocation cancels timers before deleting bridge-local rows, and cleanup runs on every revoke attempt so retries clear stale rows.
- Revoke-all cleanup derives candidates from glossary-owned bridge IDs and rechecks revocation before deleting, leaving concurrently registered bridges untouched.

<sup>Written for commit 318978340e67e665a899a89f43da23d64f584b38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

