### PR TITLE
feat: add disabled Resend setup reminder foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,8 +422,62 @@ Managed via SOPS-encrypted files in `env/app/`. See `.sops.yaml` for key configu
 | `ACTIVATION_BRIDGE_REMINDER_2_DELAY_MS` | Delay from the bridge reminder baseline to the second bridge reminder. Default `86400000` (24 hours).                                                                                        |
 | `ACTIVATION_SESSION_REMINDER_DELAY_MS` | Delay from the session reminder baseline to the first-session reminder. Default `86400000` (24 hours).                                                                                       |
 | `ACTIVATION_SWEEP_BATCH_LIMIT` | Maximum candidates queried per reminder kind per sweep. Default `100`; delivery is sequential, so raise only after measuring FCM latency.                                                    |
+| `OPTIONAL_EMAIL_SENDING_ENABLED` | Master switch for every real optional-email send. Default `false`. Credentials alone never enable sending. |
+| `OPTIONAL_EMAIL_TEST_SEND_ENABLED` | Additional gate for the one-recipient test command. Default `false`; startup validation requires the master switch too. |
+| `OPTIONAL_EMAIL_RECIPIENT_BASIS` | Recipient-basis decision: `unapproved` (default) or `account_activity_approved`. Sending fails closed unless the approved value is set after founder/legal/privacy review. |
+| `OPTIONAL_EMAIL_DAILY_CAP` | Atomic UTC-day reservation cap for optional emails. Default and hard maximum `80`, reserving 20 messages of headroom under Resend's 100/day free-plan allowance. |
+| `RESEND_API_KEY` | Resend API key. Optional while sending is off; required when the master switch is on. Store only in the SOPS-encrypted environment. |
+| `RESEND_WEBHOOK_SECRET` | Resend signing secret for `/webhooks/resend`. Optional while the route is not configured; required before sending. Store only in SOPS. |
+| `OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET` | At least 32 characters of random signing material for durable no-login unsubscribe tokens. Optional while unconfigured; required before sending. Store only in SOPS. |
+| `RESEND_FROM` | Pinned sender identity. Default and only accepted value: `Sesori <hello@updates.sesori.com>`. This is configuration, not send authorization. |
+| `RESEND_REPLY_TO` | Pinned reply address. Default and only accepted value: `hello@sesori.com`. |
+| `RESEND_TEST_RECIPIENT` | Pinned test allowlist. Default and only accepted value: `alex@sesori.com`. |
 
 Relay reports to `POST /internal/bridge-status` must include the registered `bridgeId`; missing or malformed IDs are rejected with `400`.
+
+### Optional setup email foundation
+
+The Resend foundation is deliberately inert after deployment:
+
+- the auth server constructs no Resend send client and starts no email scheduler or bulk campaign;
+- `OPTIONAL_EMAIL_SENDING_ENABLED`, `OPTIONAL_EMAIL_TEST_SEND_ENABLED`, and the recipient basis all fail closed by default;
+- provider credentials do not imply recipient consent and do not enable sending;
+- optional-message opt-out/suppression state lives in MongoDB and is not a Resend audience/contact-list enrollment;
+- essential security/account mail must use a separate delivery policy and must never consult or overwrite optional-reminder preferences.
+
+Use `npm run env:edit` to add secret values to the SOPS-encrypted production environment. Do not place real values in README, `.env`, shell history, or Git. The non-secret shape is:
+
+```text
+OPTIONAL_EMAIL_SENDING_ENABLED=false
+OPTIONAL_EMAIL_TEST_SEND_ENABLED=false
+OPTIONAL_EMAIL_RECIPIENT_BASIS=unapproved
+OPTIONAL_EMAIL_DAILY_CAP=80
+RESEND_FROM=Sesori <hello@updates.sesori.com>
+RESEND_REPLY_TO=hello@sesori.com
+RESEND_TEST_RECIPIENT=alex@sesori.com
+RESEND_API_KEY=<SOPS-managed secret>
+RESEND_WEBHOOK_SECRET=<SOPS-managed secret>
+OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET=<SOPS-managed random secret>
+```
+
+When their signing secrets are configured, the server exposes:
+
+- `GET /email/optional/unsubscribe?token=…` — no-login confirmation page;
+- `POST /email/optional/unsubscribe?token=…` — RFC 8058 one-click body `List-Unsubscribe=One-Click`;
+- `POST /webhooks/resend` — raw-body signature verification plus idempotent handling for permanent bounce, complaint, and provider suppression events.
+
+Every reminder send rechecks global policy, user existence, recipient uniqueness, Mongo opt-out/suppression, and the relevant activation milestone before reservation and again immediately before the provider call. Bridge reminders stop after `bridgeSetupAt`; first-session reminders require `bridgeSetupAt` and stop after `firstSessionAt`. Send history contains user/campaign/kind/provider IDs but no recipient address. Stable idempotency keys and the provider's idempotency header block duplicate acceptance; the local retry window is capped at 23 hours.
+
+Aggregate feasibility only (no addresses or user IDs in output, no writes, and no send path):
+
+```bash
+sops exec-env env/app/prod.env \
+  'npm run optional-email:dry-run -- --batch-limit 500'
+```
+
+The only executable send path is a single-recipient operator test. It additionally requires both send gates, the approved recipient-basis value, complete provider/signing configuration, an existing user whose sole normalized account address is the pinned test address, a unique operation slug, and the literal `SEND_ONE_TEST_EMAIL` confirmation. Do not run it until explicit send authorization is recorded. Inspect its arguments without configuration via `npm run optional-email:test-send -- --help`.
+
+Known atomicity boundary: Mongo reservation, the final eligibility check, the external Resend request, and the accepted-history update cannot be one transaction. An unsubscribe or milestone can land in the narrow interval after the final check but before the request. A process crash after Resend accepts a request but before Mongo records the provider ID leaves an in-flight row; automatic retries remain blocked rather than risking a duplicate, so operator reconciliation is required. Quota reservations are conservative and are not refunded after a later block or provider failure.
 
 ### Client IP source and rate limiting
 
@@ -855,6 +909,8 @@ the restricted target dataset/table and deletion identity exist.
 | `npm run export-product-analytics` | Run one isolated auth-private export using ADC (unscheduled until analytics IAM exists) |
 | `npm run suppress-product-analytics-export` | Read one protected suppression request from stdin and hand off a restricted deletion target |
 | `npm run purge-soniox-transcription` | Audit Soniox async residue; `-- --apply` deletes it. Reports counts only |
+| `npm run optional-email:dry-run` | Count setup-reminder segments/outcomes only; no addresses, writes, or send mode |
+| `npm run optional-email:test-send` | Guarded one-recipient test path; disabled by default and requires explicit authorization/config/confirmations |
 
 ## Project structure
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "export-product-analytics": "tsx src/scripts/export-product-analytics.ts",
     "suppress-product-analytics-export": "tsx src/scripts/suppress-product-analytics-export.ts",
     "purge-soniox-transcription": "tsx src/scripts/purge-soniox-transcription.ts",
+    "optional-email:dry-run": "tsx src/scripts/dry-run-setup-reminders.ts",
+    "optional-email:test-send": "tsx src/scripts/send-test-setup-reminder.ts",
     "circular-dependencies": "madge --circular --ts-config ./tsconfig.json ./src/index.ts"
   },
   "dependencies": {

--- a/src/clients/resend-optional-email-adapter.ts
+++ b/src/clients/resend-optional-email-adapter.ts
@@ -1,0 +1,100 @@
+export type OptionalEmailProviderSendInput = {
+  idempotencyKey: string;
+  from: string;
+  replyTo: string;
+  recipient: string;
+  subject: string;
+  html: string;
+  text: string;
+  headers: Record<string, string>;
+  tags: { name: string; value: string }[];
+};
+
+export interface OptionalEmailProvider {
+  send(input: OptionalEmailProviderSendInput): Promise<{ providerEmailId: string }>;
+}
+
+export type ResendOptionalEmailErrorCode = "configuration" | "rate_limited" | "rejected" | "unavailable";
+
+export class ResendOptionalEmailError extends Error {
+  constructor(readonly code: ResendOptionalEmailErrorCode) {
+    super("resend_email_failed");
+    this.name = "ResendOptionalEmailError";
+  }
+}
+
+export class ResendOptionalEmailAdapter implements OptionalEmailProvider {
+  readonly #apiKey: string;
+  readonly #fetch: typeof fetch;
+  readonly #timeoutMs: number;
+
+  constructor(input: { apiKey: string; fetchFn?: typeof fetch; timeoutMs?: number }) {
+    if (!input.apiKey) {
+      throw new Error("MissingResendApiKey");
+    }
+    const timeoutMs = input.timeoutMs ?? 10_000;
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 30_000) {
+      throw new Error("InvalidResendRequestTimeout");
+    }
+    this.#apiKey = input.apiKey;
+    this.#fetch = input.fetchFn ?? fetch;
+    this.#timeoutMs = timeoutMs;
+  }
+
+  async send(input: OptionalEmailProviderSendInput): Promise<{ providerEmailId: string }> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.#timeoutMs);
+    let response: Response;
+    try {
+      response = await this.#fetch("https://api.resend.com/emails", {
+        method: "POST",
+        signal: controller.signal,
+        headers: {
+          Authorization: `Bearer ${this.#apiKey}`,
+          "Content-Type": "application/json",
+          "Idempotency-Key": input.idempotencyKey,
+        },
+        body: JSON.stringify({
+          from: input.from,
+          to: [input.recipient],
+          subject: input.subject,
+          html: input.html,
+          text: input.text,
+          reply_to: input.replyTo,
+          headers: input.headers,
+          tags: input.tags,
+        }),
+      });
+    } catch {
+      throw new ResendOptionalEmailError("unavailable");
+    } finally {
+      clearTimeout(timeout);
+    }
+    if (!response.ok) {
+      throw new ResendOptionalEmailError(classifyHttpFailure(response.status));
+    }
+    let body: { id?: unknown };
+    try {
+      body = (await response.json()) as { id?: unknown };
+    } catch {
+      throw new ResendOptionalEmailError("unavailable");
+    }
+    if (typeof body.id !== "string" || !body.id) {
+      throw new ResendOptionalEmailError("unavailable");
+    }
+    return { providerEmailId: body.id };
+  }
+}
+
+function classifyHttpFailure(status: number): ResendOptionalEmailErrorCode {
+  if (status === 429) {
+    return "rate_limited";
+  }
+  if (status === 401 || status === 403) {
+    return "configuration";
+  }
+  if (status >= 400 && status < 500) {
+    return "rejected";
+  }
+  return "unavailable";
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { AsyncTranscriptionProvider, SonioxRegion } from "./types/transcription.js";
 import { clientIpSourceSchema, ClientIpSource, trustedIngressCidrsSchema } from "./types/client-ip.js";
 import { productAnalyticsPseudonymizationKeySchema } from "./types/product-analytics.js";
+import { OPTIONAL_EMAIL_MAX_DAILY_CAP, OptionalEmailRecipientBasis } from "./types/optional-email.js";
 
 const appleConfigSchema = z.object({
   APPLE_CLIENT_ID: z.string().min(1, "APPLE_CLIENT_ID is required"),
@@ -73,6 +74,29 @@ const baseConfigSchema = z.object({
   ACTIVATION_BRIDGE_REMINDER_2_DELAY_MS: z.coerce.number().int().positive().default(86_400_000),
   ACTIVATION_SESSION_REMINDER_DELAY_MS: z.coerce.number().int().positive().default(86_400_000),
   ACTIVATION_SWEEP_BATCH_LIMIT: z.coerce.number().int().positive().default(100),
+  OPTIONAL_EMAIL_SENDING_ENABLED: z
+    .union([z.literal("true"), z.literal("false"), z.literal("1"), z.literal("0")])
+    .optional()
+    .transform((value) => value === "true" || value === "1"),
+  OPTIONAL_EMAIL_TEST_SEND_ENABLED: z
+    .union([z.literal("true"), z.literal("false"), z.literal("1"), z.literal("0")])
+    .optional()
+    .transform((value) => value === "true" || value === "1"),
+  OPTIONAL_EMAIL_RECIPIENT_BASIS: z
+    .nativeEnum(OptionalEmailRecipientBasis)
+    .default(OptionalEmailRecipientBasis.Unapproved),
+  OPTIONAL_EMAIL_DAILY_CAP: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(OPTIONAL_EMAIL_MAX_DAILY_CAP)
+    .default(OPTIONAL_EMAIL_MAX_DAILY_CAP),
+  RESEND_API_KEY: z.string().min(1).optional(),
+  RESEND_WEBHOOK_SECRET: z.string().min(32).optional(),
+  OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET: z.string().min(32).optional(),
+  RESEND_FROM: z.literal("Sesori <hello@updates.sesori.com>").default("Sesori <hello@updates.sesori.com>"),
+  RESEND_REPLY_TO: z.literal("hello@sesori.com").default("hello@sesori.com"),
+  RESEND_TEST_RECIPIENT: z.literal("alex@sesori.com").default("alex@sesori.com"),
   OPENAI_API_KEY: z.string().min(1, "OPENAI_API_KEY is required"),
   OPENAI_TRANSCRIPTION_MODEL: z.string().min(1).default("gpt-4o-mini-transcribe"),
   OPENAI_METADATA_MODEL: z.string().min(1).default("gpt-5-nano"),
@@ -168,6 +192,41 @@ const validatedConfigSchema = baseConfigSchema.superRefine((config, ctx) => {
       code: "custom",
       path: ["REALTIME_MAX_CONCURRENT_SESSIONS_PER_USER"],
       message: "REALTIME_MAX_CONCURRENT_SESSIONS_PER_USER cannot exceed REALTIME_MAX_CONCURRENT_SESSIONS",
+    });
+  }
+
+  if (
+    config.OPTIONAL_EMAIL_SENDING_ENABLED &&
+    config.OPTIONAL_EMAIL_RECIPIENT_BASIS !== OptionalEmailRecipientBasis.AccountActivityApproved
+  ) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["OPTIONAL_EMAIL_RECIPIENT_BASIS"],
+      message: "OPTIONAL_EMAIL_RECIPIENT_BASIS must be explicitly approved before sending",
+    });
+  }
+
+  if (config.OPTIONAL_EMAIL_SENDING_ENABLED) {
+    for (const key of [
+      "RESEND_API_KEY",
+      "RESEND_WEBHOOK_SECRET",
+      "OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET",
+    ] as const) {
+      if (config[key] === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          path: [key],
+          message: `${key} is required when optional email sending is enabled`,
+        });
+      }
+    }
+  }
+
+  if (config.OPTIONAL_EMAIL_TEST_SEND_ENABLED && !config.OPTIONAL_EMAIL_SENDING_ENABLED) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["OPTIONAL_EMAIL_TEST_SEND_ENABLED"],
+      message: "OPTIONAL_EMAIL_TEST_SEND_ENABLED requires OPTIONAL_EMAIL_SENDING_ENABLED",
     });
   }
 });

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -67,6 +67,13 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
       // One settings document per (user, device): the unique compound key both
       // enforces that invariant and serves the sole read path (findByUserAndDevice).
       [AuthDbCollection.SettingsConfiguration]: [{ spec: { userId: 1, deviceId: 1 }, options: { unique: true } }],
+      [AuthDbCollection.OptionalEmailPreferences]: [{ spec: { userId: 1 }, options: { unique: true } }],
+      [AuthDbCollection.OptionalEmailWebhookEvents]: [{ spec: { eventId: 1 }, options: { unique: true } }],
+      [AuthDbCollection.OptionalEmailSends]: [
+        { spec: { sendKey: 1 }, options: { unique: true } },
+        { spec: { providerEmailId: 1 }, options: { unique: true, sparse: true } },
+      ],
+      [AuthDbCollection.OptionalEmailDailyQuota]: [],
     },
   } satisfies DatabaseConfig<AuthDbCollection>,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import { AppClientPresenceService } from "./services/app-client-presence-service
 import { ProductAnalyticsPreferenceService } from "./services/product-analytics-preference-service.js";
 import { SettingsService } from "./services/settings-service.js";
 import { createShutdownHandler } from "./shutdown.js";
+import { createOptionalEmailRouteServices } from "./optional-email-composition.js";
 
 async function main() {
   const config = loadConfig();
@@ -69,6 +70,12 @@ async function main() {
   });
 
   const dbAccessor = new MongoDbAccessor(dbConnector);
+
+  const optionalEmail = createOptionalEmailRouteServices({
+    dbAccessor,
+    unsubscribeSigningSecret: config.OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET,
+    webhookSigningSecret: config.RESEND_WEBHOOK_SECRET,
+  });
 
   console.log("Creating indexes...");
   await dbAccessor.ensureIndexes();
@@ -270,6 +277,7 @@ async function main() {
     appleNativeVerifier,
     pendingAuthStore,
     productAnalyticsPreferenceService,
+    optionalEmail,
     realtime,
   });
 

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -9,6 +9,11 @@ import {
   productAnalyticsPreferenceSchema,
 } from "../types/product-analytics.js";
 import { normalizedGlossaryWordSchema, projectGlossaryScopeSchema } from "./voice.js";
+import {
+  OptionalEmailReminderKind,
+  OptionalEmailSendStatus,
+  OptionalEmailSuppressionReason,
+} from "../types/optional-email.js";
 
 export const userSchema = z.object({
   _id: z.instanceof(ObjectId),
@@ -152,3 +157,58 @@ export const settingsConfigurationSchema = z.object({
 });
 
 export type SettingsConfiguration = z.infer<typeof settingsConfigurationSchema>;
+
+/**
+ * Optional setup/reactivation mail only. This state must never gate password,
+ * security, deletion, or other essential account messages.
+ */
+export const optionalEmailPreferenceSchema = z.object({
+  _id: z.instanceof(ObjectId),
+  userId: z.instanceof(ObjectId),
+  unsubscribedAt: z.date().optional(),
+  suppressedAt: z.date().optional(),
+  suppressionReason: z.nativeEnum(OptionalEmailSuppressionReason).optional(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type OptionalEmailPreference = z.infer<typeof optionalEmailPreferenceSchema>;
+
+export const optionalEmailWebhookEventSchema = z.object({
+  _id: z.instanceof(ObjectId),
+  eventId: z.string().min(1).max(256),
+  eventType: z.string().min(1).max(128),
+  processedAt: z.date(),
+});
+
+export type OptionalEmailWebhookEvent = z.infer<typeof optionalEmailWebhookEventSchema>;
+
+export const optionalEmailSendSchema = z.object({
+  _id: z.instanceof(ObjectId),
+  sendKey: z.string().min(1).max(256),
+  userId: z.instanceof(ObjectId),
+  campaignId: z.string().min(1).max(64),
+  reminderKind: z.nativeEnum(OptionalEmailReminderKind),
+  status: z.nativeEnum(OptionalEmailSendStatus),
+  attemptCount: z.number().int().nonnegative(),
+  firstProviderAttemptAt: z.date().optional(),
+  lastProviderAttemptAt: z.date().optional(),
+  providerEmailId: z.string().min(1).max(256).optional(),
+  acceptedAt: z.date().optional(),
+  lastFailureCode: z.string().min(1).max(64).optional(),
+  lastBlockReason: z.string().min(1).max(64).optional(),
+  lastDeferralReason: z.string().min(1).max(64).optional(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type OptionalEmailSend = z.infer<typeof optionalEmailSendSchema>;
+
+export const optionalEmailDailyQuotaSchema = z.object({
+  _id: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  used: z.number().int().nonnegative(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type OptionalEmailDailyQuota = z.infer<typeof optionalEmailDailyQuotaSchema>;

--- a/src/optional-email-composition.ts
+++ b/src/optional-email-composition.ts
@@ -1,0 +1,52 @@
+import type { MongoDbAccessor } from "./db/mongo-db-accessor.js";
+import { OptionalEmailPreferenceRepository } from "./repositories/optional-email-preference-repo.js";
+import { OptionalEmailSendRepository } from "./repositories/optional-email-send-repo.js";
+import { OptionalEmailWebhookEventRepository } from "./repositories/optional-email-webhook-event-repo.js";
+import {
+  OptionalEmailUnsubscribeService,
+  OptionalEmailUnsubscribeTokenService,
+} from "./services/optional-email-unsubscribe-service.js";
+import { OptionalEmailWebhookService } from "./services/optional-email-webhook-service.js";
+import { ResendWebhookVerifier } from "./services/resend-webhook-verifier.js";
+
+export type OptionalEmailRouteServices = {
+  unsubscribeService?: OptionalEmailUnsubscribeService;
+  webhook?: {
+    verifier: ResendWebhookVerifier;
+    service: OptionalEmailWebhookService;
+  };
+};
+
+export function createOptionalEmailRouteServices(input: {
+  dbAccessor: MongoDbAccessor;
+  unsubscribeSigningSecret: string | undefined;
+  webhookSigningSecret: string | undefined;
+}): OptionalEmailRouteServices | undefined {
+  if (!input.unsubscribeSigningSecret && !input.webhookSigningSecret) {
+    return undefined;
+  }
+
+  const preferenceRepo = new OptionalEmailPreferenceRepository(input.dbAccessor);
+  const services: OptionalEmailRouteServices = {};
+  if (input.unsubscribeSigningSecret) {
+    services.unsubscribeService = new OptionalEmailUnsubscribeService({
+      tokenService: new OptionalEmailUnsubscribeTokenService({
+        signingSecret: Buffer.from(input.unsubscribeSigningSecret, "utf8"),
+      }),
+      preferenceRepo,
+    });
+  }
+
+  if (input.webhookSigningSecret) {
+    services.webhook = {
+      verifier: new ResendWebhookVerifier({ signingSecret: input.webhookSigningSecret }),
+      service: new OptionalEmailWebhookService({
+        eventRepo: new OptionalEmailWebhookEventRepository(input.dbAccessor),
+        preferenceRepo,
+        sendHistory: new OptionalEmailSendRepository(input.dbAccessor),
+      }),
+    };
+  }
+
+  return services;
+}

--- a/src/repositories/optional-email-daily-quota-repo.ts
+++ b/src/repositories/optional-email-daily-quota-repo.ts
@@ -1,0 +1,82 @@
+import { Collection, MongoServerError } from "mongodb";
+import type { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import { InternalServerError } from "../lib/errors.js";
+import type { OptionalEmailDailyQuota } from "../models/documents.js";
+import { OPTIONAL_EMAIL_MAX_DAILY_CAP } from "../types/optional-email.js";
+import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
+
+export type OptionalEmailDailyQuotaResult = {
+  date: string;
+  used: number;
+  remaining: number;
+};
+
+export class OptionalEmailDailyQuotaRepository {
+  readonly #collection: Collection<OptionalEmailDailyQuota>;
+
+  constructor(accessor: MongoDbAccessor) {
+    this.#collection = accessor.getCollection<OptionalEmailDailyQuota>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.OptionalEmailDailyQuota,
+    );
+  }
+
+  async reserve(input: { at: Date; dailyCap: number }): Promise<OptionalEmailDailyQuotaResult & { reserved: boolean }> {
+    const date = this.#validateAndDate(input);
+    await this.#ensureDay({ date, at: input.at });
+    const updated = await this.#collection.findOneAndUpdate(
+      { _id: date, used: { $lt: input.dailyCap } },
+      { $inc: { used: 1 }, $set: { updatedAt: input.at } },
+      { returnDocument: "after" },
+    );
+    if (!updated) {
+      return { reserved: false, ...(await this.getUsage(input)) };
+    }
+    return {
+      reserved: true,
+      date,
+      used: updated.used,
+      remaining: input.dailyCap - updated.used,
+    };
+  }
+
+  async getUsage(input: { at: Date; dailyCap: number }): Promise<OptionalEmailDailyQuotaResult> {
+    const date = this.#validateAndDate(input);
+    const row = await this.#collection.findOne({ _id: date });
+    const used = row?.used ?? 0;
+    return { date, used, remaining: Math.max(0, input.dailyCap - used) };
+  }
+
+  async #ensureDay(input: { date: string; at: Date }): Promise<void> {
+    try {
+      await this.#collection.updateOne(
+        { _id: input.date },
+        {
+          $setOnInsert: {
+            _id: input.date,
+            used: 0,
+            createdAt: input.at,
+            updatedAt: input.at,
+          },
+        },
+        { upsert: true },
+      );
+    } catch (error) {
+      if (!(error instanceof MongoServerError) || error.code !== 11000) {
+        throw error;
+      }
+    }
+  }
+
+  #validateAndDate(input: { at: Date; dailyCap: number }): string {
+    if (
+      Number.isNaN(input.at.getTime()) ||
+      !Number.isInteger(input.dailyCap) ||
+      input.dailyCap < 1 ||
+      input.dailyCap > OPTIONAL_EMAIL_MAX_DAILY_CAP
+    ) {
+      throw new InternalServerError({ debugMessage: "Invalid optional email daily quota input" });
+    }
+    return input.at.toISOString().slice(0, 10);
+  }
+}

--- a/src/repositories/optional-email-preference-repo.ts
+++ b/src/repositories/optional-email-preference-repo.ts
@@ -1,0 +1,105 @@
+import { Collection, MongoServerError, ObjectId } from "mongodb";
+import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import { InternalServerError } from "../lib/errors.js";
+import type { OptionalEmailPreference } from "../models/documents.js";
+import { OptionalEmailBlockReason, OptionalEmailSuppressionReason } from "../types/optional-email.js";
+import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
+
+export class OptionalEmailPreferenceRepository {
+  readonly #collection: Collection<OptionalEmailPreference>;
+
+  constructor(accessor: MongoDbAccessor) {
+    this.#collection = accessor.getCollection<OptionalEmailPreference>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.OptionalEmailPreferences,
+    );
+  }
+
+  async findByUserId(input: { userId: string }): Promise<OptionalEmailPreference | null> {
+    if (!ObjectId.isValid(input.userId)) {
+      return null;
+    }
+
+    return this.#collection.findOne({ userId: new ObjectId(input.userId) });
+  }
+
+  async findBlockReason(input: { userId: string }): Promise<OptionalEmailBlockReason | null> {
+    const preference = await this.findByUserId(input);
+    if (preference?.unsubscribedAt) {
+      return OptionalEmailBlockReason.Unsubscribed;
+    }
+    if (preference?.suppressedAt) {
+      return OptionalEmailBlockReason.Suppressed;
+    }
+    return null;
+  }
+
+  async unsubscribe(input: { userId: string; at: Date }): Promise<OptionalEmailPreference> {
+    this.#assertInput({ userId: input.userId, at: input.at });
+    return this.#upsertOnce({
+      userId: input.userId,
+      at: input.at,
+      fields: {
+        unsubscribedAt: { $ifNull: ["$unsubscribedAt", input.at] },
+      },
+    });
+  }
+
+  async suppress(input: {
+    userId: string;
+    reason: OptionalEmailSuppressionReason;
+    at: Date;
+  }): Promise<OptionalEmailPreference> {
+    this.#assertInput({ userId: input.userId, at: input.at });
+    return this.#upsertOnce({
+      userId: input.userId,
+      at: input.at,
+      fields: {
+        suppressedAt: { $ifNull: ["$suppressedAt", input.at] },
+        suppressionReason: { $ifNull: ["$suppressionReason", input.reason] },
+      },
+    });
+  }
+
+  #assertInput(input: { userId: string; at: Date }): void {
+    if (!ObjectId.isValid(input.userId) || Number.isNaN(input.at.getTime())) {
+      throw new InternalServerError({ debugMessage: "Invalid optional email preference input" });
+    }
+  }
+
+  async #upsertOnce(input: {
+    userId: string;
+    at: Date;
+    fields: Record<string, unknown>;
+  }): Promise<OptionalEmailPreference> {
+    const userId = new ObjectId(input.userId);
+    try {
+      const preference = await this.#collection.findOneAndUpdate(
+        { userId },
+        [
+          {
+            $set: {
+              ...input.fields,
+              createdAt: { $ifNull: ["$createdAt", input.at] },
+              updatedAt: input.at,
+            },
+          },
+        ],
+        { upsert: true, returnDocument: "after" },
+      );
+      if (preference) {
+        return preference;
+      }
+    } catch (error) {
+      if (!(error instanceof MongoServerError) || error.code !== 11000) {
+        throw error;
+      }
+    }
+
+    const winner = await this.#collection.findOne({ userId });
+    if (!winner) {
+      throw new InternalServerError({ debugMessage: "Failed to persist optional email preference" });
+    }
+    return winner;
+  }
+}

