### PR TITLE
⚙️ Store glossary words by exact scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,9 @@ only `{ type, projectKey }`, while bridge-local scope requires
 `{ type, projectKey, bridgeId }`. There is no nullable ownership field or
 fallback shape. The server validates active bridge ownership before and after a
 bridge-local insertion so revocation cannot race vocabulary back into storage.
-Repository rows survive bridge removal; bridge-local rows do not.
+Repository scope documents survive bridge removal; bridge-local scope documents
+do not. Each exact scope has one MongoDB document containing its `words` array;
+project reads flatten and deduplicate words across those ownership documents.
 
 Glossary CRUD requires a project key: `GET /voice/glossary?projectKey=…`, while
 `POST` and `DELETE /voice/glossary` use the exact `{ scope, words }` ownership
@@ -560,14 +562,14 @@ never falls back to a global glossary.
 Safety caps are 100 words per request, 500 per project, 5,000 per user, 200
 characters per word, and an 8,000-character provider context. Caps are checked
 per request rather than serialized, so concurrent requests may narrowly exceed
-them; the compound unique index still prevents duplicates.
+them. A compound unique index enforces one document per exact scope, and atomic
+`$addToSet`/`$pull` updates keep words idempotent within that document.
 
-The glossary endpoints and collection had no callers or persisted entries before
-project-specific voice glossary adoption. At startup, the runtime drops stale
-non-`_id` glossary indexes only after proving the collection is empty, then
-creates its strong scoped indexes directly. Unexpected data fails startup rather
-than being guessed, migrated, or deleted. There is no legacy glossary data
-migration or rollback procedure.
+This scope-document schema intentionally has no data migration. Before deploying
+it, purge or drop `glossaryEntries`; existing vocabulary will be republished by
+bridges. At startup, the runtime drops stale non-`_id` glossary indexes only after
+proving the collection is empty, then creates the scoped-document indexes.
+Unexpected data fails startup rather than being guessed, migrated, or deleted.
 
 ## Async transcription providers
 

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -37,7 +37,6 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
             "scope.projectKey": 1,
             "scope.type": 1,
             "scope.bridgeId": 1,
-            word: 1,
           },
           options: { unique: true },
         },