--- a/src/repositories/optional-email-recipient-repo.ts
+++ b/src/repositories/optional-email-recipient-repo.ts
@@ -1,0 +1,60 @@
+import { Collection, ObjectId } from "mongodb";
+import { z } from "zod";
+import type { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import type { OAuthAccount, PasswordAccount, User } from "../models/documents.js";
+import type {
+  OptionalEmailRecipientLookup,
+  OptionalEmailRecipientResolution,
+} from "../services/optional-email-eligibility-service.js";
+import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
+
+const emailSchema = z
+  .string()
+  .trim()
+  .email()
+  .transform((value) => value.toLowerCase());
+
+export class OptionalEmailRecipientRepository implements OptionalEmailRecipientLookup {
+  readonly #users: Collection<User>;
+  readonly #oauthAccounts: Collection<OAuthAccount>;
+  readonly #passwordAccounts: Collection<PasswordAccount>;
+
+  constructor(accessor: MongoDbAccessor) {
+    this.#users = accessor.getCollection<User>(MongoDbDatabase.Auth, AuthDbCollection.Users);
+    this.#oauthAccounts = accessor.getCollection<OAuthAccount>(MongoDbDatabase.Auth, AuthDbCollection.OAuthAccounts);
+    this.#passwordAccounts = accessor.getCollection<PasswordAccount>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.PasswordAccounts,
+    );
+  }
+
+  async resolve(input: { userId: string }): Promise<OptionalEmailRecipientResolution> {
+    if (!ObjectId.isValid(input.userId)) {
+      return { status: "missing_user" };
+    }
+    const userId = new ObjectId(input.userId);
+    if (!(await this.#users.findOne({ _id: userId }, { projection: { _id: 1 } }))) {
+      return { status: "missing_user" };
+    }
+
+    const [passwordAccount, oauthAccounts] = await Promise.all([
+      this.#passwordAccounts.findOne({ userId }, { projection: { email: 1 } }),
+      this.#oauthAccounts.find({ userId }, { projection: { email: 1 } }).toArray(),
+    ]);
+    const values: unknown[] = [passwordAccount?.email, ...oauthAccounts.map((account) => account.email)].filter(
+      (value) => value !== null && value !== undefined,
+    );
+    const parsed = values.map((value) => emailSchema.safeParse(value));
+    if (parsed.some((result) => !result.success)) {
+      return { status: "ambiguous_recipient" };
+    }
+    const unique = new Set(parsed.map((result) => (result.success ? result.data : "")));
+    if (unique.size === 0) {
+      return { status: "missing_recipient" };
+    }
+    if (unique.size !== 1) {
+      return { status: "ambiguous_recipient" };
+    }
+    return { status: "unique", email: [...unique][0] as string };
+  }
+}

--- a/src/repositories/optional-email-send-repo.ts
+++ b/src/repositories/optional-email-send-repo.ts
@@ -1,0 +1,235 @@
+import { Collection, MongoServerError, ObjectId } from "mongodb";
+import type { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import { InternalServerError } from "../lib/errors.js";
+import type { OptionalEmailSend } from "../models/documents.js";
+import { OptionalEmailReminderKind, OptionalEmailSendStatus } from "../types/optional-email.js";
+import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
+
+export type OptionalEmailSendReservation =
+  | { status: "reserved"; send: OptionalEmailSend }
+  | { status: "duplicate"; send: OptionalEmailSend }
+  | { status: "retry_expired"; send: OptionalEmailSend };
+
+export class OptionalEmailSendRepository {
+  readonly #collection: Collection<OptionalEmailSend>;
+
+  constructor(accessor: MongoDbAccessor) {
+    this.#collection = accessor.getCollection<OptionalEmailSend>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.OptionalEmailSends,
+    );
+  }
+
+  async reserve(input: {
+    sendKey: string;
+    userId: string;
+    campaignId: string;
+    reminderKind: OptionalEmailReminderKind;
+    at: Date;
+  }): Promise<OptionalEmailSendReservation> {
+    this.#validate(input);
+    const send: OptionalEmailSend = {
+      _id: new ObjectId(),
+      sendKey: input.sendKey,
+      userId: new ObjectId(input.userId),
+      campaignId: input.campaignId,
+      reminderKind: input.reminderKind,
+      status: OptionalEmailSendStatus.Reserved,
+      attemptCount: 0,
+      createdAt: input.at,
+      updatedAt: input.at,
+    };
+    try {
+      await this.#collection.insertOne(send);
+      return { status: "reserved", send };
+    } catch (error) {
+      if (!(error instanceof MongoServerError) || error.code !== 11000) {
+        throw error;
+      }
+      const existing = await this.findBySendKey({ sendKey: input.sendKey });
+      if (!existing) {
+        throw new InternalServerError({ debugMessage: "Optional email send reservation disappeared" });
+      }
+      if (existing.status === OptionalEmailSendStatus.Failed) {
+        const firstAttemptMs = existing.firstProviderAttemptAt?.getTime();
+        const retryAgeMs =
+          firstAttemptMs === undefined ? Number.POSITIVE_INFINITY : input.at.getTime() - firstAttemptMs;
+        if (retryAgeMs < 0 || retryAgeMs > 23 * 60 * 60 * 1_000) {
+          return { status: "retry_expired", send: existing };
+        }
+        const reclaimed = await this.#collection.findOneAndUpdate(
+          { _id: existing._id, status: OptionalEmailSendStatus.Failed },
+          { $set: { status: OptionalEmailSendStatus.Reserved, updatedAt: input.at } },
+          { returnDocument: "after" },
+        );
+        if (reclaimed) {
+          return { status: "reserved", send: reclaimed };
+        }
+        const raced = await this.findBySendKey({ sendKey: input.sendKey });
+        if (!raced) {
+          throw new InternalServerError({ debugMessage: "Optional email retry reservation disappeared" });
+        }
+        return { status: "duplicate", send: raced };
+      }
+      if (existing.status === OptionalEmailSendStatus.DeferredDailyLimit) {
+        const reclaimed = await this.#collection.findOneAndUpdate(
+          { _id: existing._id, status: OptionalEmailSendStatus.DeferredDailyLimit },
+          { $set: { status: OptionalEmailSendStatus.Reserved, updatedAt: input.at } },
+          { returnDocument: "after" },
+        );
+        if (reclaimed) {
+          return { status: "reserved", send: reclaimed };
+        }
+        const raced = await this.findBySendKey({ sendKey: input.sendKey });
+        if (!raced) {
+          throw new InternalServerError({ debugMessage: "Optional email deferred reservation disappeared" });
+        }
+        return { status: "duplicate", send: raced };
+      }
+      return { status: "duplicate", send: existing };
+    }
+  }
+
+  async findBySendKey(input: { sendKey: string }): Promise<OptionalEmailSend | null> {
+    if (!input.sendKey || input.sendKey.length > 256) {
+      return null;
+    }
+    return this.#collection.findOne({ sendKey: input.sendKey });
+  }
+
+  async markInFlight(input: { sendKey: string; at: Date }): Promise<boolean> {
+    if (!input.sendKey || input.sendKey.length > 256 || Number.isNaN(input.at.getTime())) {
+      return false;
+    }
+    const result = await this.#collection.updateOne(
+      { sendKey: input.sendKey, status: OptionalEmailSendStatus.Reserved },
+      [
+        {
+          $set: {
+            status: OptionalEmailSendStatus.InFlight,
+            firstProviderAttemptAt: { $ifNull: ["$firstProviderAttemptAt", input.at] },
+            lastProviderAttemptAt: input.at,
+            updatedAt: input.at,
+            attemptCount: { $add: ["$attemptCount", 1] },
+          },
+        },
+      ],
+    );
+    return result.modifiedCount === 1;
+  }
+
+  async markAccepted(input: { sendKey: string; providerEmailId: string; at: Date }): Promise<boolean> {
+    if (
+      !input.sendKey ||
+      input.sendKey.length > 256 ||
+      !input.providerEmailId ||
+      input.providerEmailId.length > 256 ||
+      Number.isNaN(input.at.getTime())
+    ) {
+      return false;
+    }
+    const result = await this.#collection.updateOne(
+      { sendKey: input.sendKey, status: OptionalEmailSendStatus.InFlight },
+      {
+        $set: {
+          status: OptionalEmailSendStatus.Accepted,
+          providerEmailId: input.providerEmailId,
+          acceptedAt: input.at,
+          updatedAt: input.at,
+        },
+      },
+    );
+    return result.modifiedCount === 1;
+  }
+
+  async markFailed(input: { sendKey: string; failureCode: string; at: Date }): Promise<boolean> {
+    if (
+      !input.sendKey ||
+      input.sendKey.length > 256 ||
+      !/^[a-z0-9_]{1,64}$/.test(input.failureCode) ||
+      Number.isNaN(input.at.getTime())
+    ) {
+      return false;
+    }
+    const result = await this.#collection.updateOne(
+      { sendKey: input.sendKey, status: OptionalEmailSendStatus.InFlight },
+      {
+        $set: {
+          status: OptionalEmailSendStatus.Failed,
+          lastFailureCode: input.failureCode,
+          updatedAt: input.at,
+        },
+      },
+    );
+    return result.modifiedCount === 1;
+  }
+
+  async markBlocked(input: { sendKey: string; reason: string; at: Date }): Promise<boolean> {
+    if (
+      !input.sendKey ||
+      input.sendKey.length > 256 ||
+      !/^[a-z_]{1,64}$/.test(input.reason) ||
+      Number.isNaN(input.at.getTime())
+    ) {
+      return false;
+    }
+    const result = await this.#collection.updateOne(
+      { sendKey: input.sendKey, status: OptionalEmailSendStatus.Reserved },
+      {
+        $set: {
+          status: OptionalEmailSendStatus.Blocked,
+          lastBlockReason: input.reason,
+          updatedAt: input.at,
+        },
+      },
+    );
+    return result.modifiedCount === 1;
+  }
+
+  async markDeferredForDailyLimit(input: { sendKey: string; at: Date }): Promise<boolean> {
+    if (!input.sendKey || input.sendKey.length > 256 || Number.isNaN(input.at.getTime())) {
+      return false;
+    }
+    const result = await this.#collection.updateOne(
+      { sendKey: input.sendKey, status: OptionalEmailSendStatus.Reserved },
+      {
+        $set: {
+          status: OptionalEmailSendStatus.DeferredDailyLimit,
+          lastDeferralReason: "daily_limit",
+          updatedAt: input.at,
+        },
+      },
+    );
+    return result.modifiedCount === 1;
+  }
+
+  async findUserIdByProviderEmailId(input: { providerEmailId: string }): Promise<string | null> {
+    if (!input.providerEmailId || input.providerEmailId.length > 256) {
+      return null;
+    }
+    const send = await this.#collection.findOne(
+      { providerEmailId: input.providerEmailId, status: OptionalEmailSendStatus.Accepted },
+      { projection: { userId: 1 } },
+    );
+    return send?.userId.toHexString() ?? null;
+  }
+
+  #validate(input: {
+    sendKey: string;
+    userId: string;
+    campaignId: string;
+    reminderKind: OptionalEmailReminderKind;
+    at: Date;
+  }): void {
+    if (
+      !input.sendKey ||
+      input.sendKey.length > 256 ||
+      !ObjectId.isValid(input.userId) ||
+      !/^[A-Za-z0-9_-]{1,64}$/.test(input.campaignId) ||
+      !Object.values(OptionalEmailReminderKind).includes(input.reminderKind) ||
+      Number.isNaN(input.at.getTime())
+    ) {
+      throw new InternalServerError({ debugMessage: "Invalid optional email send reservation" });
+    }
+  }
+}

--- a/src/repositories/optional-email-webhook-event-repo.ts
+++ b/src/repositories/optional-email-webhook-event-repo.ts
@@ -1,0 +1,48 @@
+import { Collection, ObjectId } from "mongodb";
+import type { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import { InternalServerError } from "../lib/errors.js";
+import type { OptionalEmailWebhookEvent } from "../models/documents.js";
+import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
+
+export class OptionalEmailWebhookEventRepository {
+  readonly #collection: Collection<OptionalEmailWebhookEvent>;
+
+  constructor(dbAccessor: MongoDbAccessor) {
+    this.#collection = dbAccessor.getCollection<OptionalEmailWebhookEvent>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.OptionalEmailWebhookEvents,
+    );
+  }
+
+  async wasProcessed(input: { eventId: string }): Promise<boolean> {
+    this.#validateEventId(input.eventId);
+    return (await this.#collection.countDocuments({ eventId: input.eventId }, { limit: 1 })) > 0;
+  }
+
+  async recordProcessed(input: { eventId: string; eventType: string; processedAt: Date }): Promise<boolean> {
+    this.#validateEventId(input.eventId);
+    if (!input.eventType || input.eventType.length > 128 || Number.isNaN(input.processedAt.getTime())) {
+      throw new InternalServerError({ debugMessage: "Invalid optional email webhook event" });
+    }
+    try {
+      await this.#collection.insertOne({
+        _id: new ObjectId(),
+        eventId: input.eventId,
+        eventType: input.eventType,
+        processedAt: input.processedAt,
+      });
+      return true;
+    } catch (error) {
+      if ((error as { code?: number }).code === 11000) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  #validateEventId(eventId: string): void {
+    if (!eventId || eventId.length > 256) {
+      throw new InternalServerError({ debugMessage: "Invalid optional email webhook event id" });
+    }
+  }
+}

--- a/src/routes/optional-email-unsubscribe.ts
+++ b/src/routes/optional-email-unsubscribe.ts
@@ -1,0 +1,61 @@
+import type { FastifyPluginAsync } from "fastify";
+import { z } from "zod";
+import type { OptionalEmailUnsubscribeService } from "../services/optional-email-unsubscribe-service.js";
+
+const querySchema = z.object({ token: z.string().min(1).max(2_048) }).strict();
+
+export type OptionalEmailUnsubscribeRouteOptions = {
+  service: OptionalEmailUnsubscribeService;
+};
+
+export const optionalEmailUnsubscribeRoutes: FastifyPluginAsync<OptionalEmailUnsubscribeRouteOptions> = async (
+  app,
+  options,
+) => {
+  app.addContentTypeParser(
+    "application/x-www-form-urlencoded",
+    { parseAs: "string", bodyLimit: 1_024 },
+    (_request, body, done) => done(null, body),
+  );
+
+  app.get("/email/optional/unsubscribe", async (request, reply) => {
+    const query = querySchema.safeParse(request.query);
+    if (!query.success || !options.service.isValid({ token: query.data.token })) {
+      return reply.status(400).type("text/plain; charset=utf-8").send("Invalid unsubscribe link");
+    }
+
+    const action = `/email/optional/unsubscribe?token=${encodeURIComponent(query.data.token)}`;
+    reply.header("Cache-Control", "no-store");
+    reply.header("X-Content-Type-Options", "nosniff");
+    return reply.type("text/html; charset=utf-8").send(`<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>Unsubscribe</title></head>
+  <body>
+    <main>
+      <h1>Unsubscribe from optional Sesori setup reminders</h1>
+      <p>Security and essential account messages are not affected.</p>
+      <form method="post" action="${action}">
+        <input type="hidden" name="List-Unsubscribe" value="One-Click">
+        <button type="submit">Unsubscribe</button>
+      </form>
+    </main>
+  </body>
+</html>`);
+  });
+
+  app.post("/email/optional/unsubscribe", async (request, reply) => {
+    const query = querySchema.safeParse(request.query);
+    const body = typeof request.body === "string" ? new URLSearchParams(request.body) : null;
+    const validBody =
+      body !== null &&
+      [...body.keys()].length === 1 &&
+      body.getAll("List-Unsubscribe").length === 1 &&
+      body.get("List-Unsubscribe") === "One-Click";
+    if (!query.success || !validBody || !(await options.service.unsubscribe({ token: query.data.token }))) {
+      return reply.status(400).type("text/plain; charset=utf-8").send("Invalid unsubscribe request");
+    }
+
+    reply.header("Cache-Control", "no-store");
+    return reply.status(200).type("text/plain; charset=utf-8").send("");
+  });
+};

--- a/src/routes/optional-email-webhook.ts
+++ b/src/routes/optional-email-webhook.ts
@@ -1,0 +1,59 @@
+import type { FastifyPluginAsync } from "fastify";
+import type { OptionalEmailWebhookService } from "../services/optional-email-webhook-service.js";
+import type { ResendWebhookVerifier } from "../services/resend-webhook-verifier.js";
+
+export type OptionalEmailWebhookRouteOptions = {
+  service: OptionalEmailWebhookService;
+  verifier: ResendWebhookVerifier;
+};
+
+export const optionalEmailWebhookRoutes: FastifyPluginAsync<OptionalEmailWebhookRouteOptions> = async (
+  app,
+  options,
+) => {
+  app.removeContentTypeParser("application/json");
+  app.addContentTypeParser(
+    "application/json",
+    { parseAs: "string", bodyLimit: 256 * 1_024 },
+    (_request, body, done) => {
+      done(null, body);
+    },
+  );
+
+  app.post("/webhooks/resend", async (request, reply) => {
+    const messageId = request.headers["svix-id"];
+    const timestamp = request.headers["svix-timestamp"];
+    const signature = request.headers["svix-signature"];
+    if (
+      typeof request.body !== "string" ||
+      typeof messageId !== "string" ||
+      typeof timestamp !== "string" ||
+      typeof signature !== "string"
+    ) {
+      return reply.status(400).type("text/plain; charset=utf-8").send("Invalid webhook");
+    }
+
+    let event: unknown;
+    try {
+      event = options.verifier.verify({ rawBody: request.body, messageId, timestamp, signature });
+    } catch {
+      return reply.status(400).type("text/plain; charset=utf-8").send("Invalid webhook");
+    }
+
+    let result;
+    try {
+      result = await options.service.handleVerified({ eventId: messageId, event });
+    } catch (error) {
+      if (error instanceof Error && error.message === "InvalidResendWebhookEvent") {
+        return reply.status(400).type("text/plain; charset=utf-8").send("Invalid webhook");
+      }
+      throw error;
+    }
+
+    if (result.status === "retry") {
+      reply.header("Retry-After", "60");
+      return reply.status(503).send();
+    }
+    return reply.status(204).send();
+  });
+};