@@ -130,7 +129,7 @@ async function normalizeEmptyGlossaryIndexes(args: {
 
   const existingDocument = await args.collection.findOne({}, { projection: { _id: 1 } });
   if (existingDocument) {
-    throw new Error("Glossary schema reset refused: the collection unexpectedly contains data");
+    throw new Error("Glossary schema reset refused: purge the collection before changing its schema");
   }
 
   for (const index of unexpectedIndexes) {

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -8,7 +8,7 @@ import {
   productAnalyticsPreferenceRevisionSchema,
   productAnalyticsPreferenceSchema,
 } from "../types/product-analytics.js";
-import { projectGlossaryScopeSchema } from "./voice.js";
+import { normalizedGlossaryWordSchema, projectGlossaryScopeSchema } from "./voice.js";
 
 export const userSchema = z.object({
   _id: z.instanceof(ObjectId),
@@ -63,8 +63,9 @@ export const glossaryEntrySchema = z
     _id: z.instanceof(ObjectId),
     userId: z.instanceof(ObjectId),
     scope: projectGlossaryScopeSchema,
-    word: z.string(),
+    words: z.array(normalizedGlossaryWordSchema),
     createdAt: z.date(),
+    updatedAt: z.date(),
   })
   .strict();
 

--- a/src/models/voice.ts
+++ b/src/models/voice.ts
@@ -45,7 +45,13 @@ export const projectGlossaryScopeSchema = z.discriminatedUnion("type", [
 
 export type ProjectGlossaryScope = z.infer<typeof projectGlossaryScopeSchema>;
 
-export const glossaryWordSchema = z.string().trim().min(1).max(200);
+export const normalizedGlossaryWordSchema = z
+  .string()
+  .min(1)
+  .max(200)
+  .refine((word) => word === word.trim(), { message: "Glossary word must already be normalized" });
+
+export const glossaryWordSchema = z.string().trim().pipe(normalizedGlossaryWordSchema);
 
 export const glossaryWordsSchema = z.array(glossaryWordSchema).min(1).max(100);
 

--- a/src/repositories/glossary-entry-repo.ts
+++ b/src/repositories/glossary-entry-repo.ts
@@ -1,4 +1,4 @@
-import { Collection, MongoBulkWriteError, ObjectId } from "mongodb";
+import { Collection, MongoServerError, ObjectId, type Document } from "mongodb";
 import { z } from "zod";
 import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
 import { glossaryEntrySchema, type GlossaryEntry } from "../models/documents.js";
@@ -24,6 +24,10 @@ function scopeFilter(scope: ProjectGlossaryScope): ProjectGlossaryScopeFilter {
   return scope.type === ProjectGlossaryScopeType.bridgeLocal ? { ...base, "scope.bridgeId": scope.bridgeId } : base;
 }
 
+function sortWords(words: Iterable<string>): string[] {
+  return [...words].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+}
+
 export class GlossaryEntryRepository {
   readonly #collection: Collection<GlossaryEntry>;
 
@@ -31,66 +35,51 @@ export class GlossaryEntryRepository {
     this.#collection = accessor.getCollection<GlossaryEntry>(MongoDbDatabase.Auth, AuthDbCollection.GlossaryEntries);
   }
 
-  /** Returns the project's words. Documents stay inside the repository boundary. */
+  /** Returns the project's deduplicated words. Documents stay inside the repository boundary. */
   async findWordsByUserAndProject(args: { userId: string; projectKey: ProjectKey }): Promise<string[]> {
     const entries = await this.#collection
       .find({ userId: new ObjectId(args.userId), "scope.projectKey": args.projectKey })
-      .sort({ word: 1 })
       .toArray();
-
-    return [...new Set(entries.map((entry) => this.#parseEntry(entry).word))];
+    const words = new Set<string>();
+    for (const entry of entries) {
+      for (const word of this.#parseEntry(entry).words) {
+        words.add(word);
+      }
+    }
+    return sortWords(words);
   }
 
   async findWordsByUserAndScope(args: { userId: string; scope: ProjectGlossaryScope }): Promise<string[]> {
-    const entries = await this.#collection
-      .find({ userId: new ObjectId(args.userId), ...scopeFilter(args.scope) })
-      .sort({ word: 1 })
-      .toArray();
-
-    return entries.map((entry) => this.#parseEntry(entry).word);
+    const entry = await this.#collection.findOne({
+      userId: new ObjectId(args.userId),
+      ...scopeFilter(args.scope),
+    });
+    return entry ? sortWords(new Set(this.#parseEntry(entry).words)) : [];
   }
 
   async countByUserAndProject(args: { userId: string; projectKey: ProjectKey }): Promise<number> {
-    return this.#parseCount(
-      await this.#collection.countDocuments({
-        userId: new ObjectId(args.userId),
-        "scope.projectKey": args.projectKey,
-      }),
-    );
+    return this.#countWords({
+      userId: new ObjectId(args.userId),
+      "scope.projectKey": args.projectKey,
+    });
   }
 
   async countScopedByUserId(userId: string): Promise<number> {
-    return this.#parseCount(await this.#collection.countDocuments({ userId: new ObjectId(userId) }));
+    return this.#countWords({ userId: new ObjectId(userId) });
   }
 
-  async insertMany(args: { userId: string; scope: ProjectGlossaryScope; words: string[] }): Promise<string[]> {
-    const { userId, scope, words } = args;
-    if (words.length === 0) {
+  async addWords(args: { userId: string; scope: ProjectGlossaryScope; words: string[] }): Promise<string[]> {
+    const requested = [...new Set(args.words)];
+    if (requested.length === 0) {
       return [];
     }
 
-    const objectUserId = new ObjectId(userId);
-    const now = new Date();
-    const docs: GlossaryEntry[] = words.map((word) => ({
-      _id: new ObjectId(),
-      userId: objectUserId,
-      scope,
-      word,
-      createdAt: now,
-    }));
-
-    try {
-      const result = await this.#collection.insertMany(docs, { ordered: false });
-      const insertedIds = new Set(Object.values(result.insertedIds).map((id) => id.toHexString()));
-      return docs.filter((document) => insertedIds.has(document._id.toHexString())).map((document) => document.word);
-    } catch (error: unknown) {
-      if (error instanceof MongoBulkWriteError && error.code === 11000) {
-        const errors = Array.isArray(error.writeErrors) ? error.writeErrors : [error.writeErrors];
-        const failedIndices = new Set(errors.map((entry) => entry.index));
-        return docs.filter((_, index) => !failedIndices.has(index)).map((document) => document.word);
-      }
-      throw error;
-    }
+    return this.#addWordsToScopeWithRetry({
+      objectUserId: new ObjectId(args.userId),
+      scope: args.scope,
+      words: requested,
+      now: new Date(),
+    });
   }
 
   async findBridgeLocalOwnerIdsByUser(args: { userId: string }): Promise<string[]> {
@@ -122,18 +111,96 @@ export class GlossaryEntryRepository {
     return this.#parseCount(result.deletedCount);
   }
 
-  async deleteMany(args: { userId: string; scope: ProjectGlossaryScope; words: string[] }): Promise<number> {
-    const { userId, scope, words } = args;
-    if (words.length === 0) {
+  async removeWords(args: { userId: string; scope: ProjectGlossaryScope; words: string[] }): Promise<number> {
+    const requested = [...new Set(args.words)];
+    if (requested.length === 0) {
       return 0;
     }
 
-    const result = await this.#collection.deleteMany({
-      userId: new ObjectId(userId),
-      ...scopeFilter(scope),
-      word: { $in: words },
-    });
-    return this.#parseCount(result.deletedCount);
+    const before = await this.#collection.findOneAndUpdate(
+      {
+        userId: new ObjectId(args.userId),
+        ...scopeFilter(args.scope),
+        words: { $in: requested },
+      },
+      {
+        $pull: { words: { $in: requested } },
+        $set: { updatedAt: new Date() },
+      },
+      { returnDocument: "before" },
+    );
+    if (!before) {
+      return 0;
+    }
+
+    const entry = this.#parseEntry(before);
+    const previousWords = new Set(entry.words);
+    const removed = requested.filter((word) => previousWords.has(word)).length;
+    await this.#collection.deleteOne({ _id: entry._id, words: { $size: 0 } });
+    return removed;
+  }
+
+  async #addWordsToScopeWithRetry(args: {
+    objectUserId: ObjectId;
+    scope: ProjectGlossaryScope;
+    words: string[];
+    now: Date;
+  }): Promise<string[]> {
+    try {
+      return await this.#addWordsToScope(args);
+    } catch (error: unknown) {
+      if (error instanceof MongoServerError && error.code === 11000) {
+        // A first-write upsert can lose the exact-scope unique-index race. The
+        // winner can also remove the last word before this caller retries, so
+        // continue until one atomic upsert observes or creates the document.
+        return this.#addWordsToScopeWithRetry(args);
+      }
+      throw error;
+    }
+  }
+
+  async #addWordsToScope(args: {
+    objectUserId: ObjectId;
+    scope: ProjectGlossaryScope;
+    words: string[];
+    now: Date;
+  }): Promise<string[]> {
+    const before = await this.#collection.findOneAndUpdate(
+      {
+        userId: args.objectUserId,
+        ...scopeFilter(args.scope),
+      },
+      {
+        $setOnInsert: {
+          _id: new ObjectId(),
+          userId: args.objectUserId,
+          scope: args.scope,
+          createdAt: args.now,
+        },
+        $set: { updatedAt: args.now },
+        $addToSet: { words: { $each: args.words } },
+      },
+      { upsert: true, returnDocument: "before" },
+    );
+    if (!before) {
+      return args.words;
+    }
+
+    const existing = new Set(this.#parseEntry(before).words);
+    return args.words.filter((word) => !existing.has(word));
+  }
+
+  async #countWords(filter: Document): Promise<number> {
+    const result = await this.#collection
+      .aggregate<{
+        count: unknown;
+      }>([
+        { $match: filter },
+        { $project: { _id: 0, count: { $size: "$words" } } },
+        { $group: { _id: null, count: { $sum: "$count" } } },
+      ])
+      .next();
+    return this.#parseCount(result?.count ?? 0);
   }
 
   #parseCount(value: unknown): number {