--- a/src/scripts/dry-run-setup-reminders.ts
+++ b/src/scripts/dry-run-setup-reminders.ts
@@ -1,0 +1,166 @@
+import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import { MongoDbConnector } from "../db/mongo-db-connector.js";
+import { ActivationStateRepository } from "../repositories/activation-state-repo.js";
+import { OptionalEmailPreferenceRepository } from "../repositories/optional-email-preference-repo.js";
+import { OptionalEmailRecipientRepository } from "../repositories/optional-email-recipient-repo.js";
+import { UserRepository } from "../repositories/user-repo.js";
+import {
+  OptionalEmailDryRunService,
+  type OptionalEmailDryRunReport,
+} from "../services/optional-email-dry-run-service.js";
+import { OptionalEmailEligibilityService } from "../services/optional-email-eligibility-service.js";
+import { OPTIONAL_EMAIL_MAX_DAILY_CAP, OptionalEmailRecipientBasis } from "../types/optional-email.js";
+import { z } from "zod";
+import { pathToFileURL } from "node:url";
+
+export type OptionalEmailDryRunCliOptions = {
+  help: boolean;
+  batchLimit: number;
+};
+
+export type OptionalEmailDryRunRuntimeConfig = {
+  mongoUri: string;
+  sendingEnabled: boolean;
+  recipientBasis: OptionalEmailRecipientBasis;
+  dailyCap: number;
+};
+
+export type OptionalEmailDryRunRuntime = {
+  run(input: { batchLimit: number }): Promise<OptionalEmailDryRunReport>;
+  close(): Promise<void>;
+};
+
+export type OptionalEmailDryRunCliDependencies = {
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+  createRuntime: (config: OptionalEmailDryRunRuntimeConfig) => Promise<OptionalEmailDryRunRuntime>;
+};
+
+const DEFAULT_BATCH_LIMIT = 500;
+
+const disabledByDefaultBooleanSchema = z
+  .union([z.literal("true"), z.literal("false"), z.literal("1"), z.literal("0")])
+  .optional()
+  .transform((value) => value === "true" || value === "1");
+
+const optionalEmailDryRunEnvironmentSchema = z.object({
+  MONGODB_URI: z.string().min(1),
+  OPTIONAL_EMAIL_SENDING_ENABLED: disabledByDefaultBooleanSchema,
+  OPTIONAL_EMAIL_RECIPIENT_BASIS: z
+    .nativeEnum(OptionalEmailRecipientBasis)
+    .default(OptionalEmailRecipientBasis.Unapproved),
+  OPTIONAL_EMAIL_DAILY_CAP: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(OPTIONAL_EMAIL_MAX_DAILY_CAP)
+    .default(OPTIONAL_EMAIL_MAX_DAILY_CAP),
+});
+
+export async function createOptionalEmailDryRunRuntime(
+  config: OptionalEmailDryRunRuntimeConfig,
+): Promise<OptionalEmailDryRunRuntime> {
+  const connector = new MongoDbConnector({ connectionString: config.mongoUri });
+  const dbAccessor = new MongoDbAccessor(connector);
+  const users = new UserRepository(dbAccessor);
+  const activationStates = new ActivationStateRepository(dbAccessor);
+  const eligibility = new OptionalEmailEligibilityService({
+    policy: {
+      sendingEnabled: config.sendingEnabled,
+      recipientBasis: config.recipientBasis,
+    },
+    recipients: new OptionalEmailRecipientRepository(dbAccessor),
+    preferences: new OptionalEmailPreferenceRepository(dbAccessor),
+    activationStates,
+  });
+  const service = new OptionalEmailDryRunService({
+    users,
+    activationStates,
+    eligibility,
+    policy: {
+      sendingEnabled: config.sendingEnabled,
+      recipientBasis: config.recipientBasis,
+      dailyCap: config.dailyCap,
+    },
+  });
+  return {
+    run: (input) => service.run(input),
+    close: () => connector.close(),
+  };
+}
+
+export function parseOptionalEmailDryRunArgs(argv: string[]): OptionalEmailDryRunCliOptions {
+  const options: OptionalEmailDryRunCliOptions = { help: false, batchLimit: DEFAULT_BATCH_LIMIT };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--help" || argument === "-h") {
+      options.help = true;
+      continue;
+    }
+    let batchLimitValue: string | undefined;
+    if (argument === "--batch-limit") {
+      batchLimitValue = argv[index + 1];
+      index += 1;
+    } else if (argument.startsWith("--batch-limit=")) {
+      batchLimitValue = argument.slice("--batch-limit=".length);
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+    const batchLimit = Number(batchLimitValue);
+    if (!Number.isSafeInteger(batchLimit) || batchLimit < 1 || batchLimit > 1_000) {
+      throw new Error("--batch-limit must be an integer from 1 to 1000");
+    }
+    options.batchLimit = batchLimit;
+  }
+  return options;
+}
+
+export async function runOptionalEmailDryRunCli(
+  argv: string[],
+  env: NodeJS.ProcessEnv,
+  dependencies: OptionalEmailDryRunCliDependencies,
+): Promise<number> {
+  let options: OptionalEmailDryRunCliOptions;
+  try {
+    options = parseOptionalEmailDryRunArgs(argv);
+  } catch {
+    dependencies.stderr("Invalid optional-email dry-run arguments");
+    return 1;
+  }
+  if (options.help) {
+    dependencies.stdout("Usage: npm run optional-email:dry-run -- [--batch-limit 1..1000]");
+    return 0;
+  }
+  const config = optionalEmailDryRunEnvironmentSchema.safeParse(env);
+  if (!config.success) {
+    dependencies.stderr("Invalid optional-email dry-run configuration");
+    return 1;
+  }
+  let runtime: OptionalEmailDryRunRuntime | undefined;
+  try {
+    runtime = await dependencies.createRuntime({
+      mongoUri: config.data.MONGODB_URI,
+      sendingEnabled: config.data.OPTIONAL_EMAIL_SENDING_ENABLED,
+      recipientBasis: config.data.OPTIONAL_EMAIL_RECIPIENT_BASIS,
+      dailyCap: config.data.OPTIONAL_EMAIL_DAILY_CAP,
+    });
+    const report = await runtime.run({ batchLimit: options.batchLimit });
+    await runtime.close();
+    dependencies.stdout(JSON.stringify(report));
+    return 0;
+  } catch {
+    if (runtime) {
+      await runtime.close().catch(() => undefined);
+    }
+    dependencies.stderr("Optional-email dry-run failed");
+    return 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = await runOptionalEmailDryRunCli(process.argv.slice(2), process.env, {
+    stdout: (line) => process.stdout.write(`${line}\n`),
+    stderr: (line) => process.stderr.write(`${line}\n`),
+    createRuntime: createOptionalEmailDryRunRuntime,
+  });
+}

--- a/src/scripts/send-test-setup-reminder.ts
+++ b/src/scripts/send-test-setup-reminder.ts
@@ -1,0 +1,234 @@
+import { pathToFileURL } from "node:url";
+import { z } from "zod";
+import { ResendOptionalEmailAdapter } from "../clients/resend-optional-email-adapter.js";
+import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import { MongoDbConnector } from "../db/mongo-db-connector.js";
+import { ActivationStateRepository } from "../repositories/activation-state-repo.js";
+import { OptionalEmailDailyQuotaRepository } from "../repositories/optional-email-daily-quota-repo.js";
+import { OptionalEmailPreferenceRepository } from "../repositories/optional-email-preference-repo.js";
+import { OptionalEmailRecipientRepository } from "../repositories/optional-email-recipient-repo.js";
+import { OptionalEmailSendRepository } from "../repositories/optional-email-send-repo.js";
+import { OptionalEmailDeliveryService } from "../services/optional-email-delivery-service.js";
+import type { OptionalEmailDeliveryResult } from "../services/optional-email-delivery-service.js";
+import { OptionalEmailEligibilityService } from "../services/optional-email-eligibility-service.js";
+import { OptionalEmailUnsubscribeTokenService } from "../services/optional-email-unsubscribe-service.js";
+import {
+  OPTIONAL_EMAIL_MAX_DAILY_CAP,
+  OptionalEmailRecipientBasis,
+  OptionalEmailReminderKind,
+} from "../types/optional-email.js";
+
+export type OptionalEmailTestSendRuntimeConfig = {
+  mongoUri: string;
+  resendApiKey: string;
+  webhookSigningSecret: string;
+  unsubscribeSigningSecret: string;
+  publicBaseUrl: string;
+  from: "Sesori <hello@updates.sesori.com>";
+  replyTo: "hello@sesori.com";
+  testRecipient: "alex@sesori.com";
+  dailyCap: number;
+  recipientBasis: OptionalEmailRecipientBasis.AccountActivityApproved;
+};
+
+export type OptionalEmailTestSendRuntime = {
+  send(input: {
+    userId: string;
+    operationId: string;
+    template: OptionalEmailReminderKind;
+    recipient: string;
+  }): Promise<OptionalEmailDeliveryResult>;
+  close(): Promise<void>;
+};
+
+export type OptionalEmailTestSendCliDependencies = {
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+  createRuntime: (config: OptionalEmailTestSendRuntimeConfig) => Promise<OptionalEmailTestSendRuntime>;
+};
+
+const testSendEnvironmentSchema = z.object({
+  MONGODB_URI: z.string().min(1),
+  OPTIONAL_EMAIL_RECIPIENT_BASIS: z.literal(OptionalEmailRecipientBasis.AccountActivityApproved),
+  OPTIONAL_EMAIL_DAILY_CAP: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(OPTIONAL_EMAIL_MAX_DAILY_CAP)
+    .default(OPTIONAL_EMAIL_MAX_DAILY_CAP),
+  RESEND_API_KEY: z.string().min(1),
+  RESEND_WEBHOOK_SECRET: z
+    .string()
+    .min(32)
+    .regex(/^whsec_[A-Za-z0-9+/]+={0,2}$/),
+  OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET: z.string().min(32),
+  AUTH_BASE_URL: z.string().url().startsWith("https://"),
+  RESEND_FROM: z.literal("Sesori <hello@updates.sesori.com>").default("Sesori <hello@updates.sesori.com>"),
+  RESEND_REPLY_TO: z.literal("hello@sesori.com").default("hello@sesori.com"),
+  RESEND_TEST_RECIPIENT: z.literal("alex@sesori.com").default("alex@sesori.com"),
+});
+
+export async function createOptionalEmailTestSendRuntime(
+  config: OptionalEmailTestSendRuntimeConfig,
+  options: { fetchFn?: typeof fetch } = {},
+): Promise<OptionalEmailTestSendRuntime> {
+  const connector = new MongoDbConnector({ connectionString: config.mongoUri });
+  const dbAccessor = new MongoDbAccessor(connector);
+  const preferenceRepo = new OptionalEmailPreferenceRepository(dbAccessor);
+  const eligibility = new OptionalEmailEligibilityService({
+    policy: {
+      sendingEnabled: true,
+      recipientBasis: config.recipientBasis,
+    },
+    recipients: new OptionalEmailRecipientRepository(dbAccessor),
+    preferences: preferenceRepo,
+    activationStates: new ActivationStateRepository(dbAccessor),
+  });
+  const delivery = new OptionalEmailDeliveryService({
+    eligibility,
+    sendRepo: new OptionalEmailSendRepository(dbAccessor),
+    quotaRepo: new OptionalEmailDailyQuotaRepository(dbAccessor),
+    provider: new ResendOptionalEmailAdapter({
+      apiKey: config.resendApiKey,
+      ...(options.fetchFn ? { fetchFn: options.fetchFn } : {}),
+    }),
+    tokenService: new OptionalEmailUnsubscribeTokenService({
+      signingSecret: Buffer.from(config.unsubscribeSigningSecret, "utf8"),
+    }),
+    policy: {
+      from: config.from,
+      replyTo: config.replyTo,
+      publicBaseUrl: config.publicBaseUrl,
+      dailyCap: config.dailyCap,
+      testRecipient: config.testRecipient,
+      testSendEnabled: true,
+    },
+  });
+
+  return {
+    send: ({ userId, operationId, template, recipient }) =>
+      delivery.sendTest({
+        userId,
+        operationId,
+        templateKind: template,
+        recipient,
+      }),
+    close: () => connector.close(),
+  };
+}
+
+export async function runOptionalEmailTestSendCli(
+  _argv: string[],
+  env: NodeJS.ProcessEnv,
+  dependencies: OptionalEmailTestSendCliDependencies,
+): Promise<number> {
+  if (_argv.includes("--help") || _argv.includes("-h")) {
+    dependencies.stdout(
+      "Usage: npm run optional-email:test-send -- --user-id <id> --operation-id <slug> --template <bridge_setup|first_session> --confirm-recipient alex@sesori.com --confirm-send SEND_ONE_TEST_EMAIL",
+    );
+    return 0;
+  }
+
+  if (env.OPTIONAL_EMAIL_SENDING_ENABLED !== "true" || env.OPTIONAL_EMAIL_TEST_SEND_ENABLED !== "true") {
+    dependencies.stderr("Optional-email test send is disabled");
+    return 1;
+  }
+
+  const config = testSendEnvironmentSchema.safeParse(env);
+  if (!config.success) {
+    dependencies.stderr("Optional-email test send configuration is incomplete");
+    return 1;
+  }
+
+  const expectedFlags = new Set(["--user-id", "--operation-id", "--template", "--confirm-recipient", "--confirm-send"]);
+  const suppliedFlags = _argv.filter((_argument, index) => index % 2 === 0);
+  if (
+    _argv.length !== expectedFlags.size * 2 ||
+    suppliedFlags.length !== expectedFlags.size ||
+    new Set(suppliedFlags).size !== expectedFlags.size ||
+    suppliedFlags.some((flag) => !expectedFlags.has(flag))
+  ) {
+    dependencies.stderr("Invalid optional-email test-send arguments");
+    return 1;
+  }
+
+  const recipientFlagIndex = _argv.indexOf("--confirm-recipient");
+  if (recipientFlagIndex < 0 || _argv[recipientFlagIndex + 1] !== config.data.RESEND_TEST_RECIPIENT) {
+    dependencies.stderr("Invalid optional-email test-send arguments");
+    return 1;
+  }
+
+  const confirmationFlagIndex = _argv.indexOf("--confirm-send");
+  if (confirmationFlagIndex < 0 || _argv[confirmationFlagIndex + 1] !== "SEND_ONE_TEST_EMAIL") {
+    dependencies.stderr("Invalid optional-email test-send arguments");
+    return 1;
+  }
+
+  const userIdFlagIndex = _argv.indexOf("--user-id");
+  const userId = _argv[userIdFlagIndex + 1];
+  if (userIdFlagIndex < 0 || !userId || !/^[a-f\d]{24}$/i.test(userId)) {
+    dependencies.stderr("Invalid optional-email test-send arguments");
+    return 1;
+  }
+
+  const operationIdFlagIndex = _argv.indexOf("--operation-id");
+  const operationId = _argv[operationIdFlagIndex + 1];
+  if (operationIdFlagIndex < 0 || !operationId || !/^[a-z0-9][a-z0-9_-]{0,47}$/.test(operationId)) {
+    dependencies.stderr("Invalid optional-email test-send arguments");
+    return 1;
+  }
+
+  const templateFlagIndex = _argv.indexOf("--template");
+  const template = _argv[templateFlagIndex + 1];
+  if (
+    templateFlagIndex < 0 ||
+    (template !== OptionalEmailReminderKind.BridgeSetup && template !== OptionalEmailReminderKind.FirstSession)
+  ) {
+    dependencies.stderr("Invalid optional-email test-send arguments");
+    return 1;
+  }
+
+  let runtime: OptionalEmailTestSendRuntime | undefined;
+  try {
+    runtime = await dependencies.createRuntime({
+      mongoUri: config.data.MONGODB_URI,
+      resendApiKey: config.data.RESEND_API_KEY,
+      webhookSigningSecret: config.data.RESEND_WEBHOOK_SECRET,
+      unsubscribeSigningSecret: config.data.OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET,
+      publicBaseUrl: config.data.AUTH_BASE_URL,
+      from: config.data.RESEND_FROM,
+      replyTo: config.data.RESEND_REPLY_TO,
+      testRecipient: config.data.RESEND_TEST_RECIPIENT,
+      dailyCap: config.data.OPTIONAL_EMAIL_DAILY_CAP,
+      recipientBasis: config.data.OPTIONAL_EMAIL_RECIPIENT_BASIS,
+    });
+    const result = await runtime.send({
+      userId,
+      operationId,
+      template,
+      recipient: config.data.RESEND_TEST_RECIPIENT,
+    });
+    await runtime.close();
+    runtime = undefined;
+    dependencies.stdout(JSON.stringify(result));
+    return 0;
+  } catch {
+    if (runtime) {
+      try {
+        await runtime.close();
+      } catch {
+        // Preserve the original failure while still keeping output sanitized.
+      }
+    }
+    dependencies.stderr("Optional-email test send failed");
+    return 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = await runOptionalEmailTestSendCli(process.argv.slice(2), process.env, {
+    stdout: (line) => process.stdout.write(`${line}\n`),
+    stderr: (line) => process.stderr.write(`${line}\n`),
+    createRuntime: createOptionalEmailTestSendRuntime,
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,7 @@ import type { PendingAuthStore } from "./services/pending-auth-store.js";
 import type { AppClientPresenceService } from "./services/app-client-presence-service.js";
 import type { ProductAnalyticsPreferenceService } from "./services/product-analytics-preference-service.js";
 import type { SettingsService } from "./services/settings-service.js";
+import type { OptionalEmailRouteServices } from "./optional-email-composition.js";
 import { installRoutes } from "./routes/install.js";
 import { legalRoutes } from "./routes/legal.js";
 import { tokenRoutes } from "./routes/token.js";
@@ -43,6 +44,8 @@ import { sessionStatusRoutes } from "./routes/auth/session-status.js";
 import { appClientRoutes } from "./routes/app-clients.js";
 import { productAnalyticsRoutes } from "./routes/product-analytics.js";
 import { settingsRoutes } from "./routes/settings/settings.js";
+import { optionalEmailUnsubscribeRoutes } from "./routes/optional-email-unsubscribe.js";
+import { optionalEmailWebhookRoutes } from "./routes/optional-email-webhook.js";
 import { voiceRealtimeRoutes, type VoiceRealtimeRouteOptions } from "./routes/voice-realtime.js";
 import { MAX_TRANSPORT_PAYLOAD_BYTES } from "./routes/voice-realtime-support.js";
 
@@ -68,6 +71,7 @@ export type AppServices = {
   appleNativeVerifier: AppleNativeVerifier;
   pendingAuthStore: PendingAuthStore;
   productAnalyticsPreferenceService: ProductAnalyticsPreferenceService;
+  optionalEmail?: OptionalEmailRouteServices;
   realtime?: Omit<VoiceRealtimeRouteOptions, "preAuthRateLimit" | "requireAuth">;
 };
 
@@ -162,6 +166,16 @@ export async function buildApp(services: AppServices): Promise<FastifyInstance> 
   await app.register(legalRoutes, {
     legalDocumentService: services.legalDocumentService,
   });
+
+  if (services.optionalEmail?.unsubscribeService) {
+    await app.register(optionalEmailUnsubscribeRoutes, {
+      service: services.optionalEmail.unsubscribeService,
+    });
+  }
+
+  if (services.optionalEmail?.webhook) {
+    await app.register(optionalEmailWebhookRoutes, services.optionalEmail.webhook);
+  }
 
   const requireAuth = createAuthMiddleware(services.tokenService, {
     devBypassEnabled: services.config.AUTH_DEV_BYPASS_ENABLED,

--- a/src/services/optional-email-delivery-service.ts
+++ b/src/services/optional-email-delivery-service.ts
@@ -1,0 +1,235 @@
+import { createHash } from "node:crypto";
+import {
+  type OptionalEmailProvider,
+  ResendOptionalEmailError,
+  type ResendOptionalEmailErrorCode,
+} from "../clients/resend-optional-email-adapter.js";
+import type { OptionalEmailDailyQuotaRepository } from "../repositories/optional-email-daily-quota-repo.js";
+import type { OptionalEmailSendRepository } from "../repositories/optional-email-send-repo.js";
+import type { OptionalEmailEligibilityResult } from "./optional-email-eligibility-service.js";
+import {
+  buildOptionalEmailUnsubscribeHeaders,
+  type OptionalEmailUnsubscribeTokenService,
+} from "./optional-email-unsubscribe-service.js";
+import { OptionalEmailReminderKind } from "../types/optional-email.js";
+
+interface OptionalEmailEligibilityCheck {
+  evaluate(input: { userId: string; reminderKind: OptionalEmailReminderKind }): Promise<OptionalEmailEligibilityResult>;
+}
+
+export type OptionalEmailDeliveryResult =
+  | { status: "sent"; sendKey: string; providerEmailId: string }
+  | { status: "blocked"; reason: string; sendKey?: string }
+  | { status: "duplicate"; sendKey: string }
+  | { status: "daily_limit"; sendKey: string }
+  | { status: "provider_failed"; sendKey: string; code: ResendOptionalEmailErrorCode };
+
+export class OptionalEmailDeliveryService {
+  readonly #eligibility: OptionalEmailEligibilityCheck;
+  readonly #sendRepo: OptionalEmailSendRepository;
+  readonly #quotaRepo: OptionalEmailDailyQuotaRepository;
+  readonly #provider: OptionalEmailProvider;
+  readonly #tokenService: OptionalEmailUnsubscribeTokenService;
+  readonly #policy: {
+    from: string;
+    replyTo: string;
+    publicBaseUrl: string;
+    dailyCap: number;
+    testRecipient: string;
+    testSendEnabled: boolean;
+  };
+  readonly #clock: () => Date;
+
+  constructor(input: {
+    eligibility: OptionalEmailEligibilityCheck;
+    sendRepo: OptionalEmailSendRepository;
+    quotaRepo: OptionalEmailDailyQuotaRepository;
+    provider: OptionalEmailProvider;
+    tokenService: OptionalEmailUnsubscribeTokenService;
+    policy: {
+      from: string;
+      replyTo: string;
+      publicBaseUrl: string;
+      dailyCap: number;
+      testRecipient: string;
+      testSendEnabled: boolean;
+    };
+    clock?: () => Date;
+  }) {
+    this.#eligibility = input.eligibility;
+    this.#sendRepo = input.sendRepo;
+    this.#quotaRepo = input.quotaRepo;
+    this.#provider = input.provider;
+    this.#tokenService = input.tokenService;
+    this.#policy = input.policy;
+    this.#clock = input.clock ?? (() => new Date());
+  }
+
+  async sendReminder(input: {
+    userId: string;
+    campaignId: string;
+    reminderKind: OptionalEmailReminderKind;
+  }): Promise<OptionalEmailDeliveryResult> {
+    return this.#deliverReminder(input);
+  }
+
+  async #deliverReminder(input: {
+    userId: string;
+    campaignId: string;
+    reminderKind: OptionalEmailReminderKind;
+    requiredRecipient?: string;
+  }): Promise<OptionalEmailDeliveryResult> {
+    const firstEligibility = await this.#eligibility.evaluate({
+      userId: input.userId,
+      reminderKind: input.reminderKind,
+    });
+    if (!firstEligibility.eligible) {
+      return { status: "blocked", reason: firstEligibility.reason };
+    }
+    if (input.requiredRecipient && firstEligibility.recipient.trim().toLowerCase() !== input.requiredRecipient) {
+      return { status: "blocked", reason: "test_recipient_not_allowed" };
+    }
+
+    const sendKey = buildSendKey(input);
+    const now = this.#clock();
+    const reservation = await this.#sendRepo.reserve({ ...input, sendKey, at: now });
+    if (reservation.status === "duplicate") {
+      return { status: "duplicate", sendKey };
+    }
+    if (reservation.status === "retry_expired") {
+      return { status: "blocked", reason: "retry_window_expired" };
+    }
+    const quota = await this.#quotaRepo.reserve({ at: now, dailyCap: this.#policy.dailyCap });
+    if (!quota.reserved) {
+      if (!(await this.#sendRepo.markDeferredForDailyLimit({ sendKey, at: this.#clock() }))) {
+        throw new Error("OptionalEmailDailyLimitHistoryWriteFailed");
+      }
+      return { status: "daily_limit", sendKey };
+    }
+
+    const finalEligibility = await this.#eligibility.evaluate({
+      userId: input.userId,
+      reminderKind: input.reminderKind,
+    });
+    if (!finalEligibility.eligible) {
+      if (
+        !(await this.#sendRepo.markBlocked({
+          sendKey,
+          reason: finalEligibility.reason,
+          at: this.#clock(),
+        }))
+      ) {
+        throw new Error("OptionalEmailBlockedHistoryWriteFailed");
+      }
+      return { status: "blocked", reason: finalEligibility.reason, sendKey };
+    }
+    if (input.requiredRecipient && finalEligibility.recipient.trim().toLowerCase() !== input.requiredRecipient) {
+      if (
+        !(await this.#sendRepo.markBlocked({
+          sendKey,
+          reason: "test_recipient_not_allowed",
+          at: this.#clock(),
+        }))
+      ) {
+        throw new Error("OptionalEmailBlockedHistoryWriteFailed");
+      }
+      return { status: "blocked", reason: "test_recipient_not_allowed", sendKey };
+    }
+    if (!(await this.#sendRepo.markInFlight({ sendKey, at: this.#clock() }))) {
+      throw new Error("OptionalEmailSendClaimLost");
+    }
+
+    const token = this.#tokenService.create({ userId: input.userId });
+    const headers = buildOptionalEmailUnsubscribeHeaders({
+      publicBaseUrl: this.#policy.publicBaseUrl,
+      token,
+    });
+    const unsubscribeUrl = headers["List-Unsubscribe"].slice(1, -1);
+    const content = buildReminderContent(input.reminderKind, unsubscribeUrl);
+    let providerResult: { providerEmailId: string };
+    try {
+      providerResult = await this.#provider.send({
+        idempotencyKey: sendKey,
+        from: this.#policy.from,
+        replyTo: this.#policy.replyTo,
+        recipient: finalEligibility.recipient,
+        subject: content.subject,
+        html: content.html,
+        text: content.text,
+        headers,
+        tags: [
+          { name: "category", value: "optional_setup_reminder" },
+          { name: "campaign", value: input.campaignId },
+        ],
+      });
+    } catch (error) {
+      const code: ResendOptionalEmailErrorCode = error instanceof ResendOptionalEmailError ? error.code : "unavailable";
+      if (!(await this.#sendRepo.markFailed({ sendKey, failureCode: code, at: this.#clock() }))) {
+        throw new Error("OptionalEmailFailedHistoryWriteFailed", { cause: error });
+      }
+      return { status: "provider_failed", sendKey, code };
+    }
+    if (
+      !(await this.#sendRepo.markAccepted({
+        sendKey,
+        providerEmailId: providerResult.providerEmailId,
+        at: this.#clock(),
+      }))
+    ) {
+      throw new Error("OptionalEmailAcceptedHistoryWriteFailed");
+    }
+    return { status: "sent", sendKey, providerEmailId: providerResult.providerEmailId };
+  }
+
+  async sendTest(_input: {
+    userId: string;
+    recipient: string;
+    operationId: string;
+    templateKind: OptionalEmailReminderKind;
+  }): Promise<OptionalEmailDeliveryResult> {
+    if (!this.#policy.testSendEnabled) {
+      return { status: "blocked", reason: "test_sending_disabled" };
+    }
+    const pinnedRecipient = "alex@sesori.com";
+    if (
+      this.#policy.testRecipient.trim().toLowerCase() !== pinnedRecipient ||
+      _input.recipient.trim().toLowerCase() !== pinnedRecipient
+    ) {
+      return { status: "blocked", reason: "test_recipient_not_allowed" };
+    }
+    return this.#deliverReminder({
+      userId: _input.userId,
+      campaignId: `test_${_input.operationId}`,
+      reminderKind: _input.templateKind,
+      requiredRecipient: pinnedRecipient,
+    });
+  }
+}
+
+function buildSendKey(input: { userId: string; campaignId: string; reminderKind: OptionalEmailReminderKind }): string {
+  const digest = createHash("sha256")
+    .update(`${input.campaignId}\u0000${input.userId}\u0000${input.reminderKind}`, "utf8")
+    .digest("hex");
+  return `optional/${digest}`;
+}
+
+function buildReminderContent(
+  reminderKind: OptionalEmailReminderKind,
+  unsubscribeUrl: string,
+): { subject: string; html: string; text: string } {
+  const message =
+    reminderKind === OptionalEmailReminderKind.FirstSession
+      ? {
+          subject: "Run your first coding session with Sesori",
+          sentence: "Run your first coding session through the Sesori Bridge.",
+        }
+      : {
+          subject: "Finish setting up Sesori",
+          sentence: "Finish connecting your coding setup to Sesori.",
+        };
+  return {
+    subject: message.subject,
+    html: `<p>${message.sentence}</p><p><a href="${unsubscribeUrl}">Unsubscribe</a> from optional setup reminders.</p>`,
+    text: `${message.sentence}\n\nUnsubscribe: ${unsubscribeUrl}`,
+  };
+}

--- a/src/services/optional-email-dry-run-service.ts
+++ b/src/services/optional-email-dry-run-service.ts
@@ -1,0 +1,115 @@
+import type { ActivationState } from "../models/documents.js";
+import type { OptionalEmailEligibilityResult } from "./optional-email-eligibility-service.js";
+import type { OptionalEmailRecipientBasis } from "../types/optional-email.js";
+import { OptionalEmailReminderKind } from "../types/optional-email.js";
+
+interface OptionalEmailDryRunUserLookup {
+  findIdBatch(afterUserId: string | null, batchLimit: number, createdAtOrBefore: Date): Promise<string[]>;
+}
+
+interface OptionalEmailDryRunActivationLookup {
+  findByUserId(userId: string): Promise<ActivationState | null>;
+}
+
+interface OptionalEmailDryRunEligibility {
+  evaluateDryRun(input: {
+    userId: string;
+    reminderKind: OptionalEmailReminderKind;
+  }): Promise<OptionalEmailEligibilityResult>;
+}
+
+export type OptionalEmailDryRunReport = {
+  mode: "dry_run";
+  generatedAt: string;
+  sendingEnabled: boolean;
+  recipientBasis: OptionalEmailRecipientBasis;
+  dailyCap: number;
+  usersScanned: number;
+  candidates: number;
+  segments: Record<OptionalEmailReminderKind, number>;
+  eligible: number;
+  blockedByReason: Record<string, number>;
+};
+
+export class OptionalEmailDryRunService {
+  readonly #users: OptionalEmailDryRunUserLookup;
+  readonly #activationStates: OptionalEmailDryRunActivationLookup;
+  readonly #eligibility: OptionalEmailDryRunEligibility;
+  readonly #policy: {
+    sendingEnabled: boolean;
+    recipientBasis: OptionalEmailRecipientBasis;
+    dailyCap: number;
+  };
+  readonly #clock: () => Date;
+
+  constructor(input: {
+    users: OptionalEmailDryRunUserLookup;
+    activationStates: OptionalEmailDryRunActivationLookup;
+    eligibility: OptionalEmailDryRunEligibility;
+    policy: {
+      sendingEnabled: boolean;
+      recipientBasis: OptionalEmailRecipientBasis;
+      dailyCap: number;
+    };
+    clock?: () => Date;
+  }) {
+    this.#users = input.users;
+    this.#activationStates = input.activationStates;
+    this.#eligibility = input.eligibility;
+    this.#policy = input.policy;
+    this.#clock = input.clock ?? (() => new Date());
+  }
+
+  async run(input: { batchLimit: number }): Promise<OptionalEmailDryRunReport> {
+    if (!Number.isSafeInteger(input.batchLimit) || input.batchLimit < 1 || input.batchLimit > 1_000) {
+      throw new Error("InvalidOptionalEmailDryRunBatchLimit");
+    }
+    const generatedAt = this.#clock();
+    const report: OptionalEmailDryRunReport = {
+      mode: "dry_run",
+      generatedAt: generatedAt.toISOString(),
+      sendingEnabled: this.#policy.sendingEnabled,
+      recipientBasis: this.#policy.recipientBasis,
+      dailyCap: this.#policy.dailyCap,
+      usersScanned: 0,
+      candidates: 0,
+      segments: {
+        [OptionalEmailReminderKind.BridgeSetup]: 0,
+        [OptionalEmailReminderKind.FirstSession]: 0,
+      },
+      eligible: 0,
+      blockedByReason: {},
+    };
+
+    let afterUserId: string | null = null;
+    while (true) {
+      const userIds = await this.#users.findIdBatch(afterUserId, input.batchLimit, generatedAt);
+      if (userIds.length === 0) {
+        break;
+      }
+      for (const userId of userIds) {
+        report.usersScanned += 1;
+        const state = await this.#activationStates.findByUserId(userId);
+        if (state?.firstSessionAt) {
+          continue;
+        }
+        const reminderKind = state?.bridgeSetupAt
+          ? OptionalEmailReminderKind.FirstSession
+          : OptionalEmailReminderKind.BridgeSetup;
+        report.candidates += 1;
+        report.segments[reminderKind] += 1;
+        const eligibility = await this.#eligibility.evaluateDryRun({ userId, reminderKind });
+        if (eligibility.eligible) {
+          report.eligible += 1;
+        } else {
+          report.blockedByReason[eligibility.reason] = (report.blockedByReason[eligibility.reason] ?? 0) + 1;
+        }
+      }
+      afterUserId = userIds.at(-1) ?? null;
+      if (userIds.length < input.batchLimit) {
+        break;
+      }
+    }
+    return report;
+  }
+}

--- a/src/services/optional-email-eligibility-service.ts
+++ b/src/services/optional-email-eligibility-service.ts
@@ -1,0 +1,100 @@
+import type { ActivationState } from "../models/documents.js";
+import type { OptionalEmailBlockReason, OptionalEmailRecipientBasis } from "../types/optional-email.js";
+import { OptionalEmailRecipientBasis as RecipientBasis, OptionalEmailReminderKind } from "../types/optional-email.js";
+
+export type OptionalEmailRecipientResolution =
+  | { status: "unique"; email: string }
+  | { status: "missing_user" | "missing_recipient" | "ambiguous_recipient" };
+
+export interface OptionalEmailRecipientLookup {
+  resolve(input: { userId: string }): Promise<OptionalEmailRecipientResolution>;
+}
+
+export interface OptionalEmailPreferenceLookup {
+  findBlockReason(input: { userId: string }): Promise<OptionalEmailBlockReason | null>;
+}
+
+export interface OptionalEmailActivationStateLookup {
+  findByUserId(userId: string): Promise<ActivationState | null>;
+}
+
+export type OptionalEmailEligibilityResult =
+  | { eligible: true; recipient: string }
+  | {
+      eligible: false;
+      reason:
+        | "sending_disabled"
+        | "recipient_basis_unapproved"
+        | "missing_user"
+        | "missing_recipient"
+        | "ambiguous_recipient"
+        | "milestone_completed"
+        | "prerequisite_incomplete"
+        | OptionalEmailBlockReason;
+    };
+
+export class OptionalEmailEligibilityService {
+  readonly #policy: { sendingEnabled: boolean; recipientBasis: OptionalEmailRecipientBasis };
+  readonly #preferences: OptionalEmailPreferenceLookup;
+  readonly #activationStates: OptionalEmailActivationStateLookup;
+  readonly #recipients: OptionalEmailRecipientLookup;
+
+  constructor(input: {
+    policy: { sendingEnabled: boolean; recipientBasis: OptionalEmailRecipientBasis };
+    recipients: OptionalEmailRecipientLookup;
+    preferences: OptionalEmailPreferenceLookup;
+    activationStates: OptionalEmailActivationStateLookup;
+  }) {
+    this.#policy = input.policy;
+    this.#preferences = input.preferences;
+    this.#activationStates = input.activationStates;
+    this.#recipients = input.recipients;
+  }
+
+  async evaluate(input: {
+    userId: string;
+    reminderKind: OptionalEmailReminderKind;
+  }): Promise<OptionalEmailEligibilityResult> {
+    return this.#evaluate(input, true);
+  }
+
+  async evaluateDryRun(input: {
+    userId: string;
+    reminderKind: OptionalEmailReminderKind;
+  }): Promise<OptionalEmailEligibilityResult> {
+    return this.#evaluate(input, false);
+  }
+
+  async #evaluate(
+    _input: { userId: string; reminderKind: OptionalEmailReminderKind },
+    enforceSendingEnabled: boolean,
+  ): Promise<OptionalEmailEligibilityResult> {
+    if (enforceSendingEnabled && !this.#policy.sendingEnabled) {
+      return { eligible: false, reason: "sending_disabled" };
+    }
+    if (this.#policy.recipientBasis !== RecipientBasis.AccountActivityApproved) {
+      return { eligible: false, reason: "recipient_basis_unapproved" };
+    }
+    const blockReason = await this.#preferences.findBlockReason({ userId: _input.userId });
+    if (blockReason) {
+      return { eligible: false, reason: blockReason };
+    }
+    const state = await this.#activationStates.findByUserId(_input.userId);
+    if (_input.reminderKind === OptionalEmailReminderKind.BridgeSetup && state?.bridgeSetupAt) {
+      return { eligible: false, reason: "milestone_completed" };
+    }
+    if (_input.reminderKind === OptionalEmailReminderKind.FirstSession) {
+      if (state?.firstSessionAt) {
+        return { eligible: false, reason: "milestone_completed" };
+      }
+      if (!state?.bridgeSetupAt) {
+        return { eligible: false, reason: "prerequisite_incomplete" };
+      }
+    }
+    const recipient = await this.#recipients.resolve({ userId: _input.userId });
+    if (recipient.status !== "unique") {
+      return { eligible: false, reason: recipient.status };
+    }
+    return { eligible: true, recipient: recipient.email };
+  }
+}

--- a/src/services/optional-email-unsubscribe-service.ts
+++ b/src/services/optional-email-unsubscribe-service.ts
@@ -1,0 +1,107 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { ObjectId } from "mongodb";
+import { z } from "zod";
+import type { OptionalEmailPreferenceRepository } from "../repositories/optional-email-preference-repo.js";
+
+const TOKEN_VERSION = "v1";
+const tokenPayloadSchema = z
+  .object({
+    purpose: z.literal("optional_email_unsubscribe"),
+    userId: z.string().regex(/^[a-f0-9]{24}$/),
+  })
+  .strict();
+
+export class OptionalEmailUnsubscribeTokenService {
+  readonly #signingSecret: Buffer;
+
+  constructor(input: { signingSecret: Buffer }) {
+    if (input.signingSecret.byteLength < 32) {
+      throw new Error("OptionalEmailUnsubscribeSigningSecretTooShort");
+    }
+    this.#signingSecret = Buffer.from(input.signingSecret);
+  }
+
+  create(input: { userId: string }): string {
+    if (!ObjectId.isValid(input.userId)) {
+      throw new Error("InvalidOptionalEmailUnsubscribeUserId");
+    }
+    const payload = Buffer.from(
+      JSON.stringify({ purpose: "optional_email_unsubscribe", userId: input.userId.toLowerCase() }),
+      "utf8",
+    ).toString("base64url");
+    const unsigned = `${TOKEN_VERSION}.${payload}`;
+    return `${unsigned}.${this.#signatureFor(unsigned)}`;
+  }
+
+  verify(input: { token: string }): string | null {
+    const parts = input.token.split(".");
+    if (parts.length !== 3 || parts[0] !== TOKEN_VERSION) {
+      return null;
+    }
+
+    const unsigned = `${parts[0]}.${parts[1]}`;
+    const expected = Buffer.from(this.#signatureFor(unsigned), "base64url");
+    let actual: Buffer;
+    try {
+      actual = Buffer.from(parts[2] ?? "", "base64url");
+    } catch {
+      return null;
+    }
+    if (actual.byteLength !== expected.byteLength || !timingSafeEqual(actual, expected)) {
+      return null;
+    }
+
+    try {
+      const decoded = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString("utf8")) as unknown;
+      const result = tokenPayloadSchema.safeParse(decoded);
+      return result.success ? result.data.userId : null;
+    } catch {
+      return null;
+    }
+  }
+
+  #signatureFor(unsigned: string): string {
+    return createHmac("sha256", this.#signingSecret).update(unsigned, "utf8").digest("base64url");
+  }
+}
+
+export class OptionalEmailUnsubscribeService {
+  readonly #preferenceRepo: OptionalEmailPreferenceRepository;
+  readonly #tokenService: OptionalEmailUnsubscribeTokenService;
+  readonly #clock: () => Date;
+
+  constructor(input: {
+    preferenceRepo: OptionalEmailPreferenceRepository;
+    tokenService: OptionalEmailUnsubscribeTokenService;
+    clock?: () => Date;
+  }) {
+    this.#preferenceRepo = input.preferenceRepo;
+    this.#tokenService = input.tokenService;
+    this.#clock = input.clock ?? (() => new Date());
+  }
+
+  isValid(input: { token: string }): boolean {
+    return this.#tokenService.verify(input) !== null;
+  }
+
+  async unsubscribe(input: { token: string }): Promise<boolean> {
+    const userId = this.#tokenService.verify(input);
+    if (!userId) {
+      return false;
+    }
+    await this.#preferenceRepo.unsubscribe({ userId, at: this.#clock() });
+    return true;
+  }
+}
+
+export function buildOptionalEmailUnsubscribeHeaders(input: {
+  publicBaseUrl: string;
+  token: string;
+}): Record<"List-Unsubscribe" | "List-Unsubscribe-Post", string> {
+  const url = new URL("/email/optional/unsubscribe", input.publicBaseUrl);
+  url.searchParams.set("token", input.token);
+  return {
+    "List-Unsubscribe": `<${url.toString()}>`,
+    "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+  };
+}

--- a/src/services/optional-email-webhook-service.ts
+++ b/src/services/optional-email-webhook-service.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+import type { OptionalEmailPreferenceRepository } from "../repositories/optional-email-preference-repo.js";
+import type { OptionalEmailWebhookEventRepository } from "../repositories/optional-email-webhook-event-repo.js";
+import { OptionalEmailSuppressionReason } from "../types/optional-email.js";
+
+const webhookEventSchema = z
+  .object({
+    type: z.string().min(1).max(128),
+    data: z
+      .object({
+        email_id: z.string().min(1).max(256),
+        bounce: z
+          .object({ type: z.string().min(1).max(64) })
+          .passthrough()
+          .optional(),
+        tags: z.record(z.string(), z.string()).optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+export interface OptionalEmailSendHistoryLookup {
+  findUserIdByProviderEmailId(input: { providerEmailId: string }): Promise<string | null>;
+}
+
+export type OptionalEmailWebhookResult =
+  | { status: "processed"; outcome: "suppressed" | "ignored" }
+  | { status: "replayed" }
+  | { status: "retry" };
+
+export class OptionalEmailWebhookService {
+  readonly #eventRepo: OptionalEmailWebhookEventRepository;
+  readonly #preferenceRepo: OptionalEmailPreferenceRepository;
+  readonly #sendHistory: OptionalEmailSendHistoryLookup;
+  readonly #clock: () => Date;
+
+  constructor(input: {
+    eventRepo: OptionalEmailWebhookEventRepository;
+    preferenceRepo: OptionalEmailPreferenceRepository;
+    sendHistory: OptionalEmailSendHistoryLookup;
+    clock?: () => Date;
+  }) {
+    this.#eventRepo = input.eventRepo;
+    this.#preferenceRepo = input.preferenceRepo;
+    this.#sendHistory = input.sendHistory;
+    this.#clock = input.clock ?? (() => new Date());
+  }
+
+  async handleVerified(input: { eventId: string; event: unknown }): Promise<OptionalEmailWebhookResult> {
+    if (await this.#eventRepo.wasProcessed({ eventId: input.eventId })) {
+      return { status: "replayed" };
+    }
+    const parsed = webhookEventSchema.safeParse(input.event);
+    if (!parsed.success) {
+      throw new Error("InvalidResendWebhookEvent");
+    }
+
+    const event = parsed.data;
+    const optionalEvent = event.data.tags?.category === "optional_setup_reminder";
+    const reason =
+      event.type === "email.bounced" && event.data.bounce?.type === "Permanent"
+        ? OptionalEmailSuppressionReason.HardBounce
+        : event.type === "email.complained"
+          ? OptionalEmailSuppressionReason.Complaint
+          : event.type === "email.suppressed"
+            ? OptionalEmailSuppressionReason.ProviderSuppressed
+            : null;
+    if (!optionalEvent || !reason) {
+      const inserted = await this.#eventRepo.recordProcessed({
+        eventId: input.eventId,
+        eventType: event.type,
+        processedAt: this.#clock(),
+      });
+      return inserted ? { status: "processed", outcome: "ignored" } : { status: "replayed" };
+    }
+
+    const userId = await this.#sendHistory.findUserIdByProviderEmailId({
+      providerEmailId: event.data.email_id,
+    });
+    if (!userId) {
+      return { status: "retry" };
+    }
+
+    await this.#preferenceRepo.suppress({ userId, reason, at: this.#clock() });
+    const inserted = await this.#eventRepo.recordProcessed({
+      eventId: input.eventId,
+      eventType: event.type,
+      processedAt: this.#clock(),
+    });
+    return inserted ? { status: "processed", outcome: "suppressed" } : { status: "replayed" };
+  }
+}