@@ -148,7 +215,7 @@ export class GlossaryEntryRepository {
   #parseEntry(entry: unknown): GlossaryEntry {
     const result = glossaryEntrySchema.safeParse(entry);
     if (!result.success) {
-      throw new InternalServerError({ debugMessage: "Invalid glossary entry persistence" });
+      throw new InternalServerError({ debugMessage: "Invalid glossary scope persistence" });
     }
 
     return result.data;

--- a/src/repositories/glossary-entry-repo.ts
+++ b/src/repositories/glossary-entry-repo.ts
@@ -9,6 +9,7 @@ import { MongoDbDatabase, AuthDbCollection } from "../types/mongo.js";
 
 const countSchema = z.number().int().nonnegative().safe();
 const bridgeIdsSchema = z.array(bridgeIdSchema);
+const MAX_SCOPE_UPSERT_ATTEMPTS = 5;
 
 type ProjectGlossaryScopeFilter = {
   "scope.type": ProjectGlossaryScopeType;
@@ -79,6 +80,7 @@ export class GlossaryEntryRepository {
       scope: args.scope,
       words: requested,
       now: new Date(),
+      attemptsRemaining: MAX_SCOPE_UPSERT_ATTEMPTS,
     });
   }
 
@@ -117,10 +119,13 @@ export class GlossaryEntryRepository {
       return 0;
     }
 
+    const exactScopeFilter = {
+      userId: new ObjectId(args.userId),
+      ...scopeFilter(args.scope),
+    };
     const before = await this.#collection.findOneAndUpdate(
       {
-        userId: new ObjectId(args.userId),
-        ...scopeFilter(args.scope),
+        ...exactScopeFilter,
         words: { $in: requested },
       },
       {
@@ -130,6 +135,9 @@ export class GlossaryEntryRepository {
       { returnDocument: "before" },
     );
     if (!before) {
+      // A previous removal can have committed its $pull but failed before
+      // deleting the empty document. A retry must complete that cleanup.
+      await this.#collection.deleteOne({ ...exactScopeFilter, words: { $size: 0 } });
       return 0;
     }
 
@@ -145,15 +153,20 @@ export class GlossaryEntryRepository {
     scope: ProjectGlossaryScope;
     words: string[];
     now: Date;
+    attemptsRemaining: number;
   }): Promise<string[]> {
     try {
       return await this.#addWordsToScope(args);
     } catch (error: unknown) {
-      if (error instanceof MongoServerError && error.code === 11000) {
+      if (error instanceof MongoServerError && error.code === 11000 && args.attemptsRemaining > 1) {
         // A first-write upsert can lose the exact-scope unique-index race. The
         // winner can also remove the last word before this caller retries, so
-        // continue until one atomic upsert observes or creates the document.
-        return this.#addWordsToScopeWithRetry(args);
+        // allow several races to settle without retrying a persistent conflict
+        // forever.
+        return this.#addWordsToScopeWithRetry({
+          ...args,
+          attemptsRemaining: args.attemptsRemaining - 1,
+        });
       }
       throw error;
     }

--- a/src/services/glossary-service.ts
+++ b/src/services/glossary-service.ts
@@ -55,7 +55,7 @@ export class GlossaryService {
       Math.min(this.#policy.maxWordsPerProject - projectCount, this.#policy.maxWordsPerUser - userCount),
     );
 
-    const added = await this.#glossaryRepo.insertMany({
+    const added = await this.#glossaryRepo.addWords({
       userId: args.userId,
       scope: args.scope,
       words: candidates.slice(0, remaining),
@@ -81,7 +81,7 @@ export class GlossaryService {
       await this.#requireActiveBridge({ userId: args.userId, bridgeId: args.scope.bridgeId });
     }
 
-    return this.#glossaryRepo.deleteMany({ userId: args.userId, scope: args.scope, words: requested });
+    return this.#glossaryRepo.removeWords({ userId: args.userId, scope: args.scope, words: requested });
   }
 
   async getContextWords(args: { userId: string; projectKey: ProjectKey | null }): Promise<string[]> {

--- a/tests/db/mongo-db-accessor.test.ts
+++ b/tests/db/mongo-db-accessor.test.ts
@@ -4,6 +4,18 @@ import { indexKeyMatches, indexMatchesDesired, type IndexDefinition } from "../.
 import { createTestApp } from "../helpers/setup.js";
 import { MongoDbDatabase, AuthDbCollection } from "../../src/types/mongo.js";
 
+const glossaryScopeIndex = {
+  userId: 1,
+  "scope.projectKey": 1,
+  "scope.type": 1,
+  "scope.bridgeId": 1,
+} as const;
+
+const legacyGlossaryWordIndex = {
+  ...glossaryScopeIndex,
+  word: 1,
+} as const;
+
 describe("indexKeyMatches", () => {
   it("returns true for identical single-field specs", () => {
     assert.equal(indexKeyMatches({ email: 1 }, { email: 1 }), true);
@@ -31,32 +43,15 @@ describe("indexKeyMatches", () => {
 });
 
 describe("fresh glossary index normalization", () => {
-  it("replaces stale indexes only while the glossary collection is empty", async () => {
+  it("replaces per-word indexes only while the glossary collection is empty", async () => {
     const ctx = await createTestApp();
     try {
       const collection = ctx.dbAccessor.getDb(MongoDbDatabase.Auth).collection(AuthDbCollection.GlossaryEntries);
-      const target = (await collection.indexes()).find((index) =>
-        indexKeyMatches(index.key, {
-          userId: 1,
-          "scope.projectKey": 1,
-          "scope.type": 1,
-          "scope.bridgeId": 1,
-          word: 1,
-        }),
-      );
+      const target = (await collection.indexes()).find((index) => indexKeyMatches(index.key, glossaryScopeIndex));
       assert.ok(target?.name);
       await collection.dropIndex(target.name);
       await collection.createIndex({ userId: 1, word: 1 }, { unique: true });
-      await collection.createIndex(
-        {
-          userId: 1,
-          "scope.projectKey": 1,
-          "scope.type": 1,
-          "scope.bridgeId": 1,
-          word: 1,
-        },
-        { unique: true, sparse: true },
-      );
+      await collection.createIndex(legacyGlossaryWordIndex, { unique: true, sparse: true });
 
       await ctx.dbAccessor.ensureIndexes();
 
@@ -65,42 +60,31 @@ describe("fresh glossary index normalization", () => {
         indexes.some((index) => indexKeyMatches(index.key, { userId: 1, word: 1 })),
         false,
       );
-      const normalizedTarget = indexes.find((index) =>
-        indexKeyMatches(index.key, {
-          userId: 1,
-          "scope.projectKey": 1,
-          "scope.type": 1,
-          "scope.bridgeId": 1,
-          word: 1,
-        }),
+      assert.equal(
+        indexes.some((index) => indexKeyMatches(index.key, legacyGlossaryWordIndex)),
+        false,
       );
+      const normalizedTarget = indexes.find((index) => indexKeyMatches(index.key, glossaryScopeIndex));
       assert.ok(normalizedTarget);
+      assert.equal(normalizedTarget.unique, true);
       assert.notEqual(normalizedTarget.sparse, true);
     } finally {
       await ctx.cleanup();
     }
   });
 
-  it("refuses to create a missing target index over unexpected glossary data", async () => {
+  it("requires the old collection to be purged before changing its schema", async () => {
     const ctx = await createTestApp();
     try {
       const collection = ctx.dbAccessor.getDb(MongoDbDatabase.Auth).collection(AuthDbCollection.GlossaryEntries);
-      const target = (await collection.indexes()).find((index) =>
-        indexKeyMatches(index.key, {
-          userId: 1,
-          "scope.projectKey": 1,
-          "scope.type": 1,
-          "scope.bridgeId": 1,
-          word: 1,
-        }),
-      );
+      const target = (await collection.indexes()).find((index) => indexKeyMatches(index.key, glossaryScopeIndex));
       assert.ok(target?.name);
       await collection.dropIndex(target.name);
       await collection.insertOne({ userId: "unexpected", word: "Sesori" });
 
       await assert.rejects(
         () => ctx.dbAccessor.ensureIndexes(),
-        /Glossary schema reset refused: the collection unexpectedly contains data/,
+        /Glossary schema reset refused: purge the collection before changing its schema/,
       );
     } finally {
       await ctx.cleanup();

--- a/tests/repositories/glossary-entry-repo.test.ts
+++ b/tests/repositories/glossary-entry-repo.test.ts
@@ -159,6 +159,25 @@ describe("GlossaryEntryRepository", () => {
     assert.equal(attempts, 4);
   });
 
+  it("bounds retries for a persistent exact-scope uniqueness conflict", async () => {
+    let attempts = 0;
+    const duplicateKeyError = new MongoServerError({ ok: 0, code: 11000, errmsg: "persistent conflict" });
+    const retryingRepo = new GlossaryEntryRepository({
+      getCollection: () => ({
+        findOneAndUpdate: async () => {
+          attempts += 1;
+          throw duplicateKeyError;
+        },
+      }),
+    } as unknown as MongoDbAccessor);
+
+    await assert.rejects(
+      () => retryingRepo.addWords({ userId, scope: repositoryScope(projectA), words: ["Shared"] }),
+      (error: unknown) => error === duplicateKeyError,
+    );
+    assert.equal(attempts, 5);
+  });
+
   it("counts per project and per user", async () => {
     await repo.addWords({ userId, scope: repositoryScope(projectA), words: ["Alpha", "Beta"] });
     await repo.addWords({ userId, scope: repositoryScope(projectB), words: ["Gamma"] });
@@ -175,6 +194,26 @@ describe("GlossaryEntryRepository", () => {
     assert.equal(await repo.removeWords({ userId, scope: scopeA, words: ["Alpha"] }), 1);
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 1);
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectB }), 1);
+  });
+
+  it("cleans up an already-empty scope document when removal is retried", async () => {
+    const scope = repositoryScope(projectA);
+    await insertRaw({
+      _id: new ObjectId(),
+      userId: new ObjectId(userId),
+      scope,
+      words: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    assert.equal(await repo.removeWords({ userId, scope, words: ["AlreadyRemoved"] }), 0);
+    assert.equal(
+      await ctx.dbAccessor
+        .getCollection<GlossaryEntry>(MongoDbDatabase.Auth, AuthDbCollection.GlossaryEntries)
+        .countDocuments({ userId: new ObjectId(userId), "scope.projectKey": projectA }),
+      0,
+    );
   });
 
   it("deletes bridge-local entries without touching shared repositories or other accounts", async () => {

--- a/tests/repositories/glossary-entry-repo.test.ts
+++ b/tests/repositories/glossary-entry-repo.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, before, after, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { ObjectId } from "mongodb";
+import { MongoServerError, ObjectId } from "mongodb";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
 import { GlossaryEntryRepository } from "../../src/repositories/glossary-entry-repo.js";
 import { InternalServerError } from "../../src/lib/errors.js";
@@ -12,6 +12,7 @@ import {
   type ProjectKey,
 } from "../../src/models/voice.js";
 import { MongoDbDatabase, AuthDbCollection } from "../../src/types/mongo.js";
+import type { MongoDbAccessor } from "../../src/db/mongo-db-accessor.js";
 
 const projectA = projectKeySchema.parse(`prj_v1_${"A".repeat(43)}`);
 const projectB = projectKeySchema.parse(`prj_v1_${"B".repeat(43)}`);
@@ -50,11 +51,17 @@ describe("GlossaryEntryRepository", () => {
   }
 
   it("persists project scope and returns only the requested project's words", async () => {
-    await repo.insertMany({ userId, scope: repositoryScope(projectA), words: ["Beta", "Alpha"] });
-    await repo.insertMany({ userId, scope: repositoryScope(projectB), words: ["Gamma"] });
+    await repo.addWords({ userId, scope: repositoryScope(projectA), words: ["Beta", "Alpha"] });
+    await repo.addWords({ userId, scope: repositoryScope(projectB), words: ["Gamma"] });
 
     const words = await repo.findWordsByUserAndProject({ userId, projectKey: projectA });
+    const documents = await ctx.dbAccessor
+      .getCollection<GlossaryEntry>(MongoDbDatabase.Auth, AuthDbCollection.GlossaryEntries)
+      .find({ userId: new ObjectId(userId), "scope.projectKey": projectA })
+      .toArray();
 
+    assert.equal(documents.length, 1);
+    assert.deepEqual(documents[0]?.words, ["Beta", "Alpha"]);
     assert.deepEqual(words, ["Alpha", "Beta"]);
     assert.ok(
       words.every((word) => typeof word === "string"),
@@ -65,14 +72,10 @@ describe("GlossaryEntryRepository", () => {
   it("keeps the same word independent across projects and users", async () => {
     const otherUserId = new ObjectId().toHexString();
 
-    assert.deepEqual(await repo.insertMany({ userId, scope: repositoryScope(projectA), words: ["Shared"] }), [
-      "Shared",
-    ]);
-    assert.deepEqual(await repo.insertMany({ userId, scope: repositoryScope(projectB), words: ["Shared"] }), [
-      "Shared",
-    ]);
+    assert.deepEqual(await repo.addWords({ userId, scope: repositoryScope(projectA), words: ["Shared"] }), ["Shared"]);
+    assert.deepEqual(await repo.addWords({ userId, scope: repositoryScope(projectB), words: ["Shared"] }), ["Shared"]);
     assert.deepEqual(
-      await repo.insertMany({ userId: otherUserId, scope: repositoryScope(projectA), words: ["Shared"] }),
+      await repo.addWords({ userId: otherUserId, scope: repositoryScope(projectA), words: ["Shared"] }),
       ["Shared"],
     );
   });
@@ -82,27 +85,33 @@ describe("GlossaryEntryRepository", () => {
     const firstLocal = bridgeLocalScope({ projectKey: projectA, bridgeId: "br_bridge0001" });
     const secondLocal = bridgeLocalScope({ projectKey: projectA, bridgeId: "br_bridge0002" });
 
-    assert.deepEqual(await repo.insertMany({ userId, scope: repository, words: ["Shared"] }), ["Shared"]);
-    assert.deepEqual(await repo.insertMany({ userId, scope: firstLocal, words: ["Shared"] }), ["Shared"]);
-    assert.deepEqual(await repo.insertMany({ userId, scope: secondLocal, words: ["Shared"] }), ["Shared"]);
+    assert.deepEqual(await repo.addWords({ userId, scope: repository, words: ["Shared"] }), ["Shared"]);
+    assert.deepEqual(await repo.addWords({ userId, scope: firstLocal, words: ["Shared"] }), ["Shared"]);
+    assert.deepEqual(await repo.addWords({ userId, scope: secondLocal, words: ["Shared"] }), ["Shared"]);
 
     assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectA }), ["Shared"]);
     assert.deepEqual(await repo.findWordsByUserAndScope({ userId, scope: repository }), ["Shared"]);
     assert.deepEqual(await repo.findWordsByUserAndScope({ userId, scope: firstLocal }), ["Shared"]);
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 3);
 
-    assert.equal(await repo.deleteMany({ userId, scope: repository, words: ["Shared"] }), 1);
+    assert.equal(await repo.removeWords({ userId, scope: repository, words: ["Shared"] }), 1);
     assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectA }), ["Shared"]);
-    assert.equal(await repo.deleteMany({ userId, scope: firstLocal, words: ["Shared"] }), 1);
+    assert.equal(await repo.removeWords({ userId, scope: firstLocal, words: ["Shared"] }), 1);
     assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectA }), ["Shared"]);
-    assert.equal(await repo.deleteMany({ userId, scope: secondLocal, words: ["Shared"] }), 1);
+    assert.equal(await repo.removeWords({ userId, scope: secondLocal, words: ["Shared"] }), 1);
     assert.deepEqual(await repo.findWordsByUserAndProject({ userId, projectKey: projectA }), []);
+    assert.equal(
+      await ctx.dbAccessor
+        .getCollection<GlossaryEntry>(MongoDbDatabase.Auth, AuthDbCollection.GlossaryEntries)
+        .countDocuments({ userId: new ObjectId(userId), "scope.projectKey": projectA }),
+      0,
+    );
   });
 
   it("treats a repeated word in the same exact scope as an idempotent duplicate", async () => {
-    await repo.insertMany({ userId, scope: repositoryScope(projectA), words: ["Alpha"] });
+    await repo.addWords({ userId, scope: repositoryScope(projectA), words: ["Alpha"] });
 
-    const inserted = await repo.insertMany({
+    const inserted = await repo.addWords({
       userId,
       scope: repositoryScope(projectA),
       words: ["Alpha", "Beta"],
@@ -112,9 +121,47 @@ describe("GlossaryEntryRepository", () => {
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 2);
   });
 
+  it("atomically creates one scope document for concurrent first writes", async () => {
+    const scope = repositoryScope(projectA);
+
+    const results = await Promise.all([
+      repo.addWords({ userId, scope, words: ["Shared"] }),
+      repo.addWords({ userId, scope, words: ["Shared"] }),
+    ]);
+
+    assert.deepEqual(results.flat(), ["Shared"]);
+    const documents = await ctx.dbAccessor
+      .getCollection<GlossaryEntry>(MongoDbDatabase.Auth, AuthDbCollection.GlossaryEntries)
+      .find({ userId: new ObjectId(userId), "scope.projectKey": projectA })
+      .toArray();
+    assert.equal(documents.length, 1);
+    assert.deepEqual(documents[0]?.words, ["Shared"]);
+  });
+
+  it("retries repeated exact-scope upsert collisions", async () => {
+    let attempts = 0;
+    const duplicateKeyError = new MongoServerError({ ok: 0, code: 11000, errmsg: "duplicate exact scope" });
+    const retryingRepo = new GlossaryEntryRepository({
+      getCollection: () => ({
+        findOneAndUpdate: async () => {
+          attempts += 1;
+          if (attempts <= 3) {
+            throw duplicateKeyError;
+          }
+          return null;
+        },
+      }),
+    } as unknown as MongoDbAccessor);
+
+    assert.deepEqual(await retryingRepo.addWords({ userId, scope: repositoryScope(projectA), words: ["Shared"] }), [
+      "Shared",
+    ]);
+    assert.equal(attempts, 4);
+  });
+
   it("counts per project and per user", async () => {
-    await repo.insertMany({ userId, scope: repositoryScope(projectA), words: ["Alpha", "Beta"] });
-    await repo.insertMany({ userId, scope: repositoryScope(projectB), words: ["Gamma"] });
+    await repo.addWords({ userId, scope: repositoryScope(projectA), words: ["Alpha", "Beta"] });
+    await repo.addWords({ userId, scope: repositoryScope(projectB), words: ["Gamma"] });
 
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 2);
     assert.equal(await repo.countScopedByUserId(userId), 3);
@@ -122,10 +169,10 @@ describe("GlossaryEntryRepository", () => {
 
   it("deletes only words within the requested scope", async () => {
     const scopeA = repositoryScope(projectA);
-    await repo.insertMany({ userId, scope: scopeA, words: ["Alpha", "Beta"] });
-    await repo.insertMany({ userId, scope: repositoryScope(projectB), words: ["Alpha"] });
+    await repo.addWords({ userId, scope: scopeA, words: ["Alpha", "Beta"] });
+    await repo.addWords({ userId, scope: repositoryScope(projectB), words: ["Alpha"] });
 
-    assert.equal(await repo.deleteMany({ userId, scope: scopeA, words: ["Alpha"] }), 1);
+    assert.equal(await repo.removeWords({ userId, scope: scopeA, words: ["Alpha"] }), 1);
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectA }), 1);
     assert.equal(await repo.countByUserAndProject({ userId, projectKey: projectB }), 1);
   });
@@ -135,18 +182,18 @@ describe("GlossaryEntryRepository", () => {
     const targetBridgeId = "br_bridge0001";
     const otherBridgeId = "br_bridge0002";
 
-    await repo.insertMany({
+    await repo.addWords({
       userId,
       scope: bridgeLocalScope({ projectKey: projectA, bridgeId: targetBridgeId }),
       words: ["Local"],
     });
-    await repo.insertMany({ userId, scope: repositoryScope(projectB), words: ["Repository"] });
-    await repo.insertMany({
+    await repo.addWords({ userId, scope: repositoryScope(projectB), words: ["Repository"] });
+    await repo.addWords({
       userId,
       scope: bridgeLocalScope({ projectKey: projectB, bridgeId: otherBridgeId }),
       words: ["OtherBridge"],
     });
-    await repo.insertMany({
+    await repo.addWords({
       userId: otherUserId,
       scope: bridgeLocalScope({ projectKey: projectA, bridgeId: targetBridgeId }),
       words: ["OtherUser"],
@@ -166,30 +213,45 @@ describe("GlossaryEntryRepository", () => {
 
   it("performs no database work for empty word or bridge lists", async () => {
     const scope = repositoryScope(projectA);
-    assert.deepEqual(await repo.insertMany({ userId, scope, words: [] }), []);
-    assert.equal(await repo.deleteMany({ userId, scope, words: [] }), 0);
+    assert.deepEqual(await repo.addWords({ userId, scope, words: [] }), []);
+    assert.equal(await repo.removeWords({ userId, scope, words: [] }), 0);
     assert.equal(await repo.deleteByUserAndBridges({ userId, bridgeIds: [] }), 0);
   });
 
-  it("fails closed on a malformed persisted document without leaking its content", async () => {
-    await insertRaw({
-      _id: new ObjectId(),
-      userId: new ObjectId(userId),
-      scope: repositoryScope(projectA),
-      word: "Broken",
-      createdAt: new Date(),
-      unexpected: "SecretValue",
-    });
-
-    await assert.rejects(
-      () => repo.findWordsByUserAndProject({ userId, projectKey: projectA }),
-      (error: unknown) => {
-        assert.ok(error instanceof InternalServerError);
-        assert.equal(error.message, "internal_server_error");
-        const diagnostics = `${error.debugMessage ?? ""}${JSON.stringify(error.nestedError ?? null)}`;
-        assert.ok(!diagnostics.includes("Broken") && !diagnostics.includes("SecretValue"));
-        return true;
+  it("fails closed on malformed persisted words without leaking their content", async () => {
+    const malformedCases = [
+      {
+        fields: { words: ["Broken"], unexpected: "SecretValue" },
+        secrets: ["Broken", "SecretValue"],
       },
-    );
+      { fields: { words: [""] }, secrets: [] },
+      { fields: { words: [" PaddedSecretValue "] }, secrets: ["PaddedSecretValue"] },
+      { fields: { words: ["LongSecretValue".repeat(20)] }, secrets: ["LongSecretValue"] },
+    ];
+
+    for (const malformed of malformedCases) {
+      await insertRaw({
+        _id: new ObjectId(),
+        userId: new ObjectId(userId),
+        scope: repositoryScope(projectA),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ...malformed.fields,
+      });
+
+      await assert.rejects(
+        () => repo.findWordsByUserAndProject({ userId, projectKey: projectA }),
+        (error: unknown) => {
+          assert.ok(error instanceof InternalServerError);
+          assert.equal(error.message, "internal_server_error");
+          const diagnostics = `${error.debugMessage ?? ""}${JSON.stringify(error.nestedError ?? null)}`;
+          assert.ok(malformed.secrets.every((secret) => !diagnostics.includes(secret)));
+          return true;
+        },
+      );
+      await ctx.dbAccessor
+        .getCollection<GlossaryEntry>(MongoDbDatabase.Auth, AuthDbCollection.GlossaryEntries)
+        .deleteMany({});
+    }
   });
 });

--- a/tests/services/glossary-service.test.ts
+++ b/tests/services/glossary-service.test.ts
@@ -126,7 +126,7 @@ describe("GlossaryService", () => {
   });
 
   it("truncates to the remaining per-project capacity", async () => {
-    await repo.insertMany({
+    await repo.addWords({
       userId,
       scope: repositoryScope(projectA),
       words: words("p", glossaryPolicy.maxWordsPerProject - 2),
@@ -144,9 +144,9 @@ describe("GlossaryService", () => {
       projectKeySchema.parse(`prj_v1_${String(index).repeat(43)}`),
     );
     for (const [index, projectKey] of projects.entries()) {
-      await repo.insertMany({ userId, scope: repositoryScope(projectKey), words: words(`u${index}_`, perProject) });
+      await repo.addWords({ userId, scope: repositoryScope(projectKey), words: words(`u${index}_`, perProject) });
     }
-    await repo.insertMany({ userId, scope: repositoryScope(projectA), words: words("tail_", 499) });
+    await repo.addWords({ userId, scope: repositoryScope(projectA), words: words("tail_", 499) });
 
     const added = await service.addWords({ userId, scope: repositoryScope(projectA), words: ["Last", "Overflow"] });
 
@@ -155,7 +155,7 @@ describe("GlossaryService", () => {
   });
 
   it("adds nothing and never passes a negative limit when a cap is already exceeded", async () => {
-    await repo.insertMany({
+    await repo.addWords({
       userId,
       scope: repositoryScope(projectA),
       words: words("over", glossaryPolicy.maxWordsPerProject + 5),
@@ -171,7 +171,7 @@ describe("GlossaryService", () => {
   });
 
   it("does not let an already-stored word consume the last free capacity slot", async () => {
-    await repo.insertMany({
+    await repo.addWords({
       userId,
       scope: repositoryScope(projectA),
       words: [...words("w", glossaryPolicy.maxWordsPerProject - 2), "Dup"],
@@ -197,8 +197,8 @@ describe("GlossaryService", () => {
         queried = true;
         return 0;
       },
-      insertMany: async () => [],
-      deleteMany: async () => 0,
+      addWords: async () => [],
+      removeWords: async () => 0,
     } as unknown as GlossaryEntryRepository;
     const spyService = new GlossaryService({ glossaryRepo: spyRepo, bridgeRepo });
 
@@ -249,11 +249,11 @@ describe("GlossaryService", () => {
   });
 
   it("keeps the rendered prompt within the context budget", async () => {
-    const term = "x".repeat(glossaryPolicy.maxWordCharacters);
-    await repo.insertMany({
+    const termSuffix = "x".repeat(glossaryPolicy.maxWordCharacters - 3);
+    await repo.addWords({
       userId,
       scope: repositoryScope(projectA),
-      words: Array.from({ length: 90 }, (_, index) => `${String(index).padStart(3, "0")}${term}`),
+      words: Array.from({ length: 90 }, (_, index) => `${String(index).padStart(3, "0")}${termSuffix}`),
     });
 
     const prompt = renderTranscriptionPrompt(await service.getContextWords({ userId, projectKey: projectA }));
@@ -307,7 +307,7 @@ describe("GlossaryService", () => {
     const stored = words("", 0).concat(
       Array.from({ length: 120 }, (_, index) => `${String(index).padStart(3, "0")}${term}`),
     );
-    await repo.insertMany({ userId, scope: repositoryScope(projectA), words: stored });
+    await repo.addWords({ userId, scope: repositoryScope(projectA), words: stored });
 
     const context = await service.getContextWords({ userId, projectKey: projectA });
 


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this changes the MongoDB persistence shape and concurrent mutation behavior while preserving the public glossary contracts.

## What

- Store one glossary document per exact `(userId, scope)` with a bounded-domain `words` array.
- Replace the per-word unique index with an exact-scope unique index.
- Add and remove terms atomically with `$addToSet` and `$pull`, deleting documents once their arrays are empty.
- Flatten and deduplicate project reads across repository and bridge-local ownership scopes while counting stored ownership terms for existing safety caps.
- Retry repeated first-write upsert collisions and reject malformed persisted terms without exposing their content.
- Update index-reset, repository, service, concurrency, and malformed-persistence coverage.

## Why

Per-word documents repeated the full user and ownership scope for every term and made MongoDB row counts stand in for vocabulary counts. Scope documents retain complete exact ownership while substantially reducing document and index overhead.

## Risk and test focus

This intentionally has no data migration. `glossaryEntries` must be purged or dropped before deployment; bridges will republish vocabulary. Startup refuses to replace stale indexes while the collection contains data.

The main risks are exact-scope isolation, concurrent first writes, add/remove response accuracy, empty-document deletion races, aggregate cap counts, malformed persistence, and bridge-local revocation cleanup. Public request and response contracts are unchanged, so there is no direct user-visible API impact; the database representation changes and existing glossary vocabulary is reset during rollout.

## Expected result

Each exact ownership scope occupies one MongoDB document, project reads still return sorted deduplicated words, and all existing glossary limits and bridge cleanup semantics remain intact.

## Verification

- `npm run build`
- `npm run lint`
- `npm run format:check`
- Focused schema/index/repository/service/model tests: 46 passed
- Glossary route and transcription-context integration tests: 39 passed
- Bridge revocation, glossary cleanup, route, and transcription integration tests: 47 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stores glossary words in one MongoDB document per exact `(userId, scope)` instead of one document per word, cutting document and index overhead while keeping the public glossary API and existing limits unchanged. This is a persistence schema change, so existing glossary data must be reset before deployment.

- Adds and removes words atomically with `$addToSet` and `$pull`, deleting scope documents once empty.
- Flattens and deduplicates project reads across repository and bridge-local scope documents while counts still cover stored ownership terms.
- Bounds concurrent first-write upsert collisions to five retries, completes empty-document cleanup when a removal retry finds one, and rejects malformed persisted terms without exposing their contents.

**Migration**
- No data migration is provided; purge or drop `glossaryEntries` before deploying, and bridges will republish vocabulary.
- Startup refuses to replace stale indexes while the collection contains data.

<sup>Written for commit 014f6357cce99a02a97b585ae840751f41858bc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