--- a/src/services/resend-webhook-verifier.ts
+++ b/src/services/resend-webhook-verifier.ts
@@ -1,0 +1,49 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export class ResendWebhookVerifier {
+  readonly #secret: Buffer;
+  readonly #clock: () => Date;
+
+  constructor(input: { signingSecret: string; clock?: () => Date }) {
+    const match = /^whsec_([A-Za-z0-9+/]+={0,2})$/.exec(input.signingSecret);
+    if (!match) {
+      throw new Error("InvalidResendWebhookSigningSecret");
+    }
+    this.#secret = Buffer.from(match[1] ?? "", "base64");
+    if (this.#secret.byteLength < 16) {
+      throw new Error("InvalidResendWebhookSigningSecret");
+    }
+    this.#clock = input.clock ?? (() => new Date());
+  }
+
+  verify(input: { rawBody: string; messageId: string; timestamp: string; signature: string }): unknown {
+    if (!/^\d{1,12}$/.test(input.timestamp)) {
+      throw new Error("InvalidResendWebhookTimestamp");
+    }
+    const timestampSeconds = Number(input.timestamp);
+    const nowSeconds = Math.floor(this.#clock().getTime() / 1_000);
+    if (!Number.isSafeInteger(timestampSeconds) || Math.abs(nowSeconds - timestampSeconds) > 300) {
+      throw new Error("InvalidResendWebhookTimestamp");
+    }
+
+    const signedContent = `${input.messageId}.${input.timestamp}.${input.rawBody}`;
+    const expected = createHmac("sha256", this.#secret).update(signedContent, "utf8").digest();
+    const valid = input.signature.split(" ").some((candidate) => {
+      const [version, encoded, ...rest] = candidate.split(",");
+      if (version !== "v1" || !encoded || rest.length > 0) {
+        return false;
+      }
+      const actual = Buffer.from(encoded, "base64");
+      return actual.byteLength === expected.byteLength && timingSafeEqual(actual, expected);
+    });
+    if (!valid) {
+      throw new Error("InvalidResendWebhookSignature");
+    }
+
+    try {
+      return JSON.parse(input.rawBody) as unknown;
+    } catch {
+      throw new Error("InvalidResendWebhookPayload");
+    }
+  }
+}

--- a/src/types/mongo.ts
+++ b/src/types/mongo.ts
@@ -12,4 +12,8 @@ export enum AuthDbCollection {
   Bridges = "bridges",
   ActivationStates = "activationStates",
   SettingsConfiguration = "settingsConfiguration",
+  OptionalEmailPreferences = "optionalEmailPreferences",
+  OptionalEmailWebhookEvents = "optionalEmailWebhookEvents",
+  OptionalEmailSends = "optionalEmailSends",
+  OptionalEmailDailyQuota = "optionalEmailDailyQuota",
 }

--- a/src/types/optional-email.ts
+++ b/src/types/optional-email.ts
@@ -1,0 +1,33 @@
+export enum OptionalEmailRecipientBasis {
+  Unapproved = "unapproved",
+  AccountActivityApproved = "account_activity_approved",
+}
+
+export enum OptionalEmailSuppressionReason {
+  HardBounce = "hard_bounce",
+  Complaint = "complaint",
+  ProviderSuppressed = "provider_suppressed",
+}
+
+export enum OptionalEmailBlockReason {
+  Unsubscribed = "unsubscribed",
+  Suppressed = "suppressed",
+}
+
+export enum OptionalEmailReminderKind {
+  BridgeSetup = "bridge_setup",
+  FirstSession = "first_session",
+}
+
+export enum OptionalEmailSendStatus {
+  Reserved = "reserved",
+  InFlight = "in_flight",
+  Accepted = "accepted",
+  Failed = "failed",
+  Blocked = "blocked",
+  DeferredDailyLimit = "deferred_daily_limit",
+}
+
+// Resend's free transactional plan permits 100 emails/day. Optional mail is
+// capped lower so account/security traffic and inbound quota use retain room.
+export const OPTIONAL_EMAIL_MAX_DAILY_CAP = 80;

--- a/tests/clients/resend-optional-email-adapter.test.ts
+++ b/tests/clients/resend-optional-email-adapter.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { ResendOptionalEmailAdapter } from "../../src/clients/resend-optional-email-adapter.js";
+
+describe("ResendOptionalEmailAdapter", () => {
+  it("sends one unscheduled email with explicit identity, one-click headers, and provider idempotency", async () => {
+    let captured: { input: Parameters<typeof fetch>[0]; init?: Parameters<typeof fetch>[1] } | null = null;
+    const fetchFn: typeof fetch = async (input, init) => {
+      captured = { input, init };
+      return new Response(JSON.stringify({ id: "resend-email-id-1" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    const adapter = new ResendOptionalEmailAdapter({
+      apiKey: "re_test_placeholder_not_a_secret",
+      fetchFn,
+    });
+
+    const result = await adapter.send({
+      idempotencyKey: "optional/setup-2026-09/stable-key",
+      from: "Sesori <hello@updates.sesori.com>",
+      replyTo: "hello@sesori.com",
+      recipient: "one@example.test",
+      subject: "Finish setting up Sesori",
+      html: "<p>Setup</p>",
+      text: "Setup",
+      headers: {
+        "List-Unsubscribe": "<https://api.sesori.com/email/optional/unsubscribe?token=signed>",
+        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+      },
+      tags: [
+        { name: "category", value: "optional_setup_reminder" },
+        { name: "campaign", value: "setup-2026-09" },
+      ],
+    });
+
+    assert.deepEqual(result, { providerEmailId: "resend-email-id-1" });
+    assert.equal(captured?.input, "https://api.resend.com/emails");
+    assert.equal(captured?.init?.method, "POST");
+    const requestHeaders = new Headers(captured?.init?.headers);
+    assert.equal(requestHeaders.get("authorization"), "Bearer re_test_placeholder_not_a_secret");
+    assert.equal(requestHeaders.get("content-type"), "application/json");
+    assert.equal(requestHeaders.get("idempotency-key"), "optional/setup-2026-09/stable-key");
+    assert.deepEqual(JSON.parse(String(captured?.init?.body)), {
+      from: "Sesori <hello@updates.sesori.com>",
+      to: ["one@example.test"],
+      subject: "Finish setting up Sesori",
+      html: "<p>Setup</p>",
+      text: "Setup",
+      reply_to: "hello@sesori.com",
+      headers: {
+        "List-Unsubscribe": "<https://api.sesori.com/email/optional/unsubscribe?token=signed>",
+        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+      },
+      tags: [
+        { name: "category", value: "optional_setup_reminder" },
+        { name: "campaign", value: "setup-2026-09" },
+      ],
+    });
+  });
+
+  it("classifies HTTP failures without exposing provider, key, or recipient details", async () => {
+    for (const testCase of [
+      { status: 429, code: "rate_limited" },
+      { status: 401, code: "configuration" },
+      { status: 422, code: "rejected" },
+      { status: 503, code: "unavailable" },
+    ]) {
+      const adapter = new ResendOptionalEmailAdapter({
+        apiKey: "re_test_sensitive_placeholder",
+        fetchFn: async () =>
+          new Response(JSON.stringify({ message: "provider detail for private@example.test" }), {
+            status: testCase.status,
+            headers: { "content-type": "application/json" },
+          }),
+      });
+      let thrown: unknown;
+      try {
+        await adapter.send({
+          idempotencyKey: `failure/${testCase.status}`,
+          from: "Sesori <hello@updates.sesori.com>",
+          replyTo: "hello@sesori.com",
+          recipient: "private@example.test",
+          subject: "Setup",
+          html: "<p>Setup</p>",
+          text: "Setup",
+          headers: {},
+          tags: [],
+        });
+      } catch (error) {
+        thrown = error;
+      }
+
+      assert.equal((thrown as { code?: unknown }).code, testCase.code);
+      assert.equal((thrown as Error).message, "resend_email_failed");
+      assert.doesNotMatch(String(thrown), /private@example\.test|re_test_sensitive|provider detail/);
+    }
+  });
+
+  it("sanitizes transport failures as unavailable", async () => {
+    const adapter = new ResendOptionalEmailAdapter({
+      apiKey: "re_test_sensitive_placeholder",
+      fetchFn: async () => {
+        throw new Error("socket detail for private@example.test");
+      },
+    });
+
+    let thrown: unknown;
+    try {
+      await adapter.send({
+        idempotencyKey: "failure/network",
+        from: "Sesori <hello@updates.sesori.com>",
+        replyTo: "hello@sesori.com",
+        recipient: "private@example.test",
+        subject: "Setup",
+        html: "<p>Setup</p>",
+        text: "Setup",
+        headers: {},
+        tags: [],
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    assert.equal((thrown as { code?: unknown }).code, "unavailable");
+    assert.equal((thrown as Error).message, "resend_email_failed");
+    assert.doesNotMatch(String(thrown), /private@example\.test|socket detail/);
+  });
+
+  it("rejects malformed success payloads as unavailable", async () => {
+    const adapter = new ResendOptionalEmailAdapter({
+      apiKey: "re_test_placeholder_not_a_secret",
+      fetchFn: async () => new Response("not-json", { status: 200 }),
+    });
+
+    await assert.rejects(
+      adapter.send({
+        idempotencyKey: "failure/malformed",
+        from: "Sesori <hello@updates.sesori.com>",
+        replyTo: "hello@sesori.com",
+        recipient: "one@example.test",
+        subject: "Setup",
+        html: "<p>Setup</p>",
+        text: "Setup",
+        headers: {},
+        tags: [],
+      }),
+      (error: unknown) =>
+        (error as { code?: unknown }).code === "unavailable" && (error as Error).message === "resend_email_failed",
+    );
+  });
+
+  it("passes a bounded abort signal to the provider request", async () => {
+    let signalSeen = false;
+    const adapter = new ResendOptionalEmailAdapter({
+      apiKey: "re_test_placeholder_not_a_secret",
+      timeoutMs: 5,
+      fetchFn: async (_input, init) => {
+        const signal = init?.signal;
+        signalSeen = signal instanceof AbortSignal;
+        if (!(signal instanceof AbortSignal)) {
+          throw new Error("missing abort signal");
+        }
+        return new Promise<Response>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+        });
+      },
+    });
+
+    await assert.rejects(
+      adapter.send({
+        idempotencyKey: "failure/timeout",
+        from: "Sesori <hello@updates.sesori.com>",
+        replyTo: "hello@sesori.com",
+        recipient: "one@example.test",
+        subject: "Setup",
+        html: "<p>Setup</p>",
+        text: "Setup",
+        headers: {},
+        tags: [],
+      }),
+      (error: unknown) => (error as { code?: unknown }).code === "unavailable",
+    );
+    assert.equal(signalSeen, true);
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -367,6 +367,91 @@ function restoreEnv(name: string, value: string | undefined): void {
   process.env[name] = value;
 }
 
+describe("optional setup email configuration", () => {
+  it("defaults every send path off while pinning sender identity and free-plan headroom", () => {
+    const result = configSchema.safeParse(validEnv());
+
+    assert.equal(result.success, true);
+    if (!result.success) {
+      throw new Error("expected config parse success");
+    }
+
+    const config = result.data as Record<string, unknown>;
+    assert.equal(config.OPTIONAL_EMAIL_SENDING_ENABLED, false);
+    assert.equal(config.OPTIONAL_EMAIL_TEST_SEND_ENABLED, false);
+    assert.equal(config.OPTIONAL_EMAIL_RECIPIENT_BASIS, "unapproved");
+    assert.equal(config.RESEND_FROM, "Sesori <hello@updates.sesori.com>");
+    assert.equal(config.RESEND_REPLY_TO, "hello@sesori.com");
+    assert.equal(config.RESEND_TEST_RECIPIENT, "alex@sesori.com");
+    assert.equal(config.OPTIONAL_EMAIL_DAILY_CAP, 80);
+  });
+
+  it("fails closed when real sending lacks an approved recipient basis or safety secrets", () => {
+    const missingBasis = configSchema.safeParse(
+      validEnv({
+        OPTIONAL_EMAIL_SENDING_ENABLED: "true",
+        RESEND_API_KEY: "test-resend-key",
+        RESEND_WEBHOOK_SECRET: "whsec_test-webhook-secret-at-least-32",
+        OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET: "test-unsubscribe-secret-at-least-32",
+      }),
+    );
+    assert.equal(missingBasis.success, false);
+    assert.ok(missingBasis.error?.issues.some((issue) => issue.path.includes("OPTIONAL_EMAIL_RECIPIENT_BASIS")));
+
+    const missingSecrets = configSchema.safeParse(
+      validEnv({
+        OPTIONAL_EMAIL_SENDING_ENABLED: "true",
+        OPTIONAL_EMAIL_RECIPIENT_BASIS: "account_activity_approved",
+      }),
+    );
+    assert.equal(missingSecrets.success, false);
+    for (const path of ["RESEND_API_KEY", "RESEND_WEBHOOK_SECRET", "OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET"]) {
+      assert.ok(
+        missingSecrets.error?.issues.some((issue) => issue.path.includes(path)),
+        `missing ${path} issue`,
+      );
+    }
+  });
+
+  it("accepts an explicitly approved, fully configured sender without enabling the test path", () => {
+    const result = configSchema.safeParse(
+      validEnv({
+        OPTIONAL_EMAIL_SENDING_ENABLED: "true",
+        OPTIONAL_EMAIL_RECIPIENT_BASIS: "account_activity_approved",
+        RESEND_API_KEY: "test-resend-key",
+        RESEND_WEBHOOK_SECRET: "whsec_test-webhook-secret-at-least-32",
+        OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET: "test-unsubscribe-secret-at-least-32",
+      }),
+    );
+
+    assert.equal(result.success, true);
+    if (!result.success) {
+      throw new Error("expected configured optional email sender");
+    }
+    const config = result.data as Record<string, unknown>;
+    assert.equal(config.OPTIONAL_EMAIL_SENDING_ENABLED, true);
+    assert.equal(config.OPTIONAL_EMAIL_TEST_SEND_ENABLED, false);
+  });
+
+  it("requires the global gate for the allowlisted test path and rejects drift from the approved recipient", () => {
+    const testWithoutGlobal = configSchema.safeParse(validEnv({ OPTIONAL_EMAIL_TEST_SEND_ENABLED: "true" }));
+    assert.equal(testWithoutGlobal.success, false);
+    assert.ok(testWithoutGlobal.error?.issues.some((issue) => issue.path.includes("OPTIONAL_EMAIL_TEST_SEND_ENABLED")));
+
+    const wrongRecipient = configSchema.safeParse(validEnv({ RESEND_TEST_RECIPIENT: "other@example.com" }));
+    assert.equal(wrongRecipient.success, false);
+  });
+
+  it("rejects non-literal switches, an unapproved basis, and a cap above the 80-send safety ceiling", () => {
+    for (const value of ["TRUE", "yes", "", " true", "2"]) {
+      assert.equal(configSchema.safeParse(validEnv({ OPTIONAL_EMAIL_SENDING_ENABLED: value })).success, false);
+    }
+    assert.equal(configSchema.safeParse(validEnv({ OPTIONAL_EMAIL_RECIPIENT_BASIS: "account_email" })).success, false);
+    assert.equal(configSchema.safeParse(validEnv({ OPTIONAL_EMAIL_DAILY_CAP: "81" })).success, false);
+    assert.equal(configSchema.safeParse(validEnv({ OPTIONAL_EMAIL_DAILY_CAP: "80" })).success, true);
+  });
+});
+
 describe("configSchema", () => {
   it("accepts the baseline environment", () => {
     assert.equal(configSchema.safeParse(validEnv()).success, true);

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -43,6 +43,9 @@ import { MAX_BINARY_BYTES, MAX_TEXT_BYTES } from "../../src/routes/voice-realtim
 import { AppClientPresenceService } from "../../src/services/app-client-presence-service.js";
 import { ProductAnalyticsPreferenceService } from "../../src/services/product-analytics-preference-service.js";
 import { SettingsService } from "../../src/services/settings-service.js";
+import type { OptionalEmailUnsubscribeService } from "../../src/services/optional-email-unsubscribe-service.js";
+import type { OptionalEmailWebhookService } from "../../src/services/optional-email-webhook-service.js";
+import type { ResendWebhookVerifier } from "../../src/services/resend-webhook-verifier.js";
 import { loadConfig, type Config } from "../../src/config.js";
 import { ProductAnalyticsPreference } from "../../src/types/product-analytics.js";
 import { AsyncTranscriptionPublicErrorPolicy } from "../../src/types/transcription.js";
@@ -93,6 +96,13 @@ export type TestAppOverrides = {
   asyncTranscriptionClient?: AsyncTranscriptionClient;
   asyncTranscriptionPublicErrorPolicy?: AsyncTranscriptionPublicErrorPolicy;
   configOverrides?: Partial<Config>;
+  optionalEmail?: {
+    unsubscribeService?: OptionalEmailUnsubscribeService;
+    webhook?: {
+      verifier: ResendWebhookVerifier;
+      service: OptionalEmailWebhookService;
+    };
+  };
 };
 
 export type { OAuthClient };
@@ -259,6 +269,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
     appleNativeVerifier,
     pendingAuthStore,
     productAnalyticsPreferenceService,
+    optionalEmail: overrides?.optionalEmail,
     realtime:
       overrides?.realtimeService && effectiveConfig.REALTIME_TRANSCRIPTION_ENABLED
         ? {

--- a/tests/optional-email-composition.test.ts
+++ b/tests/optional-email-composition.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { createOptionalEmailRouteServices } from "../src/optional-email-composition.js";
+import { createTestApp, type TestContext } from "./helpers/setup.js";
+
+describe("optional email route composition", () => {
+  let ctx: TestContext;
+
+  before(async () => {
+    ctx = await createTestApp();
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("constructs only the safety routes backed by configured signing secrets", () => {
+    assert.equal(
+      createOptionalEmailRouteServices({
+        dbAccessor: ctx.dbAccessor,
+        unsubscribeSigningSecret: undefined,
+        webhookSigningSecret: undefined,
+      }),
+      undefined,
+    );
+
+    const unsubscribeOnly = createOptionalEmailRouteServices({
+      dbAccessor: ctx.dbAccessor,
+      unsubscribeSigningSecret: "u".repeat(32),
+      webhookSigningSecret: undefined,
+    });
+    assert.ok(unsubscribeOnly?.unsubscribeService);
+    assert.equal(unsubscribeOnly?.webhook, undefined);
+
+    const webhookOnly = createOptionalEmailRouteServices({
+      dbAccessor: ctx.dbAccessor,
+      unsubscribeSigningSecret: undefined,
+      webhookSigningSecret: `whsec_${Buffer.alloc(32, 7).toString("base64")}`,
+    });
+    assert.equal(webhookOnly?.unsubscribeService, undefined);
+    assert.ok(webhookOnly?.webhook?.verifier);
+    assert.ok(webhookOnly?.webhook?.service);
+  });
+});

--- a/tests/repositories/optional-email-daily-quota-repo.test.ts
+++ b/tests/repositories/optional-email-daily-quota-repo.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { OptionalEmailDailyQuotaRepository } from "../../src/repositories/optional-email-daily-quota-repo.js";
+import { InternalServerError } from "../../src/lib/errors.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+describe("OptionalEmailDailyQuotaRepository", () => {
+  let ctx: TestContext;
+  let repo: OptionalEmailDailyQuotaRepository;
+
+  before(async () => {
+    ctx = await createTestApp();
+    repo = new OptionalEmailDailyQuotaRepository(ctx.dbAccessor);
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("atomically enforces a UTC daily limit and starts a new counter the next day", async () => {
+    const firstDay = new Date("2026-09-06T23:59:59.000Z");
+    const attempts = await Promise.all(Array.from({ length: 20 }, () => repo.reserve({ at: firstDay, dailyCap: 3 })));
+
+    assert.equal(attempts.filter((attempt) => attempt.reserved).length, 3);
+    assert.deepEqual(await repo.getUsage({ at: firstDay, dailyCap: 3 }), {
+      date: "2026-09-06",
+      used: 3,
+      remaining: 0,
+    });
+    assert.deepEqual(await repo.reserve({ at: new Date("2026-09-07T00:00:00.000Z"), dailyCap: 3 }), {
+      reserved: true,
+      date: "2026-09-07",
+      used: 1,
+      remaining: 2,
+    });
+  });
+
+  it("rejects a cap above 80 so free-plan headroom cannot be configured away", async () => {
+    await assert.rejects(repo.reserve({ at: new Date("2026-09-08T00:00:00.000Z"), dailyCap: 81 }), InternalServerError);
+  });
+});

--- a/tests/repositories/optional-email-preference-repo.test.ts
+++ b/tests/repositories/optional-email-preference-repo.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { ObjectId } from "mongodb";
+import type { OptionalEmailPreference } from "../../src/models/documents.js";
+import { OptionalEmailPreferenceRepository } from "../../src/repositories/optional-email-preference-repo.js";
+import { OptionalEmailBlockReason, OptionalEmailSuppressionReason } from "../../src/types/optional-email.js";
+import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+describe("OptionalEmailPreferenceRepository", () => {
+  let ctx: TestContext;
+  let repo: OptionalEmailPreferenceRepository;
+
+  before(async () => {
+    ctx = await createTestApp();
+    repo = new OptionalEmailPreferenceRepository(ctx.dbAccessor);
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("treats an absent optional-mail preference as not locally blocked", async () => {
+    const user = await ctx.createUser();
+
+    assert.equal(await repo.findByUserId({ userId: user.userId }), null);
+    assert.equal(await repo.findBlockReason({ userId: user.userId }), null);
+  });
+
+  it("persists an unsubscribe once and never resets it on replay", async () => {
+    const user = await ctx.createUser();
+    const first = new Date("2026-09-06T10:00:00.000Z");
+    const replay = new Date("2026-09-06T11:00:00.000Z");
+
+    await repo.unsubscribe({ userId: user.userId, at: first });
+    await repo.unsubscribe({ userId: user.userId, at: replay });
+
+    const stored = await repo.findByUserId({ userId: user.userId });
+    assert.equal(stored?.unsubscribedAt?.toISOString(), first.toISOString());
+    assert.equal(await repo.findBlockReason({ userId: user.userId }), OptionalEmailBlockReason.Unsubscribed);
+  });
+
+  it("durably suppresses hard bounces, complaints, and provider suppressions", async () => {
+    for (const reason of [
+      OptionalEmailSuppressionReason.HardBounce,
+      OptionalEmailSuppressionReason.Complaint,
+      OptionalEmailSuppressionReason.ProviderSuppressed,
+    ]) {
+      const user = await ctx.createUser();
+      const at = new Date("2026-09-06T12:00:00.000Z");
+
+      await repo.suppress({ userId: user.userId, reason, at });
+
+      const stored = await repo.findByUserId({ userId: user.userId });
+      assert.equal(stored?.suppressedAt?.toISOString(), at.toISOString());
+      assert.equal(stored?.suppressionReason, reason);
+      assert.equal(await repo.findBlockReason({ userId: user.userId }), OptionalEmailBlockReason.Suppressed);
+    }
+  });
+
+  it("preserves both independent blockers when suppression follows unsubscribe", async () => {
+    const user = await ctx.createUser();
+    const unsubscribeAt = new Date("2026-09-06T10:00:00.000Z");
+    const complaintAt = new Date("2026-09-06T12:00:00.000Z");
+
+    await repo.unsubscribe({ userId: user.userId, at: unsubscribeAt });
+    await repo.suppress({
+      userId: user.userId,
+      reason: OptionalEmailSuppressionReason.Complaint,
+      at: complaintAt,
+    });
+
+    const stored = await repo.findByUserId({ userId: user.userId });
+    assert.equal(stored?.unsubscribedAt?.toISOString(), unsubscribeAt.toISOString());
+    assert.equal(stored?.suppressedAt?.toISOString(), complaintAt.toISOString());
+    assert.equal(await repo.findBlockReason({ userId: user.userId }), OptionalEmailBlockReason.Unsubscribed);
+  });
+
+  it("keeps one preference document when concurrent unsubscribe requests race", async () => {
+    const user = await ctx.createUser();
+    const at = new Date("2026-09-06T10:00:00.000Z");
+
+    await Promise.all([repo.unsubscribe({ userId: user.userId, at }), repo.unsubscribe({ userId: user.userId, at })]);
+
+    const count = await ctx.dbAccessor
+      .getCollection<OptionalEmailPreference>(MongoDbDatabase.Auth, AuthDbCollection.OptionalEmailPreferences)
+      .countDocuments({ userId: new ObjectId(user.userId) });
+    assert.equal(count, 1);
+  });
+
+  it("rejects malformed user IDs and dates at the repository boundary", async () => {
+    await assert.rejects(() => repo.unsubscribe({ userId: "not-an-id", at: new Date() }), /internal_server_error/);
+    await assert.rejects(
+      () =>
+        repo.suppress({
+          userId: new ObjectId().toHexString(),
+          reason: OptionalEmailSuppressionReason.HardBounce,
+          at: new Date("invalid"),
+        }),
+      /internal_server_error/,
+    );
+  });
+});

--- a/tests/repositories/optional-email-recipient-repo.test.ts
+++ b/tests/repositories/optional-email-recipient-repo.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { ObjectId } from "mongodb";
+import type { OAuthAccount, PasswordAccount } from "../../src/models/documents.js";
+import { OptionalEmailRecipientRepository } from "../../src/repositories/optional-email-recipient-repo.js";
+import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+describe("OptionalEmailRecipientRepository", () => {
+  let ctx: TestContext;
+  let repo: OptionalEmailRecipientRepository;
+
+  before(async () => {
+    ctx = await createTestApp();
+    repo = new OptionalEmailRecipientRepository(ctx.dbAccessor);
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("requires an existing user and exactly one normalized account email", async () => {
+    assert.deepEqual(await repo.resolve({ userId: new ObjectId().toHexString() }), { status: "missing_user" });
+
+    const user = await ctx.createUser();
+    assert.deepEqual(await repo.resolve({ userId: user.userId }), { status: "missing_recipient" });
+
+    const userObjectId = new ObjectId(user.userId);
+    const oauth = ctx.dbAccessor.getCollection<OAuthAccount>(MongoDbDatabase.Auth, AuthDbCollection.OAuthAccounts);
+    await oauth.updateOne({ userId: userObjectId }, { $set: { email: "One@Example.test" } });
+    assert.deepEqual(await repo.resolve({ userId: user.userId }), {
+      status: "unique",
+      email: "one@example.test",
+    });
+
+    const password = ctx.dbAccessor.getCollection<PasswordAccount>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.PasswordAccounts,
+    );
+    await password.insertOne({
+      _id: new ObjectId(),
+      userId: userObjectId,
+      email: "one@example.test",
+      passwordHash: "test-only-hash",
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    });
+    assert.deepEqual(await repo.resolve({ userId: user.userId }), {
+      status: "unique",
+      email: "one@example.test",
+    });
+
+    await password.updateOne({ userId: userObjectId }, { $set: { email: "different@example.test" } });
+    assert.deepEqual(await repo.resolve({ userId: user.userId }), { status: "ambiguous_recipient" });
+  });
+});

--- a/tests/repositories/optional-email-send-repo.test.ts
+++ b/tests/repositories/optional-email-send-repo.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { OptionalEmailSendRepository } from "../../src/repositories/optional-email-send-repo.js";
+import { OptionalEmailReminderKind } from "../../src/types/optional-email.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+const NOW = new Date("2026-09-06T12:00:00.000Z");
+
+describe("OptionalEmailSendRepository", () => {
+  let ctx: TestContext;
+  let repo: OptionalEmailSendRepository;
+
+  before(async () => {
+    ctx = await createTestApp();
+    repo = new OptionalEmailSendRepository(ctx.dbAccessor);
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("atomically reserves one send per key without persisting a recipient address", async () => {
+    const user = await ctx.createUser();
+    const input = {
+      sendKey: "optional/setup-2026-09/user-key-1",
+      userId: user.userId,
+      campaignId: "setup-2026-09",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+      at: NOW,
+    };
+
+    const results = await Promise.all([repo.reserve(input), repo.reserve(input), repo.reserve(input)]);
+    const statuses = results.map((result) => result.status).sort();
+    const stored = await repo.findBySendKey({ sendKey: input.sendKey });
+
+    assert.deepEqual(statuses, ["duplicate", "duplicate", "reserved"]);
+    assert.equal(stored?.status, "reserved");
+    assert.equal(stored?.attemptCount, 0);
+    assert.equal(stored?.userId.toHexString(), user.userId);
+    assert.equal(stored && "recipient" in stored, false);
+    assert.equal(stored && "email" in stored, false);
+  });
+
+  it("records one provider attempt and keeps an accepted send permanently duplicate-blocked", async () => {
+    const user = await ctx.createUser();
+    const input = {
+      sendKey: "optional/setup-2026-09/user-key-accepted",
+      userId: user.userId,
+      campaignId: "setup-2026-09",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+      at: NOW,
+    };
+    await repo.reserve(input);
+
+    assert.equal(await repo.markInFlight({ sendKey: input.sendKey, at: NOW }), true);
+    assert.equal(
+      await repo.markAccepted({
+        sendKey: input.sendKey,
+        providerEmailId: "resend-email-accepted-1",
+        at: new Date(NOW.getTime() + 1_000),
+      }),
+      true,
+    );
+
+    const stored = await repo.findBySendKey({ sendKey: input.sendKey });
+    const duplicate = await repo.reserve({ ...input, at: new Date(NOW.getTime() + 10_000) });
+    assert.equal(stored?.status, "accepted");
+    assert.equal(stored?.attemptCount, 1);
+    assert.equal(stored?.firstProviderAttemptAt?.toISOString(), NOW.toISOString());
+    assert.equal(stored?.providerEmailId, "resend-email-accepted-1");
+    assert.equal(await repo.findUserIdByProviderEmailId({ providerEmailId: "resend-email-accepted-1" }), user.userId);
+    assert.equal(duplicate.status, "duplicate");
+    assert.equal(duplicate.send.status, "accepted");
+  });
+
+  it("reclaims a failed send only inside the provider idempotency safety window", async () => {
+    const user = await ctx.createUser();
+    const input = {
+      sendKey: "optional/setup-2026-09/user-key-retry",
+      userId: user.userId,
+      campaignId: "setup-2026-09",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+      at: NOW,
+    };
+    await repo.reserve(input);
+    await repo.markInFlight({ sendKey: input.sendKey, at: NOW });
+    await repo.markFailed({
+      sendKey: input.sendKey,
+      failureCode: "provider_unavailable",
+      at: new Date(NOW.getTime() + 1_000),
+    });
+
+    const retryAt = new Date(NOW.getTime() + 60 * 60 * 1_000);
+    const retry = await repo.reserve({ ...input, at: retryAt });
+    assert.equal(retry.status, "reserved");
+    assert.equal(await repo.markInFlight({ sendKey: input.sendKey, at: retryAt }), true);
+    await repo.markFailed({
+      sendKey: input.sendKey,
+      failureCode: "provider_unavailable",
+      at: new Date(retryAt.getTime() + 1_000),
+    });
+
+    const stored = await repo.findBySendKey({ sendKey: input.sendKey });
+    assert.equal(stored?.attemptCount, 2);
+    assert.equal(stored?.firstProviderAttemptAt?.toISOString(), NOW.toISOString());
+    assert.equal(stored?.lastProviderAttemptAt?.toISOString(), retryAt.toISOString());
+    assert.equal(stored?.lastFailureCode, "provider_unavailable");
+
+    const expired = await repo.reserve({
+      ...input,
+      at: new Date(NOW.getTime() + 23 * 60 * 60 * 1_000 + 1),
+    });
+    assert.equal(expired.status, "retry_expired");
+    assert.equal(expired.send.status, "failed");
+  });
+});

--- a/tests/routes/optional-email-server-wiring.test.ts
+++ b/tests/routes/optional-email-server-wiring.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { OptionalEmailUnsubscribeService } from "../../src/services/optional-email-unsubscribe-service.js";
+import type { OptionalEmailWebhookService } from "../../src/services/optional-email-webhook-service.js";
+import type { ResendWebhookVerifier } from "../../src/services/resend-webhook-verifier.js";
+import { createTestApp } from "../helpers/setup.js";
+
+describe("optional email server wiring", () => {
+  it("registers the public unsubscribe route only when its service is configured", async () => {
+    const defaultContext = await createTestApp();
+    try {
+      const absent = await defaultContext.app.inject({
+        method: "GET",
+        url: "/email/optional/unsubscribe?token=signed-token",
+      });
+      assert.equal(absent.statusCode, 404);
+    } finally {
+      await defaultContext.cleanup();
+    }
+
+    const unsubscribeService = {
+      isValid: ({ token }: { token: string }) => token === "signed-token",
+      unsubscribe: async ({ token }: { token: string }) => token === "signed-token",
+    } as unknown as OptionalEmailUnsubscribeService;
+    const configuredContext = await createTestApp({
+      optionalEmail: { unsubscribeService },
+    });
+    try {
+      const available = await configuredContext.app.inject({
+        method: "GET",
+        url: "/email/optional/unsubscribe?token=signed-token",
+      });
+      assert.equal(available.statusCode, 200);
+      assert.match(available.body, /Security and essential account messages are not affected/);
+    } finally {
+      await configuredContext.cleanup();
+    }
+  });
+
+  it("registers the Resend webhook route only when its verifier and handler are configured", async () => {
+    const verifier = {
+      verify: () => ({ type: "email.sent", data: { email_id: "provider-id" } }),
+    } as unknown as ResendWebhookVerifier;
+    const service = {
+      handleVerified: async () => ({ status: "processed", outcome: "ignored" }),
+    } as unknown as OptionalEmailWebhookService;
+    const context = await createTestApp({
+      optionalEmail: { webhook: { verifier, service } },
+    });
+    try {
+      const response = await context.app.inject({
+        method: "POST",
+        url: "/webhooks/resend",
+        headers: {
+          "content-type": "application/json",
+          "svix-id": "msg_test",
+          "svix-timestamp": "1",
+          "svix-signature": "v1,test",
+        },
+        payload: '{"type":"email.sent"}',
+      });
+
+      assert.equal(response.statusCode, 204);
+    } finally {
+      await context.cleanup();
+    }
+  });
+});

--- a/tests/routes/optional-email-unsubscribe.test.ts
+++ b/tests/routes/optional-email-unsubscribe.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import Fastify, { type FastifyInstance } from "fastify";
+import { after, before, describe, it } from "node:test";
+import { OptionalEmailPreferenceRepository } from "../../src/repositories/optional-email-preference-repo.js";
+import { optionalEmailUnsubscribeRoutes } from "../../src/routes/optional-email-unsubscribe.js";
+import {
+  OptionalEmailUnsubscribeService,
+  OptionalEmailUnsubscribeTokenService,
+  buildOptionalEmailUnsubscribeHeaders,
+} from "../../src/services/optional-email-unsubscribe-service.js";
+import { OptionalEmailBlockReason } from "../../src/types/optional-email.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+const SECRET = Buffer.alloc(32, 7);
+const NOW = new Date("2026-09-06T12:00:00.000Z");
+
+describe("optional email unsubscribe token and headers", () => {
+  it("round-trips a signed persistent token and rejects tampering", () => {
+    const tokens = new OptionalEmailUnsubscribeTokenService({ signingSecret: SECRET });
+    const userId = "000000000000000000000001";
+
+    const token = tokens.create({ userId });
+
+    assert.equal(tokens.verify({ token }), userId);
+    const finalCharacter = token.endsWith("a") ? "b" : "a";
+    assert.equal(tokens.verify({ token: `${token.slice(0, -1)}${finalCharacter}` }), null);
+    assert.equal(tokens.verify({ token: "not-a-token" }), null);
+  });
+
+  it("builds the RFC 8058 one-click headers against the signed no-login URL", () => {
+    const tokens = new OptionalEmailUnsubscribeTokenService({ signingSecret: SECRET });
+    const token = tokens.create({ userId: "000000000000000000000001" });
+
+    const result = buildOptionalEmailUnsubscribeHeaders({
+      publicBaseUrl: "https://api.sesori.com",
+      token,
+    });
+
+    assert.deepEqual(result, {
+      "List-Unsubscribe": `<https://api.sesori.com/email/optional/unsubscribe?token=${encodeURIComponent(token)}>`,
+      "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+    });
+  });
+});
+
+describe("optional email unsubscribe routes", () => {
+  let ctx: TestContext;
+  let preferenceRepo: OptionalEmailPreferenceRepository;
+  let tokens: OptionalEmailUnsubscribeTokenService;
+  let app: FastifyInstance;
+
+  before(async () => {
+    ctx = await createTestApp();
+    preferenceRepo = new OptionalEmailPreferenceRepository(ctx.dbAccessor);
+    tokens = new OptionalEmailUnsubscribeTokenService({ signingSecret: SECRET });
+    const service = new OptionalEmailUnsubscribeService({
+      preferenceRepo,
+      tokenService: tokens,
+      clock: () => NOW,
+    });
+    app = Fastify();
+    await app.register(optionalEmailUnsubscribeRoutes, { service });
+    await app.ready();
+  });
+
+  after(async () => {
+    await app.close();
+    await ctx.cleanup();
+  });
+
+  it("shows a confirmation form on GET without changing preference state", async () => {
+    const user = await ctx.createUser();
+    const token = tokens.create({ userId: user.userId });
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/email/optional/unsubscribe?token=${encodeURIComponent(token)}`,
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.match(response.headers["content-type"] ?? "", /^text\/html/);
+    assert.match(response.body, /Unsubscribe from optional Sesori setup reminders/);
+    assert.match(response.body, /method="post"/);
+    assert.equal(await preferenceRepo.findBlockReason({ userId: user.userId }), null);
+  });
+
+  it("accepts an unauthenticated RFC 8058 POST and remains idempotent on replay", async () => {
+    const user = await ctx.createUser();
+    const token = tokens.create({ userId: user.userId });
+    const request = {
+      method: "POST" as const,
+      url: `/email/optional/unsubscribe?token=${encodeURIComponent(token)}`,
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      payload: "List-Unsubscribe=One-Click",
+    };
+
+    const first = await app.inject(request);
+    const replay = await app.inject(request);
+
+    assert.equal(first.statusCode, 200);
+    assert.equal(first.body, "");
+    assert.equal(replay.statusCode, 200);
+    assert.equal(await preferenceRepo.findBlockReason({ userId: user.userId }), OptionalEmailBlockReason.Unsubscribed);
+    assert.equal(
+      (await preferenceRepo.findByUserId({ userId: user.userId }))?.unsubscribedAt?.toISOString(),
+      NOW.toISOString(),
+    );
+  });
+
+  it("rejects a tampered token and malformed one-click body without writing", async () => {
+    const user = await ctx.createUser();
+    const token = tokens.create({ userId: user.userId });
+    const tampered = `${token.slice(0, -1)}${token.endsWith("a") ? "b" : "a"}`;
+
+    const badToken = await app.inject({
+      method: "POST",
+      url: `/email/optional/unsubscribe?token=${encodeURIComponent(tampered)}`,
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      payload: "List-Unsubscribe=One-Click",
+    });
+    const badBody = await app.inject({
+      method: "POST",
+      url: `/email/optional/unsubscribe?token=${encodeURIComponent(token)}`,
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      payload: "List-Unsubscribe=No",
+    });
+
+    assert.equal(badToken.statusCode, 400);
+    assert.equal(badBody.statusCode, 400);
+    assert.equal(await preferenceRepo.findByUserId({ userId: user.userId }), null);
+  });
+});

--- a/tests/routes/optional-email-webhook.test.ts
+++ b/tests/routes/optional-email-webhook.test.ts
@@ -1,0 +1,125 @@
+import { createHmac } from "node:crypto";
+import assert from "node:assert/strict";
+import Fastify, { type FastifyInstance } from "fastify";
+import { after, before, describe, it } from "node:test";
+import { OptionalEmailPreferenceRepository } from "../../src/repositories/optional-email-preference-repo.js";
+import { OptionalEmailWebhookEventRepository } from "../../src/repositories/optional-email-webhook-event-repo.js";
+import { optionalEmailWebhookRoutes } from "../../src/routes/optional-email-webhook.js";
+import { OptionalEmailWebhookService } from "../../src/services/optional-email-webhook-service.js";
+import { ResendWebhookVerifier } from "../../src/services/resend-webhook-verifier.js";
+import { OptionalEmailBlockReason } from "../../src/types/optional-email.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+const NOW = new Date("2026-09-06T12:00:00.000Z");
+const SECRET_BYTES = Buffer.alloc(32, 3);
+const SIGNING_SECRET = `whsec_${SECRET_BYTES.toString("base64")}`;
+
+function signatureFor(input: { rawBody: string; messageId: string; timestamp: string }): string {
+  const value = createHmac("sha256", SECRET_BYTES)
+    .update(`${input.messageId}.${input.timestamp}.${input.rawBody}`, "utf8")
+    .digest("base64");
+  return `v1,${value}`;
+}
+
+describe("POST /webhooks/resend", () => {
+  let ctx: TestContext;
+  let app: FastifyInstance;
+  let userId: string;
+
+  before(async () => {
+    ctx = await createTestApp();
+    userId = (await ctx.createUser()).userId;
+    const service = new OptionalEmailWebhookService({
+      eventRepo: new OptionalEmailWebhookEventRepository(ctx.dbAccessor),
+      preferenceRepo: new OptionalEmailPreferenceRepository(ctx.dbAccessor),
+      sendHistory: { findUserIdByProviderEmailId: async () => userId },
+      clock: () => NOW,
+    });
+    app = Fastify();
+    await app.register(optionalEmailWebhookRoutes, {
+      service,
+      verifier: new ResendWebhookVerifier({ signingSecret: SIGNING_SECRET, clock: () => NOW }),
+    });
+    await app.ready();
+  });
+
+  after(async () => {
+    await app.close();
+    await ctx.cleanup();
+  });
+
+  it("verifies the raw request before suppressing and rejects a modified signature", async () => {
+    const rawBody = JSON.stringify({
+      type: "email.complained",
+      data: {
+        email_id: "resend-route-complaint-1",
+        tags: { category: "optional_setup_reminder" },
+      },
+    });
+    const messageId = "msg_route_complaint_1";
+    const timestamp = String(Math.floor(NOW.getTime() / 1_000));
+    const headers = {
+      "content-type": "application/json",
+      "svix-id": messageId,
+      "svix-timestamp": timestamp,
+      "svix-signature": signatureFor({ rawBody, messageId, timestamp }),
+    };
+
+    const valid = await app.inject({ method: "POST", url: "/webhooks/resend", headers, payload: rawBody });
+    const invalid = await app.inject({
+      method: "POST",
+      url: "/webhooks/resend",
+      headers: { ...headers, "svix-signature": "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" },
+      payload: rawBody,
+    });
+
+    assert.equal(valid.statusCode, 204);
+    assert.equal(invalid.statusCode, 400);
+    assert.equal(
+      await new OptionalEmailPreferenceRepository(ctx.dbAccessor).findBlockReason({ userId }),
+      OptionalEmailBlockReason.Suppressed,
+    );
+  });
+
+  it("returns a retryable response when optional send history is not yet correlated", async () => {
+    const retryApp = Fastify();
+    await retryApp.register(optionalEmailWebhookRoutes, {
+      service: new OptionalEmailWebhookService({
+        eventRepo: new OptionalEmailWebhookEventRepository(ctx.dbAccessor),
+        preferenceRepo: new OptionalEmailPreferenceRepository(ctx.dbAccessor),
+        sendHistory: { findUserIdByProviderEmailId: async () => null },
+        clock: () => NOW,
+      }),
+      verifier: new ResendWebhookVerifier({ signingSecret: SIGNING_SECRET, clock: () => NOW }),
+    });
+    await retryApp.ready();
+    const rawBody = JSON.stringify({
+      type: "email.complained",
+      data: {
+        email_id: "resend-route-not-correlated-yet",
+        tags: { category: "optional_setup_reminder" },
+      },
+    });
+    const messageId = "msg_route_not_correlated_1";
+    const timestamp = String(Math.floor(NOW.getTime() / 1_000));
+
+    try {
+      const response = await retryApp.inject({
+        method: "POST",
+        url: "/webhooks/resend",
+        headers: {
+          "content-type": "application/json",
+          "svix-id": messageId,
+          "svix-timestamp": timestamp,
+          "svix-signature": signatureFor({ rawBody, messageId, timestamp }),
+        },
+        payload: rawBody,
+      });
+
+      assert.equal(response.statusCode, 503);
+      assert.equal(response.headers["retry-after"], "60");
+    } finally {
+      await retryApp.close();
+    }
+  });
+});

--- a/tests/scripts/dry-run-setup-reminders.test.ts
+++ b/tests/scripts/dry-run-setup-reminders.test.ts
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { describe, it } from "node:test";
+import {
+  createOptionalEmailDryRunRuntime,
+  parseOptionalEmailDryRunArgs,
+  runOptionalEmailDryRunCli,
+} from "../../src/scripts/dry-run-setup-reminders.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+import { after, before } from "node:test";
+
+describe("dry-run-setup-reminders CLI", () => {
+  let ctx: TestContext;
+
+  before(async () => {
+    ctx = await createTestApp();
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("supports only dry-run batch sizing and help", () => {
+    assert.deepEqual(parseOptionalEmailDryRunArgs([]), { help: false, batchLimit: 500 });
+    assert.deepEqual(parseOptionalEmailDryRunArgs(["--help"]), { help: true, batchLimit: 500 });
+    assert.deepEqual(parseOptionalEmailDryRunArgs(["--batch-limit", "25"]), {
+      help: false,
+      batchLimit: 25,
+    });
+    assert.deepEqual(parseOptionalEmailDryRunArgs(["--batch-limit=10"]), {
+      help: false,
+      batchLimit: 10,
+    });
+    assert.throws(() => parseOptionalEmailDryRunArgs(["--apply"]), /Unknown argument/);
+    assert.throws(() => parseOptionalEmailDryRunArgs(["--send"]), /Unknown argument/);
+    assert.throws(() => parseOptionalEmailDryRunArgs(["--batch-limit", "0"]), /batch-limit/);
+  });
+
+  it("contains parser failures before runtime construction", async () => {
+    const output: string[] = [];
+    const exitCode = await runOptionalEmailDryRunCli(
+      ["--apply"],
+      {},
+      {
+        stdout: (line) => output.push(line),
+        stderr: (line) => output.push(line),
+        createRuntime: async () => {
+          throw new Error("runtime must not be created for invalid arguments");
+        },
+      },
+    );
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(output, ["Invalid optional-email dry-run arguments"]);
+  });
+
+  it("prints one aggregate report without passing provider credentials to the runtime", async () => {
+    const output: string[] = [];
+    let runtimeConfig: unknown;
+    let closed = false;
+    const report = {
+      mode: "dry_run" as const,
+      generatedAt: "2026-09-06T16:00:00.000Z",
+      sendingEnabled: false,
+      recipientBasis: "unapproved" as const,
+      dailyCap: 80,
+      usersScanned: 3,
+      candidates: 2,
+      segments: { bridge_setup: 1, first_session: 1 },
+      eligible: 0,
+      blockedByReason: { recipient_basis_unapproved: 2 },
+    };
+
+    const exitCode = await runOptionalEmailDryRunCli(
+      ["--batch-limit=25"],
+      {
+        MONGODB_URI: "mongodb://isolated-test.invalid/auth",
+        OPTIONAL_EMAIL_SENDING_ENABLED: "false",
+        OPTIONAL_EMAIL_RECIPIENT_BASIS: "unapproved",
+        OPTIONAL_EMAIL_DAILY_CAP: "80",
+        RESEND_API_KEY: "must-not-be-read",
+      },
+      {
+        stdout: (line) => output.push(line),
+        stderr: (line) => output.push(`error:${line}`),
+        createRuntime: async (config) => {
+          runtimeConfig = config;
+          return {
+            run: async (input) => {
+              assert.deepEqual(input, { batchLimit: 25 });
+              return report;
+            },
+            close: async () => {
+              closed = true;
+            },
+          };
+        },
+      },
+    );
+
+    assert.equal(exitCode, 0);
+    assert.equal(closed, true);
+    assert.deepEqual(runtimeConfig, {
+      mongoUri: "mongodb://isolated-test.invalid/auth",
+      sendingEnabled: false,
+      recipientBasis: "unapproved",
+      dailyCap: 80,
+    });
+    assert.deepEqual(output, [JSON.stringify(report)]);
+    assert.doesNotMatch(output.join("\n"), /must-not-be-read|RESEND_API_KEY|@/);
+  });
+
+  it("prints usage without reading configuration or creating a runtime", async () => {
+    const output: string[] = [];
+    const exitCode = await runOptionalEmailDryRunCli(
+      ["--help"],
+      {},
+      {
+        stdout: (line) => output.push(line),
+        stderr: (line) => output.push(`error:${line}`),
+        createRuntime: async () => {
+          throw new Error("runtime must not be created for help");
+        },
+      },
+    );
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(output, ["Usage: npm run optional-email:dry-run -- [--batch-limit 1..1000]"]);
+  });
+
+  it("fails closed on invalid narrow configuration without echoing values", async () => {
+    const invalidEnvironments: NodeJS.ProcessEnv[] = [
+      {},
+      { MONGODB_URI: "mongodb://test.invalid", OPTIONAL_EMAIL_SENDING_ENABLED: "yes" },
+      { MONGODB_URI: "mongodb://test.invalid", OPTIONAL_EMAIL_RECIPIENT_BASIS: "guessed" },
+      { MONGODB_URI: "mongodb://test.invalid", OPTIONAL_EMAIL_DAILY_CAP: "81" },
+    ];
+
+    for (const env of invalidEnvironments) {
+      const output: string[] = [];
+      const exitCode = await runOptionalEmailDryRunCli([], env, {
+        stdout: (line) => output.push(line),
+        stderr: (line) => output.push(line),
+        createRuntime: async () => {
+          throw new Error("runtime must not be created for invalid config");
+        },
+      });
+
+      assert.equal(exitCode, 1);
+      assert.deepEqual(output, ["Invalid optional-email dry-run configuration"]);
+      assert.doesNotMatch(output.join("\n"), /mongodb|yes|guessed|81/);
+    }
+  });
+
+  it("closes the runtime and sanitizes operational failures", async () => {
+    const output: string[] = [];
+    let closed = false;
+    const exitCode = await runOptionalEmailDryRunCli(
+      [],
+      { MONGODB_URI: "mongodb://isolated-test.invalid/auth" },
+      {
+        stdout: (line) => output.push(line),
+        stderr: (line) => output.push(line),
+        createRuntime: async () => ({
+          run: async () => {
+            throw new Error("failed while inspecting recipient@example.test at mongodb://secret");
+          },
+          close: async () => {
+            closed = true;
+          },
+        }),
+      },
+    );
+
+    assert.equal(exitCode, 1);
+    assert.equal(closed, true);
+    assert.deepEqual(output, ["Optional-email dry-run failed"]);
+    assert.doesNotMatch(output.join("\n"), /recipient|@|mongodb|secret/);
+  });
+
+  it("builds the aggregate runtime against an isolated Mongo database", async () => {
+    await ctx.createUser();
+    const mongoUri = process.env.MONGODB_URI;
+    assert.ok(mongoUri);
+    const runtime = await createOptionalEmailDryRunRuntime({
+      mongoUri,
+      sendingEnabled: false,
+      recipientBasis: "unapproved",
+      dailyCap: 80,
+    });
+
+    try {
+      const report = await runtime.run({ batchLimit: 10 });
+      assert.equal(report.usersScanned, 1);
+      assert.equal(report.candidates, 1);
+      assert.deepEqual(report.segments, { bridge_setup: 1, first_session: 0 });
+      assert.equal(report.eligible, 0);
+      assert.deepEqual(report.blockedByReason, { recipient_basis_unapproved: 1 });
+      const serialized = JSON.stringify(report);
+      assert.doesNotMatch(serialized, /"(?:userId|recipient|email)"\s*:/i);
+      assert.doesNotMatch(serialized, /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i);
+    } finally {
+      await runtime.close();
+    }
+  });
+
+  it("runs directly as a help-only command without database configuration", () => {
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", "src/scripts/dry-run-setup-reminders.ts", "--help"],
+      { cwd: process.cwd(), encoding: "utf8" },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "Usage: npm run optional-email:dry-run -- [--batch-limit 1..1000]");
+    assert.equal(result.stderr, "");
+  });
+});

--- a/tests/scripts/send-test-setup-reminder.test.ts
+++ b/tests/scripts/send-test-setup-reminder.test.ts
@@ -1,0 +1,338 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { ObjectId } from "mongodb";
+import { describe, it } from "node:test";
+import type { OAuthAccount } from "../../src/models/documents.js";
+import {
+  createOptionalEmailTestSendRuntime,
+  runOptionalEmailTestSendCli,
+} from "../../src/scripts/send-test-setup-reminder.js";
+import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
+import { createTestApp } from "../helpers/setup.js";
+
+const VALID_ARGS = [
+  "--user-id",
+  "507f1f77bcf86cd799439011",
+  "--operation-id",
+  "manual_smoke_1",
+  "--template",
+  "bridge_setup",
+  "--confirm-recipient",
+  "alex@sesori.com",
+  "--confirm-send",
+  "SEND_ONE_TEST_EMAIL",
+];
+
+const VALID_ENABLED_ENV: NodeJS.ProcessEnv = {
+  MONGODB_URI: "mongodb://isolated.invalid/auth",
+  OPTIONAL_EMAIL_SENDING_ENABLED: "true",
+  OPTIONAL_EMAIL_TEST_SEND_ENABLED: "true",
+  OPTIONAL_EMAIL_RECIPIENT_BASIS: "account_activity_approved",
+  OPTIONAL_EMAIL_DAILY_CAP: "80",
+  RESEND_API_KEY: "re_placeholder_not_a_secret",
+  RESEND_WEBHOOK_SECRET: `whsec_${Buffer.alloc(32, 3).toString("base64")}`,
+  OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET: "u".repeat(32),
+  AUTH_BASE_URL: "https://api.sesori.com",
+};
+
+describe("send-test-setup-reminder CLI", () => {
+  it("fails before runtime construction while either send gate is disabled", async () => {
+    for (const env of [
+      { MONGODB_URI: "mongodb://isolated.invalid/auth" },
+      {
+        MONGODB_URI: "mongodb://isolated.invalid/auth",
+        OPTIONAL_EMAIL_SENDING_ENABLED: "true",
+      },
+    ]) {
+      const output: string[] = [];
+      const exitCode = await runOptionalEmailTestSendCli(VALID_ARGS, env, {
+        stdout: (line) => output.push(line),
+        stderr: (line) => output.push(line),
+        createRuntime: async () => {
+          throw new Error("test-send runtime must remain unconstructed");
+        },
+      });
+
+      assert.equal(exitCode, 1);
+      assert.deepEqual(output, ["Optional-email test send is disabled"]);
+    }
+  });
+
+  it("fails closed without an explicitly approved basis and complete signing config", async () => {
+    const output: string[] = [];
+    const exitCode = await runOptionalEmailTestSendCli(
+      VALID_ARGS,
+      {
+        MONGODB_URI: "mongodb://isolated.invalid/auth",
+        OPTIONAL_EMAIL_SENDING_ENABLED: "true",
+        OPTIONAL_EMAIL_TEST_SEND_ENABLED: "true",
+        RESEND_API_KEY: "re_placeholder_not_a_secret",
+        RESEND_WEBHOOK_SECRET: `whsec_${Buffer.alloc(32, 3).toString("base64")}`,
+        OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET: "u".repeat(32),
+        AUTH_BASE_URL: "https://api.sesori.com",
+      },
+      {
+        stdout: (line) => output.push(line),
+        stderr: (line) => output.push(line),
+        createRuntime: async () => {
+          throw new Error("runtime must not be created without approved basis");
+        },
+      },
+    );
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(output, ["Optional-email test send configuration is incomplete"]);
+    assert.doesNotMatch(output.join("\n"), /re_placeholder|whsec|mongodb|api\.sesori/);
+  });
+
+  it("rejects a webhook secret that cannot verify Resend signatures", async () => {
+    const output: string[] = [];
+    const exitCode = await runOptionalEmailTestSendCli(
+      VALID_ARGS,
+      { ...VALID_ENABLED_ENV, RESEND_WEBHOOK_SECRET: "x".repeat(40) },
+      {
+        stdout: (line) => output.push(line),
+        stderr: (line) => output.push(line),
+        createRuntime: async () => {
+          throw new Error("runtime must not be created with an invalid webhook secret");
+        },
+      },
+    );
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(output, ["Optional-email test send configuration is incomplete"]);
+  });
+
+  it("rejects every recipient except the pinned test address", async () => {
+    const args = [...VALID_ARGS];
+    args[args.indexOf("alex@sesori.com")] = "other@example.test";
+    const output: string[] = [];
+    const exitCode = await runOptionalEmailTestSendCli(args, VALID_ENABLED_ENV, {
+      stdout: (line) => output.push(line),
+      stderr: (line) => output.push(line),
+      createRuntime: async () => {
+        throw new Error("runtime must not be created for a non-allowlisted recipient");
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(output, ["Invalid optional-email test-send arguments"]);
+    assert.doesNotMatch(output.join("\n"), /other@example|alex@sesori/);
+  });
+
+  it("requires the literal one-test-email operator confirmation", async () => {
+    const args = [...VALID_ARGS];
+    args[args.indexOf("SEND_ONE_TEST_EMAIL")] = "SEND_EMAILS";
+    const output: string[] = [];
+    const exitCode = await runOptionalEmailTestSendCli(args, VALID_ENABLED_ENV, {
+      stdout: (line) => output.push(line),
+      stderr: (line) => output.push(line),
+      createRuntime: async () => {
+        throw new Error("runtime must not be created without exact confirmation");
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(output, ["Invalid optional-email test-send arguments"]);
+  });
+
+  it("rejects a non-canonical Mongo user id", async () => {
+    const args = [...VALID_ARGS];
+    args[args.indexOf("507f1f77bcf86cd799439011")] = "not-a-user-id";
+    const output: string[] = [];
+    const exitCode = await runOptionalEmailTestSendCli(args, VALID_ENABLED_ENV, {
+      stdout: (line) => output.push(line),
+      stderr: (line) => output.push(line),
+      createRuntime: async () => {
+        throw new Error("runtime must not be created for an invalid user id");
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(output, ["Invalid optional-email test-send arguments"]);
+  });
+
+  it("rejects an operation id that is not a short slug", async () => {
+    const args = [...VALID_ARGS];
+    args[args.indexOf("manual_smoke_1")] = "manual smoke / address@example.test";
+    const output: string[] = [];
+    const exitCode = await runOptionalEmailTestSendCli(args, VALID_ENABLED_ENV, {
+      stdout: (line) => output.push(line),
+      stderr: (line) => output.push(line),
+      createRuntime: async () => {
+        throw new Error("runtime must not be created for an invalid operation id");
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(output, ["Invalid optional-email test-send arguments"]);
+    assert.doesNotMatch(output.join("\n"), /address@example/);
+  });
+
+  it("rejects any template outside the two setup reminders", async () => {
+    const args = [...VALID_ARGS];
+    args[args.indexOf("bridge_setup")] = "bulk_campaign";
+    const output: string[] = [];
+    const exitCode = await runOptionalEmailTestSendCli(args, VALID_ENABLED_ENV, {
+      stdout: (line) => output.push(line),
+      stderr: (line) => output.push(line),
+      createRuntime: async () => {
+        throw new Error("runtime must not be created for an invalid template");
+      },
+    });
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(output, ["Invalid optional-email test-send arguments"]);
+  });
+
+  it("rejects unexpected or duplicate argument pairs", async () => {
+    const output: string[] = [];
+    const exitCode = await runOptionalEmailTestSendCli(
+      [...VALID_ARGS, "--recipient", "customer@example.test"],
+      VALID_ENABLED_ENV,
+      {
+        stdout: (line) => output.push(line),
+        stderr: (line) => output.push(line),
+        createRuntime: async () => {
+          throw new Error("runtime must not be created for unexpected arguments");
+        },
+      },
+    );
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(output, ["Invalid optional-email test-send arguments"]);
+    assert.doesNotMatch(output.join("\n"), /customer@example/);
+  });
+
+  it("runs exactly one allowlisted test send and prints no recipient or user", async () => {
+    const output: string[] = [];
+    let closed = false;
+    let runtimeInput: unknown;
+    let runtimeConfig: unknown;
+    const exitCode = await runOptionalEmailTestSendCli(VALID_ARGS, VALID_ENABLED_ENV, {
+      stdout: (line) => output.push(line),
+      stderr: (line) => output.push(line),
+      createRuntime: async (config) => {
+        runtimeConfig = config;
+        return {
+          send: async (input) => {
+            runtimeInput = input;
+            return {
+              status: "sent",
+              sendKey: "optional/opaque-test-key",
+              providerEmailId: "resend_test_1",
+            };
+          },
+          close: async () => {
+            closed = true;
+          },
+        };
+      },
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(closed, true);
+    assert.deepEqual(runtimeInput, {
+      userId: "507f1f77bcf86cd799439011",
+      operationId: "manual_smoke_1",
+      template: "bridge_setup",
+      recipient: "alex@sesori.com",
+    });
+    assert.deepEqual(runtimeConfig, {
+      mongoUri: "mongodb://isolated.invalid/auth",
+      resendApiKey: "re_placeholder_not_a_secret",
+      webhookSigningSecret: VALID_ENABLED_ENV.RESEND_WEBHOOK_SECRET,
+      unsubscribeSigningSecret: "u".repeat(32),
+      publicBaseUrl: "https://api.sesori.com",
+      from: "Sesori <hello@updates.sesori.com>",
+      replyTo: "hello@sesori.com",
+      testRecipient: "alex@sesori.com",
+      dailyCap: 80,
+      recipientBasis: "account_activity_approved",
+    });
+    assert.deepEqual(output, [
+      '{"status":"sent","sendKey":"optional/opaque-test-key","providerEmailId":"resend_test_1"}',
+    ]);
+    assert.doesNotMatch(output[0] ?? "", /@|507f1f77|re_placeholder|whsec/);
+  });
+
+  it("closes and sanitizes a runtime failure", async () => {
+    const output: string[] = [];
+    let closed = false;
+    const exitCode = await runOptionalEmailTestSendCli(VALID_ARGS, VALID_ENABLED_ENV, {
+      stdout: (line) => output.push(line),
+      stderr: (line) => output.push(line),
+      createRuntime: async () => ({
+        send: async () => {
+          throw new Error("alex@sesori.com mongodb://private re_private");
+        },
+        close: async () => {
+          closed = true;
+        },
+      }),
+    });
+
+    assert.equal(exitCode, 1);
+    assert.equal(closed, true);
+    assert.deepEqual(output, ["Optional-email test send failed"]);
+  });
+
+  it("uses isolated Mongo state and injected fetch for the real runtime", async () => {
+    const ctx = await createTestApp();
+    try {
+      const user = await ctx.createUser();
+      await ctx.dbAccessor
+        .getCollection<OAuthAccount>(MongoDbDatabase.Auth, AuthDbCollection.OAuthAccounts)
+        .updateOne({ userId: new ObjectId(user.userId) }, { $set: { email: "alex@sesori.com" } });
+
+      let requestCount = 0;
+      const runtime = await createOptionalEmailTestSendRuntime(
+        {
+          mongoUri: process.env.MONGODB_URI!,
+          resendApiKey: "re_placeholder_not_a_secret",
+          webhookSigningSecret: `whsec_${Buffer.alloc(32, 3).toString("base64")}`,
+          unsubscribeSigningSecret: "u".repeat(32),
+          publicBaseUrl: "https://api.sesori.com",
+          from: "Sesori <hello@updates.sesori.com>",
+          replyTo: "hello@sesori.com",
+          testRecipient: "alex@sesori.com",
+          dailyCap: 80,
+          recipientBasis: "account_activity_approved",
+        },
+        {
+          fetchFn: async () => {
+            requestCount += 1;
+            return new Response(JSON.stringify({ id: "resend_isolated_1" }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            });
+          },
+        },
+      );
+      const result = await runtime.send({
+        userId: user.userId,
+        operationId: "isolated_smoke_1",
+        template: "bridge_setup",
+        recipient: "alex@sesori.com",
+      });
+      await runtime.close();
+
+      assert.equal(result.status, "sent");
+      assert.equal(requestCount, 1);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it("prints help without reading send configuration", () => {
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", "src/scripts/send-test-setup-reminder.ts", "--help"],
+      { cwd: process.cwd(), encoding: "utf8", env: {} },
+    );
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /^Usage: npm run optional-email:test-send --/);
+    assert.equal(result.stderr, "");
+  });
+});

--- a/tests/services/optional-email-delivery-service.test.ts
+++ b/tests/services/optional-email-delivery-service.test.ts
@@ -1,0 +1,583 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import type { OptionalEmailProviderSendInput } from "../../src/clients/resend-optional-email-adapter.js";
+import { ResendOptionalEmailError } from "../../src/clients/resend-optional-email-adapter.js";
+import { OptionalEmailDailyQuotaRepository } from "../../src/repositories/optional-email-daily-quota-repo.js";
+import { OptionalEmailSendRepository } from "../../src/repositories/optional-email-send-repo.js";
+import { OptionalEmailDeliveryService } from "../../src/services/optional-email-delivery-service.js";
+import { OptionalEmailUnsubscribeTokenService } from "../../src/services/optional-email-unsubscribe-service.js";
+import { OptionalEmailReminderKind } from "../../src/types/optional-email.js";
+import { createTestApp, type TestAppContext } from "../helpers/setup.js";
+
+describe("OptionalEmailDeliveryService", () => {
+  let ctx: TestAppContext;
+
+  before(async () => {
+    ctx = await createTestApp();
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("rechecks eligibility immediately before one idempotent provider send", async () => {
+    const user = await ctx.createUser();
+    const now = new Date("2026-09-06T12:00:00.000Z");
+    const tokenService = new OptionalEmailUnsubscribeTokenService({
+      signingSecret: Buffer.alloc(32, 17),
+    });
+    let eligibilityChecks = 0;
+    const providerCalls: OptionalEmailProviderSendInput[] = [];
+    const sendRepo = new OptionalEmailSendRepository(ctx.dbAccessor);
+    const service = new OptionalEmailDeliveryService({
+      eligibility: {
+        evaluate: async () => {
+          eligibilityChecks += 1;
+          return { eligible: true as const, recipient: "unique@example.test" };
+        },
+      },
+      sendRepo,
+      quotaRepo: new OptionalEmailDailyQuotaRepository(ctx.dbAccessor),
+      provider: {
+        send: async (input) => {
+          providerCalls.push(input);
+          return { providerEmailId: "resend-delivery-1" };
+        },
+      },
+      tokenService,
+      policy: {
+        from: "Sesori <hello@updates.sesori.com>",
+        replyTo: "hello@sesori.com",
+        publicBaseUrl: "https://api.sesori.com",
+        dailyCap: 80,
+        testRecipient: "alex@sesori.com",
+        testSendEnabled: false,
+      },
+      clock: () => now,
+    });
+
+    const result = await service.sendReminder({
+      userId: user.userId,
+      campaignId: "setup-2026-09",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+    });
+
+    assert.equal(result.status, "sent");
+    assert.equal(result.providerEmailId, "resend-delivery-1");
+    assert.equal(eligibilityChecks, 2);
+    assert.equal(providerCalls.length, 1);
+    const message = providerCalls[0];
+    assert.equal(message?.idempotencyKey, result.sendKey);
+    assert.equal(message?.from, "Sesori <hello@updates.sesori.com>");
+    assert.equal(message?.replyTo, "hello@sesori.com");
+    assert.equal(message?.recipient, "unique@example.test");
+    assert.equal(message?.headers["List-Unsubscribe-Post"], "List-Unsubscribe=One-Click");
+    const unsubscribeHeader = message?.headers["List-Unsubscribe"];
+    assert.match(unsubscribeHeader ?? "", /^<https:\/\/api\.sesori\.com\/email\/optional\/unsubscribe\?token=/);
+    const token = new URL((unsubscribeHeader ?? "").slice(1, -1)).searchParams.get("token");
+    assert.equal(tokenService.verify({ token: token ?? "" }), user.userId);
+    assert.match(message?.html ?? "", /Unsubscribe/);
+    assert.match(message?.text ?? "", /Unsubscribe:/);
+    assert.deepEqual(message?.tags, [
+      { name: "category", value: "optional_setup_reminder" },
+      { name: "campaign", value: "setup-2026-09" },
+    ]);
+
+    const stored = await sendRepo.findBySendKey({ sendKey: result.sendKey });
+    assert.equal(stored?.status, "accepted");
+    assert.equal(stored?.providerEmailId, "resend-delivery-1");
+    assert.equal(stored?.attemptCount, 1);
+  });
+
+  it("blocks an already reserved reminder when unsubscribe appears before the provider call", async () => {
+    const user = await ctx.createUser();
+    const sendRepo = new OptionalEmailSendRepository(ctx.dbAccessor);
+    let checks = 0;
+    let providerCalls = 0;
+    const service = new OptionalEmailDeliveryService({
+      eligibility: {
+        evaluate: async () => {
+          checks += 1;
+          return checks === 1
+            ? { eligible: true as const, recipient: "queued@example.test" }
+            : { eligible: false as const, reason: "unsubscribed" };
+        },
+      },
+      sendRepo,
+      quotaRepo: new OptionalEmailDailyQuotaRepository(ctx.dbAccessor),
+      provider: {
+        send: async () => {
+          providerCalls += 1;
+          return { providerEmailId: "must-not-send" };
+        },
+      },
+      tokenService: new OptionalEmailUnsubscribeTokenService({ signingSecret: Buffer.alloc(32, 18) }),
+      policy: {
+        from: "Sesori <hello@updates.sesori.com>",
+        replyTo: "hello@sesori.com",
+        publicBaseUrl: "https://api.sesori.com",
+        dailyCap: 80,
+        testRecipient: "alex@sesori.com",
+        testSendEnabled: false,
+      },
+      clock: () => new Date("2026-09-06T13:00:00.000Z"),
+    });
+
+    const result = await service.sendReminder({
+      userId: user.userId,
+      campaignId: "queued-unsubscribe",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+    });
+
+    assert.equal(result.status, "blocked");
+    assert.equal(result.reason, "unsubscribed");
+    assert.equal(providerCalls, 0);
+    const stored = await sendRepo.findBySendKey({ sendKey: result.sendKey });
+    assert.equal(stored?.status, "blocked");
+    assert.equal(stored?.lastBlockReason, "unsubscribed");
+  });
+
+  it("returns duplicate without another provider call or quota slot", async () => {
+    const user = await ctx.createUser();
+    const at = new Date("2026-09-07T12:00:00.000Z");
+    let providerCalls = 0;
+    const quotaRepo = new OptionalEmailDailyQuotaRepository(ctx.dbAccessor);
+    const service = new OptionalEmailDeliveryService({
+      eligibility: {
+        evaluate: async () => ({ eligible: true as const, recipient: "duplicate@example.test" }),
+      },
+      sendRepo: new OptionalEmailSendRepository(ctx.dbAccessor),
+      quotaRepo,
+      provider: {
+        send: async () => {
+          providerCalls += 1;
+          return { providerEmailId: "resend-duplicate-1" };
+        },
+      },
+      tokenService: new OptionalEmailUnsubscribeTokenService({ signingSecret: Buffer.alloc(32, 19) }),
+      policy: {
+        from: "Sesori <hello@updates.sesori.com>",
+        replyTo: "hello@sesori.com",
+        publicBaseUrl: "https://api.sesori.com",
+        dailyCap: 80,
+        testRecipient: "alex@sesori.com",
+        testSendEnabled: false,
+      },
+      clock: () => at,
+    });
+    const input = {
+      userId: user.userId,
+      campaignId: "duplicate-delivery",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+    };
+
+    const first = await service.sendReminder(input);
+    const second = await service.sendReminder(input);
+
+    assert.equal(first.status, "sent");
+    assert.equal(second.status, "duplicate");
+    assert.equal(providerCalls, 1);
+    assert.equal((await quotaRepo.getUsage({ at, dailyCap: 80 })).used, 1);
+  });
+
+  it("defers at the daily cap and reclaims the same send on the next UTC day", async () => {
+    const firstUser = await ctx.createUser();
+    const secondUser = await ctx.createUser();
+    let now = new Date("2026-09-08T12:00:00.000Z");
+    let providerCalls = 0;
+    const sendRepo = new OptionalEmailSendRepository(ctx.dbAccessor);
+    const service = new OptionalEmailDeliveryService({
+      eligibility: {
+        evaluate: async () => ({ eligible: true as const, recipient: "quota@example.test" }),
+      },
+      sendRepo,
+      quotaRepo: new OptionalEmailDailyQuotaRepository(ctx.dbAccessor),
+      provider: {
+        send: async () => {
+          providerCalls += 1;
+          return { providerEmailId: `resend-quota-${providerCalls}` };
+        },
+      },
+      tokenService: new OptionalEmailUnsubscribeTokenService({ signingSecret: Buffer.alloc(32, 20) }),
+      policy: {
+        from: "Sesori <hello@updates.sesori.com>",
+        replyTo: "hello@sesori.com",
+        publicBaseUrl: "https://api.sesori.com",
+        dailyCap: 1,
+        testRecipient: "alex@sesori.com",
+        testSendEnabled: false,
+      },
+      clock: () => now,
+    });
+
+    assert.equal(
+      (
+        await service.sendReminder({
+          userId: firstUser.userId,
+          campaignId: "quota-first",
+          reminderKind: OptionalEmailReminderKind.BridgeSetup,
+        })
+      ).status,
+      "sent",
+    );
+    const deferred = await service.sendReminder({
+      userId: secondUser.userId,
+      campaignId: "quota-second",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+    });
+    assert.equal(deferred.status, "daily_limit");
+    assert.equal(providerCalls, 1);
+    assert.equal((await sendRepo.findBySendKey({ sendKey: deferred.sendKey }))?.status, "deferred_daily_limit");
+
+    now = new Date("2026-09-09T00:00:00.000Z");
+    const retried = await service.sendReminder({
+      userId: secondUser.userId,
+      campaignId: "quota-second",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+    });
+    assert.equal(retried.status, "sent");
+    assert.equal(providerCalls, 2);
+  });
+
+  it("persists a sanitized provider failure for an idempotent retry", async () => {
+    const user = await ctx.createUser();
+    const sendRepo = new OptionalEmailSendRepository(ctx.dbAccessor);
+    const service = new OptionalEmailDeliveryService({
+      eligibility: {
+        evaluate: async () => ({ eligible: true as const, recipient: "retry@example.test" }),
+      },
+      sendRepo,
+      quotaRepo: new OptionalEmailDailyQuotaRepository(ctx.dbAccessor),
+      provider: {
+        send: async () => {
+          throw new ResendOptionalEmailError("unavailable");
+        },
+      },
+      tokenService: new OptionalEmailUnsubscribeTokenService({ signingSecret: Buffer.alloc(32, 21) }),
+      policy: {
+        from: "Sesori <hello@updates.sesori.com>",
+        replyTo: "hello@sesori.com",
+        publicBaseUrl: "https://api.sesori.com",
+        dailyCap: 80,
+        testRecipient: "alex@sesori.com",
+        testSendEnabled: false,
+      },
+      clock: () => new Date("2026-09-10T12:00:00.000Z"),
+    });
+
+    const result = await service.sendReminder({
+      userId: user.userId,
+      campaignId: "provider-retry",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+    });
+
+    assert.equal(result.status, "provider_failed");
+    assert.equal(result.code, "unavailable");
+    const stored = await sendRepo.findBySendKey({ sendKey: result.sendKey });
+    assert.equal(stored?.status, "failed");
+    assert.equal(stored?.lastFailureCode, "unavailable");
+    assert.equal(stored?.attemptCount, 1);
+  });
+
+  it("blocks a failed retry and a later campaign after unsubscribe", async () => {
+    const user = await ctx.createUser();
+    let unsubscribed = false;
+    let providerCalls = 0;
+    const service = new OptionalEmailDeliveryService({
+      eligibility: {
+        evaluate: async () =>
+          unsubscribed
+            ? { eligible: false as const, reason: "unsubscribed" }
+            : { eligible: true as const, recipient: "unsubscribe@example.test" },
+      },
+      sendRepo: new OptionalEmailSendRepository(ctx.dbAccessor),
+      quotaRepo: new OptionalEmailDailyQuotaRepository(ctx.dbAccessor),
+      provider: {
+        send: async () => {
+          providerCalls += 1;
+          throw new ResendOptionalEmailError("unavailable");
+        },
+      },
+      tokenService: new OptionalEmailUnsubscribeTokenService({ signingSecret: Buffer.alloc(32, 22) }),
+      policy: {
+        from: "Sesori <hello@updates.sesori.com>",
+        replyTo: "hello@sesori.com",
+        publicBaseUrl: "https://api.sesori.com",
+        dailyCap: 80,
+        testRecipient: "alex@sesori.com",
+        testSendEnabled: false,
+      },
+      clock: () => new Date("2026-09-11T12:00:00.000Z"),
+    });
+    const firstCampaign = {
+      userId: user.userId,
+      campaignId: "unsubscribe-retry",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+    };
+
+    assert.equal((await service.sendReminder(firstCampaign)).status, "provider_failed");
+    unsubscribed = true;
+    const retry = await service.sendReminder(firstCampaign);
+    const laterCampaign = await service.sendReminder({
+      ...firstCampaign,
+      campaignId: "unsubscribe-later",
+    });
+
+    assert.deepEqual(retry, { status: "blocked", reason: "unsubscribed" });
+    assert.deepEqual(laterCampaign, { status: "blocked", reason: "unsubscribed" });
+    assert.equal(providerCalls, 1);
+  });
+
+  it("delivers distinct first-session reminder content", async () => {
+    const user = await ctx.createUser();
+    const sentMessages: OptionalEmailProviderSendInput[] = [];
+    const service = new OptionalEmailDeliveryService({
+      eligibility: {
+        evaluate: async () => ({ eligible: true as const, recipient: "session@example.test" }),
+      },
+      sendRepo: new OptionalEmailSendRepository(ctx.dbAccessor),
+      quotaRepo: new OptionalEmailDailyQuotaRepository(ctx.dbAccessor),
+      provider: {
+        send: async (input: OptionalEmailProviderSendInput) => {
+          sentMessages.push(input);
+          return { providerEmailId: "resend-first-session-1" };
+        },
+      },
+      tokenService: new OptionalEmailUnsubscribeTokenService({ signingSecret: Buffer.alloc(32, 23) }),
+      policy: {
+        from: "Sesori <hello@updates.sesori.com>",
+        replyTo: "hello@sesori.com",
+        publicBaseUrl: "https://api.sesori.com",
+        dailyCap: 80,
+        testRecipient: "alex@sesori.com",
+        testSendEnabled: false,
+      },
+      clock: () => new Date("2026-09-12T12:00:00.000Z"),
+    });
+
+    const result = await service.sendReminder({
+      userId: user.userId,
+      campaignId: "first-session-reminder",
+      reminderKind: OptionalEmailReminderKind.FirstSession,
+    });
+
+    assert.equal(result.status, "sent");
+    assert.equal(sentMessages[0]?.subject, "Run your first coding session with Sesori");
+    assert.match(sentMessages[0]?.text ?? "", /first coding session/);
+  });
+
+  it("keeps the test-send path disabled without any downstream access", async () => {
+    let downstreamCalls = 0;
+    const service = new OptionalEmailDeliveryService({
+      eligibility: {
+        evaluate: async () => {
+          downstreamCalls += 1;
+          return { eligible: true as const, recipient: "alex@sesori.com" };
+        },
+      },
+      sendRepo: new OptionalEmailSendRepository(ctx.dbAccessor),
+      quotaRepo: new OptionalEmailDailyQuotaRepository(ctx.dbAccessor),
+      provider: {
+        send: async () => {
+          downstreamCalls += 1;
+          return { providerEmailId: "must-not-send" };
+        },
+      },
+      tokenService: new OptionalEmailUnsubscribeTokenService({ signingSecret: Buffer.alloc(32, 24) }),
+      policy: {
+        from: "Sesori <hello@updates.sesori.com>",
+        replyTo: "hello@sesori.com",
+        publicBaseUrl: "https://api.sesori.com",
+        dailyCap: 80,
+        testRecipient: "alex@sesori.com",
+        testSendEnabled: false,
+      },
+      clock: () => new Date("2026-09-13T12:00:00.000Z"),
+    });
+
+    const result = await service.sendTest({
+      userId: "000000000000000000000001",
+      recipient: "alex@sesori.com",
+      operationId: "manual-1",
+      templateKind: OptionalEmailReminderKind.BridgeSetup,
+    });
+
+    assert.deepEqual(result, { status: "blocked", reason: "test_sending_disabled" });
+    assert.equal(downstreamCalls, 0);
+  });
+
+  it("rejects every test recipient outside the pinned allowlist", async () => {
+    let downstreamCalls = 0;
+    const service = new OptionalEmailDeliveryService({
+      eligibility: {
+        evaluate: async () => {
+          downstreamCalls += 1;
+          return { eligible: true as const, recipient: "other@example.test" };
+        },
+      },
+      sendRepo: new OptionalEmailSendRepository(ctx.dbAccessor),
+      quotaRepo: new OptionalEmailDailyQuotaRepository(ctx.dbAccessor),
+      provider: {
+        send: async () => {
+          downstreamCalls += 1;
+          return { providerEmailId: "must-not-send" };
+        },
+      },
+      tokenService: new OptionalEmailUnsubscribeTokenService({ signingSecret: Buffer.alloc(32, 25) }),
+      policy: {
+        from: "Sesori <hello@updates.sesori.com>",
+        replyTo: "hello@sesori.com",
+        publicBaseUrl: "https://api.sesori.com",
+        dailyCap: 80,
+        testRecipient: "alex@sesori.com",
+        testSendEnabled: true,
+      },
+      clock: () => new Date("2026-09-13T13:00:00.000Z"),
+    });
+
+    const result = await service.sendTest({
+      userId: "000000000000000000000001",
+      recipient: "other@example.test",
+      operationId: "manual-2",
+      templateKind: OptionalEmailReminderKind.BridgeSetup,
+    });
+
+    assert.deepEqual(result, { status: "blocked", reason: "test_recipient_not_allowed" });
+    assert.equal(downstreamCalls, 0);
+  });
+
+  it("sends only the pinned test recipient through normal quota and idempotency safeguards", async () => {
+    const user = await ctx.createUser();
+    let eligibilityChecks = 0;
+    const providerMessages: OptionalEmailProviderSendInput[] = [];
+    const service = new OptionalEmailDeliveryService({
+      eligibility: {
+        evaluate: async () => {
+          eligibilityChecks += 1;
+          return { eligible: true as const, recipient: "alex@sesori.com" };
+        },
+      },
+      sendRepo: new OptionalEmailSendRepository(ctx.dbAccessor),
+      quotaRepo: new OptionalEmailDailyQuotaRepository(ctx.dbAccessor),
+      provider: {
+        send: async (input: OptionalEmailProviderSendInput) => {
+          providerMessages.push(input);
+          return { providerEmailId: "resend-test-only-1" };
+        },
+      },
+      tokenService: new OptionalEmailUnsubscribeTokenService({ signingSecret: Buffer.alloc(32, 26) }),
+      policy: {
+        from: "Sesori <hello@updates.sesori.com>",
+        replyTo: "hello@sesori.com",
+        publicBaseUrl: "https://api.sesori.com",
+        dailyCap: 80,
+        testRecipient: "alex@sesori.com",
+        testSendEnabled: true,
+      },
+      clock: () => new Date("2026-09-13T14:00:00.000Z"),
+    });
+    const input = {
+      userId: user.userId,
+      recipient: "alex@sesori.com",
+      operationId: "manual_allowed_1",
+      templateKind: OptionalEmailReminderKind.BridgeSetup,
+    };
+
+    const first = await service.sendTest(input);
+    const duplicate = await service.sendTest(input);
+
+    assert.equal(first.status, "sent");
+    assert.equal(duplicate.status, "duplicate");
+    assert.equal(eligibilityChecks, 3);
+    assert.equal(providerMessages.length, 1);
+    assert.equal(providerMessages[0]?.recipient, "alex@sesori.com");
+    assert.match(providerMessages[0]?.idempotencyKey ?? "", /^optional\/[a-f0-9]{64}$/);
+  });
+
+  it("blocks the test path if resolved recipient changes before the provider call", async () => {
+    const user = await ctx.createUser();
+    let eligibilityChecks = 0;
+    let providerCalls = 0;
+    const service = new OptionalEmailDeliveryService({
+      eligibility: {
+        evaluate: async () => {
+          eligibilityChecks += 1;
+          return {
+            eligible: true as const,
+            recipient: eligibilityChecks === 1 ? "alex@sesori.com" : "changed@example.test",
+          };
+        },
+      },
+      sendRepo: new OptionalEmailSendRepository(ctx.dbAccessor),
+      quotaRepo: new OptionalEmailDailyQuotaRepository(ctx.dbAccessor),
+      provider: {
+        send: async () => {
+          providerCalls += 1;
+          return { providerEmailId: "must-not-send" };
+        },
+      },
+      tokenService: new OptionalEmailUnsubscribeTokenService({ signingSecret: Buffer.alloc(32, 27) }),
+      policy: {
+        from: "Sesori <hello@updates.sesori.com>",
+        replyTo: "hello@sesori.com",
+        publicBaseUrl: "https://api.sesori.com",
+        dailyCap: 80,
+        testRecipient: "alex@sesori.com",
+        testSendEnabled: true,
+      },
+      clock: () => new Date("2026-09-13T15:00:00.000Z"),
+    });
+
+    const result = await service.sendTest({
+      userId: user.userId,
+      recipient: "alex@sesori.com",
+      operationId: "recipient_race_1",
+      templateKind: OptionalEmailReminderKind.BridgeSetup,
+    });
+
+    assert.equal(result.status, "blocked");
+    assert.equal(result.reason, "test_recipient_not_allowed");
+    assert.equal(providerCalls, 0);
+  });
+
+  it("fails closed when a provider retry is outside the idempotency safety window", async () => {
+    const user = await ctx.createUser();
+    let now = new Date("2026-09-14T00:00:00.000Z");
+    let providerCalls = 0;
+    const service = new OptionalEmailDeliveryService({
+      eligibility: {
+        evaluate: async () => ({ eligible: true as const, recipient: "expired@example.test" }),
+      },
+      sendRepo: new OptionalEmailSendRepository(ctx.dbAccessor),
+      quotaRepo: new OptionalEmailDailyQuotaRepository(ctx.dbAccessor),
+      provider: {
+        send: async () => {
+          providerCalls += 1;
+          throw new ResendOptionalEmailError("unavailable");
+        },
+      },
+      tokenService: new OptionalEmailUnsubscribeTokenService({ signingSecret: Buffer.alloc(32, 28) }),
+      policy: {
+        from: "Sesori <hello@updates.sesori.com>",
+        replyTo: "hello@sesori.com",
+        publicBaseUrl: "https://api.sesori.com",
+        dailyCap: 80,
+        testRecipient: "alex@sesori.com",
+        testSendEnabled: false,
+      },
+      clock: () => now,
+    });
+    const input = {
+      userId: user.userId,
+      campaignId: "expired-retry",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+    };
+
+    assert.equal((await service.sendReminder(input)).status, "provider_failed");
+    now = new Date("2026-09-15T00:00:01.000Z");
+    const expired = await service.sendReminder(input);
+
+    assert.deepEqual(expired, { status: "blocked", reason: "retry_window_expired" });
+    assert.equal(providerCalls, 1);
+  });
+});

--- a/tests/services/optional-email-dry-run-service.test.ts
+++ b/tests/services/optional-email-dry-run-service.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { ObjectId } from "mongodb";
+import type { ActivationState } from "../../src/models/documents.js";
+import { OptionalEmailDryRunService } from "../../src/services/optional-email-dry-run-service.js";
+import { OptionalEmailRecipientBasis, OptionalEmailReminderKind } from "../../src/types/optional-email.js";
+
+function activationState(input: { userId: string; bridgeSetupAt?: Date; firstSessionAt?: Date }): ActivationState {
+  const createdAt = new Date("2026-09-01T00:00:00.000Z");
+  return {
+    _id: new ObjectId(),
+    userId: new ObjectId(input.userId),
+    mobileSetupAt: null,
+    bridgeSetupAt: input.bridgeSetupAt ?? null,
+    firstSessionAt: input.firstSessionAt ?? null,
+    reminderSchedule: null,
+    reminderRevision: 0,
+    backfilledAt: null,
+    createdAt,
+    updatedAt: createdAt,
+  };
+}
+
+describe("OptionalEmailDryRunService", () => {
+  it("returns aggregate segment and eligibility counts without identifiers or addresses", async () => {
+    const users = [new ObjectId().toHexString(), new ObjectId().toHexString(), new ObjectId().toHexString()];
+    const states = new Map<string, ActivationState | null>([
+      [users[0] ?? "", null],
+      [
+        users[1] ?? "",
+        activationState({ userId: users[1] ?? "", bridgeSetupAt: new Date("2026-09-02T00:00:00.000Z") }),
+      ],
+      [
+        users[2] ?? "",
+        activationState({
+          userId: users[2] ?? "",
+          bridgeSetupAt: new Date("2026-09-02T00:00:00.000Z"),
+          firstSessionAt: new Date("2026-09-03T00:00:00.000Z"),
+        }),
+      ],
+    ]);
+    let page = 0;
+    const service = new OptionalEmailDryRunService({
+      users: {
+        findIdBatch: async () => {
+          page += 1;
+          return page === 1 ? users.slice(0, 2) : page === 2 ? users.slice(2) : [];
+        },
+      },
+      activationStates: {
+        findByUserId: async (userId) => states.get(userId) ?? null,
+      },
+      eligibility: {
+        evaluateDryRun: async ({ reminderKind }) =>
+          reminderKind === OptionalEmailReminderKind.BridgeSetup
+            ? { eligible: true as const, recipient: "must-not-escape@example.test" }
+            : { eligible: false as const, reason: "suppressed" },
+      },
+      policy: {
+        sendingEnabled: false,
+        recipientBasis: OptionalEmailRecipientBasis.AccountActivityApproved,
+        dailyCap: 80,
+      },
+      clock: () => new Date("2026-09-06T16:00:00.000Z"),
+    });
+
+    const report = await service.run({ batchLimit: 2 });
+
+    assert.deepEqual(report, {
+      mode: "dry_run",
+      generatedAt: "2026-09-06T16:00:00.000Z",
+      sendingEnabled: false,
+      recipientBasis: "account_activity_approved",
+      dailyCap: 80,
+      usersScanned: 3,
+      candidates: 2,
+      segments: { bridge_setup: 1, first_session: 1 },
+      eligible: 1,
+      blockedByReason: { suppressed: 1 },
+    });
+    const serialized = JSON.stringify(report);
+    assert.doesNotMatch(serialized, /@|must-not-escape/);
+    for (const userId of users) {
+      assert.doesNotMatch(serialized, new RegExp(userId));
+    }
+  });
+});

--- a/tests/services/optional-email-eligibility-service.test.ts
+++ b/tests/services/optional-email-eligibility-service.test.ts
@@ -1,0 +1,245 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { ObjectId } from "mongodb";
+import type { ActivationState } from "../../src/models/documents.js";
+import { OptionalEmailEligibilityService } from "../../src/services/optional-email-eligibility-service.js";
+import {
+  OptionalEmailBlockReason,
+  OptionalEmailRecipientBasis,
+  OptionalEmailReminderKind,
+} from "../../src/types/optional-email.js";
+
+describe("OptionalEmailEligibilityService", () => {
+  it("fails closed before user or email lookup when recipient basis is unapproved", async () => {
+    let downstreamReads = 0;
+    const service = new OptionalEmailEligibilityService({
+      policy: {
+        sendingEnabled: true,
+        recipientBasis: OptionalEmailRecipientBasis.Unapproved,
+      },
+      recipients: {
+        resolve: async () => {
+          downstreamReads += 1;
+          return { status: "unique", email: "should-not-be-read@example.test" } as const;
+        },
+      },
+      preferences: {
+        findBlockReason: async () => {
+          downstreamReads += 1;
+          return null;
+        },
+      },
+      activationStates: {
+        findByUserId: async () => {
+          downstreamReads += 1;
+          return null;
+        },
+      },
+    });
+
+    const result = await service.evaluate({
+      userId: "000000000000000000000001",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+    });
+
+    assert.deepEqual(result, { eligible: false, reason: "recipient_basis_unapproved" });
+    assert.equal(downstreamReads, 0);
+  });
+
+  it("blocks all real sends before downstream reads while sending is disabled", async () => {
+    let downstreamReads = 0;
+    const read = async () => {
+      downstreamReads += 1;
+      return null;
+    };
+    const service = new OptionalEmailEligibilityService({
+      policy: {
+        sendingEnabled: false,
+        recipientBasis: OptionalEmailRecipientBasis.AccountActivityApproved,
+      },
+      recipients: { resolve: read as never },
+      preferences: { findBlockReason: read as never },
+      activationStates: { findByUserId: read },
+    });
+
+    const result = await service.evaluate({
+      userId: "000000000000000000000001",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+    });
+
+    assert.deepEqual(result, { eligible: false, reason: "sending_disabled" });
+    assert.equal(downstreamReads, 0);
+  });
+
+  it("blocks unsubscribe and suppression before resolving a recipient address", async () => {
+    for (const blockReason of [OptionalEmailBlockReason.Unsubscribed, OptionalEmailBlockReason.Suppressed]) {
+      let recipientReads = 0;
+      const service = new OptionalEmailEligibilityService({
+        policy: {
+          sendingEnabled: true,
+          recipientBasis: OptionalEmailRecipientBasis.AccountActivityApproved,
+        },
+        recipients: {
+          resolve: async () => {
+            recipientReads += 1;
+            return { status: "unique", email: "should-not-be-read@example.test" };
+          },
+        },
+        preferences: { findBlockReason: async () => blockReason },
+        activationStates: { findByUserId: async () => null },
+      });
+
+      assert.deepEqual(
+        await service.evaluate({
+          userId: "000000000000000000000001",
+          reminderKind: OptionalEmailReminderKind.BridgeSetup,
+        }),
+        { eligible: false, reason: blockReason },
+      );
+      assert.equal(recipientReads, 0);
+    }
+  });
+
+  it("blocks milestone-obsolete reminders and unmet session prerequisites before recipient lookup", async () => {
+    const state = (input: { bridgeSetupAt: Date | null; firstSessionAt: Date | null }): ActivationState => ({
+      _id: new ObjectId(),
+      userId: new ObjectId("000000000000000000000001"),
+      mobileSetupAt: null,
+      bridgeSetupAt: input.bridgeSetupAt,
+      firstSessionAt: input.firstSessionAt,
+      bridgeReminderBaseAt: null,
+      sessionReminderBaseAt: null,
+      bridgeReminder1SentAt: null,
+      bridgeReminder2SentAt: null,
+      sessionReminderSentAt: null,
+      backfilledAt: null,
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    });
+    const cases = [
+      {
+        reminderKind: OptionalEmailReminderKind.BridgeSetup,
+        activation: state({ bridgeSetupAt: new Date(1), firstSessionAt: null }),
+        reason: "milestone_completed",
+      },
+      {
+        reminderKind: OptionalEmailReminderKind.FirstSession,
+        activation: state({ bridgeSetupAt: new Date(1), firstSessionAt: new Date(2) }),
+        reason: "milestone_completed",
+      },
+      {
+        reminderKind: OptionalEmailReminderKind.FirstSession,
+        activation: state({ bridgeSetupAt: null, firstSessionAt: null }),
+        reason: "prerequisite_incomplete",
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      let recipientReads = 0;
+      const service = new OptionalEmailEligibilityService({
+        policy: { sendingEnabled: true, recipientBasis: OptionalEmailRecipientBasis.AccountActivityApproved },
+        recipients: {
+          resolve: async () => {
+            recipientReads += 1;
+            return { status: "unique", email: "should-not-be-read@example.test" };
+          },
+        },
+        preferences: { findBlockReason: async () => null },
+        activationStates: { findByUserId: async () => testCase.activation },
+      });
+
+      assert.deepEqual(
+        await service.evaluate({
+          userId: "000000000000000000000001",
+          reminderKind: testCase.reminderKind,
+        }),
+        { eligible: false, reason: testCase.reason },
+      );
+      assert.equal(recipientReads, 0);
+    }
+  });
+
+  it("fails closed for non-unique recipient resolution and returns only one eligible address", async () => {
+    const cases = [
+      { resolution: { status: "missing_user" } as const, result: { eligible: false, reason: "missing_user" } },
+      {
+        resolution: { status: "missing_recipient" } as const,
+        result: { eligible: false, reason: "missing_recipient" },
+      },
+      {
+        resolution: { status: "ambiguous_recipient" } as const,
+        result: { eligible: false, reason: "ambiguous_recipient" },
+      },
+      {
+        resolution: { status: "unique", email: "one@example.test" } as const,
+        result: { eligible: true, recipient: "one@example.test" },
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const service = new OptionalEmailEligibilityService({
+        policy: { sendingEnabled: true, recipientBasis: OptionalEmailRecipientBasis.AccountActivityApproved },
+        recipients: { resolve: async () => testCase.resolution },
+        preferences: { findBlockReason: async () => null },
+        activationStates: { findByUserId: async () => null },
+      });
+
+      assert.deepEqual(
+        await service.evaluate({
+          userId: "000000000000000000000001",
+          reminderKind: OptionalEmailReminderKind.BridgeSetup,
+        }),
+        testCase.result,
+      );
+    }
+  });
+
+  it("ignores only the operational send switch during dry-run", async () => {
+    let recipientReads = 0;
+    const approved = new OptionalEmailEligibilityService({
+      policy: {
+        sendingEnabled: false,
+        recipientBasis: OptionalEmailRecipientBasis.AccountActivityApproved,
+      },
+      recipients: {
+        resolve: async () => {
+          recipientReads += 1;
+          return { status: "unique" as const, email: "dry-run@example.test" };
+        },
+      },
+      preferences: { findBlockReason: async () => null },
+      activationStates: { findByUserId: async () => null },
+    });
+    const input = {
+      userId: "000000000000000000000001",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+    };
+
+    assert.deepEqual(await approved.evaluate(input), { eligible: false, reason: "sending_disabled" });
+    assert.deepEqual(await approved.evaluateDryRun(input), {
+      eligible: true,
+      recipient: "dry-run@example.test",
+    });
+    assert.equal(recipientReads, 1);
+
+    const unapproved = new OptionalEmailEligibilityService({
+      policy: {
+        sendingEnabled: false,
+        recipientBasis: OptionalEmailRecipientBasis.Unapproved,
+      },
+      recipients: {
+        resolve: async () => {
+          recipientReads += 1;
+          return { status: "unique" as const, email: "must-not-read@example.test" };
+        },
+      },
+      preferences: { findBlockReason: async () => null },
+      activationStates: { findByUserId: async () => null },
+    });
+    assert.deepEqual(await unapproved.evaluateDryRun(input), {
+      eligible: false,
+      reason: "recipient_basis_unapproved",
+    });
+    assert.equal(recipientReads, 1);
+  });
+});

--- a/tests/services/optional-email-webhook-service.test.ts
+++ b/tests/services/optional-email-webhook-service.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { OptionalEmailPreferenceRepository } from "../../src/repositories/optional-email-preference-repo.js";
+import { OptionalEmailWebhookEventRepository } from "../../src/repositories/optional-email-webhook-event-repo.js";
+import { OptionalEmailWebhookService } from "../../src/services/optional-email-webhook-service.js";
+import { OptionalEmailBlockReason, OptionalEmailSuppressionReason } from "../../src/types/optional-email.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+const NOW = new Date("2026-09-06T12:00:00.000Z");
+
+describe("OptionalEmailWebhookService", () => {
+  let ctx: TestContext;
+  let preferenceRepo: OptionalEmailPreferenceRepository;
+  let eventRepo: OptionalEmailWebhookEventRepository;
+
+  before(async () => {
+    ctx = await createTestApp();
+    preferenceRepo = new OptionalEmailPreferenceRepository(ctx.dbAccessor);
+    eventRepo = new OptionalEmailWebhookEventRepository(ctx.dbAccessor);
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("suppresses an optional-mail hard bounce and recognizes a repeated Svix event id", async () => {
+    const user = await ctx.createUser();
+    let lookups = 0;
+    const service = new OptionalEmailWebhookService({
+      eventRepo,
+      preferenceRepo,
+      sendHistory: {
+        findUserIdByProviderEmailId: async ({ providerEmailId }: { providerEmailId: string }) => {
+          lookups += 1;
+          return providerEmailId === "resend-email-1" ? user.userId : null;
+        },
+      },
+      clock: () => NOW,
+    });
+    const input = {
+      eventId: "msg_optional_hard_bounce_1",
+      event: {
+        type: "email.bounced",
+        created_at: NOW.toISOString(),
+        data: {
+          email_id: "resend-email-1",
+          bounce: { type: "Permanent", subType: "General" },
+          tags: { category: "optional_setup_reminder" },
+        },
+      },
+    };
+
+    const first = await service.handleVerified(input);
+    const replay = await service.handleVerified(input);
+
+    assert.deepEqual(first, { status: "processed", outcome: "suppressed" });
+    assert.deepEqual(replay, { status: "replayed" });
+    assert.equal(lookups, 1);
+    assert.equal(await preferenceRepo.findBlockReason({ userId: user.userId }), OptionalEmailBlockReason.Suppressed);
+    assert.equal(
+      (await preferenceRepo.findByUserId({ userId: user.userId }))?.suppressionReason,
+      OptionalEmailSuppressionReason.HardBounce,
+    );
+  });
+
+  it("suppresses optional reminders after a recipient complaint", async () => {
+    const user = await ctx.createUser();
+    const service = new OptionalEmailWebhookService({
+      eventRepo,
+      preferenceRepo,
+      sendHistory: {
+        findUserIdByProviderEmailId: async () => user.userId,
+      },
+      clock: () => NOW,
+    });
+
+    const result = await service.handleVerified({
+      eventId: "msg_optional_complaint_1",
+      event: {
+        type: "email.complained",
+        data: {
+          email_id: "resend-email-complaint-1",
+          tags: { category: "optional_setup_reminder" },
+        },
+      },
+    });
+
+    assert.deepEqual(result, { status: "processed", outcome: "suppressed" });
+    assert.equal(
+      (await preferenceRepo.findByUserId({ userId: user.userId }))?.suppressionReason,
+      OptionalEmailSuppressionReason.Complaint,
+    );
+  });
+
+  it("mirrors Resend provider suppression into optional-mail state", async () => {
+    const user = await ctx.createUser();
+    const service = new OptionalEmailWebhookService({
+      eventRepo,
+      preferenceRepo,
+      sendHistory: { findUserIdByProviderEmailId: async () => user.userId },
+      clock: () => NOW,
+    });
+
+    const result = await service.handleVerified({
+      eventId: "msg_optional_provider_suppressed_1",
+      event: {
+        type: "email.suppressed",
+        data: {
+          email_id: "resend-email-suppressed-1",
+          tags: { category: "optional_setup_reminder" },
+        },
+      },
+    });
+
+    assert.deepEqual(result, { status: "processed", outcome: "suppressed" });
+    assert.equal(
+      (await preferenceRepo.findByUserId({ userId: user.userId }))?.suppressionReason,
+      OptionalEmailSuppressionReason.ProviderSuppressed,
+    );
+  });
+
+  it("leaves an unmatched optional-mail event retryable without recording it as processed", async () => {
+    const service = new OptionalEmailWebhookService({
+      eventRepo,
+      preferenceRepo,
+      sendHistory: { findUserIdByProviderEmailId: async () => null },
+      clock: () => NOW,
+    });
+
+    const result = await service.handleVerified({
+      eventId: "msg_optional_unmatched_1",
+      event: {
+        type: "email.complained",
+        data: {
+          email_id: "resend-email-not-recorded-yet",
+          tags: { category: "optional_setup_reminder" },
+        },
+      },
+    });
+
+    assert.deepEqual(result, { status: "retry" });
+    assert.equal(await eventRepo.wasProcessed({ eventId: "msg_optional_unmatched_1" }), false);
+  });
+
+  it("records unrelated and non-permanent events as ignored without looking up a user", async () => {
+    let lookups = 0;
+    const service = new OptionalEmailWebhookService({
+      eventRepo,
+      preferenceRepo,
+      sendHistory: {
+        findUserIdByProviderEmailId: async () => {
+          lookups += 1;
+          return null;
+        },
+      },
+      clock: () => NOW,
+    });
+
+    for (const input of [
+      {
+        eventId: "msg_unrelated_delivered_1",
+        event: { type: "email.delivered", data: { email_id: "other-email", tags: { category: "account_security" } } },
+      },
+      {
+        eventId: "msg_optional_transient_bounce_1",
+        event: {
+          type: "email.bounced",
+          data: {
+            email_id: "temporary-bounce",
+            bounce: { type: "Transient" },
+            tags: { category: "optional_setup_reminder" },
+          },
+        },
+      },
+    ]) {
+      assert.deepEqual(await service.handleVerified(input), { status: "processed", outcome: "ignored" });
+    }
+    assert.equal(lookups, 0);
+  });
+});

--- a/tests/services/resend-webhook-verifier.test.ts
+++ b/tests/services/resend-webhook-verifier.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { ResendWebhookVerifier } from "../../src/services/resend-webhook-verifier.js";
+
+const DOCUMENTED_SECRET = "whsec_plJ3nmyCDGBKInavdOK15jsl";
+const DOCUMENTED_PAYLOAD = '{"event_type":"ping","data":{"success":true}}';
+const DOCUMENTED_MESSAGE_ID = "msg_loFOjxBNrRLzqYUf";
+const DOCUMENTED_TIMESTAMP = "1731705121";
+const DOCUMENTED_SIGNATURE = "v1,rAvfW3dJ/X/qxhsaXPOyyCGmRKsaKWcsNccKXlIktD0=";
+
+describe("ResendWebhookVerifier", () => {
+  it("accepts the published Svix signature vector and rejects a modified raw body", () => {
+    const verifier = new ResendWebhookVerifier({
+      signingSecret: DOCUMENTED_SECRET,
+      clock: () => new Date(Number(DOCUMENTED_TIMESTAMP) * 1_000),
+    });
+
+    assert.deepEqual(
+      verifier.verify({
+        rawBody: DOCUMENTED_PAYLOAD,
+        messageId: DOCUMENTED_MESSAGE_ID,
+        timestamp: DOCUMENTED_TIMESTAMP,
+        signature: DOCUMENTED_SIGNATURE,
+      }),
+      { event_type: "ping", data: { success: true } },
+    );
+    assert.throws(
+      () =>
+        verifier.verify({
+          rawBody: `${DOCUMENTED_PAYLOAD} `,
+          messageId: DOCUMENTED_MESSAGE_ID,
+          timestamp: DOCUMENTED_TIMESTAMP,
+          signature: DOCUMENTED_SIGNATURE,
+        }),
+      /InvalidResendWebhookSignature/,
+    );
+  });
+
+  it("rejects otherwise-valid signatures outside the five-minute timestamp window", () => {
+    const oldVerifier = new ResendWebhookVerifier({
+      signingSecret: DOCUMENTED_SECRET,
+      clock: () => new Date((Number(DOCUMENTED_TIMESTAMP) + 301) * 1_000),
+    });
+    const futureVerifier = new ResendWebhookVerifier({
+      signingSecret: DOCUMENTED_SECRET,
+      clock: () => new Date((Number(DOCUMENTED_TIMESTAMP) - 301) * 1_000),
+    });
+    const input = {
+      rawBody: DOCUMENTED_PAYLOAD,
+      messageId: DOCUMENTED_MESSAGE_ID,
+      timestamp: DOCUMENTED_TIMESTAMP,
+      signature: DOCUMENTED_SIGNATURE,
+    };
+
+    assert.throws(() => oldVerifier.verify(input), /InvalidResendWebhookTimestamp/);
+    assert.throws(() => futureVerifier.verify(input), /InvalidResendWebhookTimestamp/);
+  });
+});


### PR DESCRIPTION
## Summary

- add a dependency-free Resend single-email adapter with a bounded request timeout and idempotency header
- add disabled-by-default optional-email configuration with pinned sender/reply-to/test recipient and an 80/day hard cap
- add Mongo-owned optional-mail preferences/suppression, send history, replay ledger, and atomic daily quota
- add signed no-login unsubscribe plus RFC 8058 one-click headers/POST handling
- add verified raw-body Resend webhook handling for permanent bounce, complaint, and provider suppression
- recheck recipient basis, user/account resolution, opt-out/suppression, and activation milestones immediately before provider calls
- add aggregate-only dry-run and a separately gated, one-recipient test CLI
- register only unsubscribe/webhook safety routes in normal server startup; no sender, bulk campaign, or scheduler is started

## Safety defaults

- `OPTIONAL_EMAIL_SENDING_ENABLED=false`
- `OPTIONAL_EMAIL_TEST_SEND_ENABLED=false`
- `OPTIONAL_EMAIL_RECIPIENT_BASIS=unapproved`
- missing approved recipient basis fails closed before account-email reads
- test CLI is pinned to `alex@sesori.com` and requires five exact argument pairs plus `SEND_ONE_TEST_EMAIL`
- optional-mail suppression does not apply to essential account/security mail
- no production env, DNS, provider settings, or production data were changed

## Verification

Using Node 22.23.2:

- `npm run build` — pass
- `npm run lint` — pass
- `npm run format:check` — pass
- `npm run circular-dependencies` — pass, no circular dependency found
- `npm test` — 1,010 tests; 1,009 passed; 1 existing skipped; 0 failed
- both package CLI `--help` paths — pass without config or DB access
- staged `git diff --check` — pass

Authorized provider verification after automated gates:

- 5/5 narrow test requests accepted by Resend
- delayed readback: delivered simulator=`delivered`; bounce simulator=`bounced`; complaint simulator=`complained`; suppression simulator=`suppressed`; founder inbox provider state=`delivered`
- provider state is not proof of human inbox receipt
- temporary owner-only credential directory was deleted and verified absent

## Remaining blockers / review

- do not set the recipient basis to approved until founder/legal/privacy review explicitly authorizes the account-activity basis
- production Resend, webhook, and unsubscribe signing secrets must be added only through SOPS
- deploy/register the verified webhook endpoint and signing secret before any real reminder send; live provider webhook delivery was not exercised in this change
- no current `master` field represents a pending account-deletion schedule; integrate that eligibility signal if/when the separate deletion branch lands
- final eligibility check and provider call are not atomic; a state change can race the outbound request
- provider acceptance and Mongo acceptance-history write are not atomic; crashes can strand `in_flight` rows and require manual reconciliation
- quota reservations are intentionally not refunded on blocked/failed attempts
- `AGENTS.md` was not changed because the protected-file approval timed out; README contains the operational guidance
- human review is required; no independent AI reviewer was used because the assignment prohibited assigning other bots

No merge or deployment is requested by this draft PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the foundation for optional setup-reminder emails through Resend, disabled by default so no mail actually sends. Only the unsubscribe and webhook safety routes register at server startup; no sender, bulk campaign, or scheduler starts.

**What's included**
- Dependency-free Resend adapter with bounded request timeout and idempotency header.
- Mongo-owned preferences, suppression, send history, replay ledger, and atomic 80/day quota.
- Signed no-login unsubscribe plus RFC 8058 one-click headers and POST handling.
- Verified raw-body webhook handling for permanent bounce, complaint, and provider suppression.
- Aggregate-only dry-run CLI and separately gated one-recipient test CLI.
- Eligibility, opt-out, suppression, and activation milestones re-checked immediately before provider calls.
- Build, lint, format, circular-dependency checks, and 1,010 tests pass.

**Safety and rollout**
- Sending and test-send default to false; recipient basis defaults to unapproved and fails closed before account-email reads.
- Optional-mail suppression does not affect essential account or security mail.
- No production env, DNS, provider settings, or production data were changed.
- Keep recipient basis unapproved until founder/legal/privacy review authorizes the account-activity basis.
- Add production secrets only through SOPS and register the live webhook endpoint before any real reminder send.
- Eligibility and provider call, and provider acceptance and history write, are not atomic; quota reservations are not refunded on blocked or failed sends.

<sup>Written for commit 616d84c21f9f689495e9400c740cfd99ffd47b28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

