### PR TITLE
feat(optional-email): add dormant data layer

### DIFF
--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -67,6 +67,13 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
       // One settings document per (user, device): the unique compound key both
       // enforces that invariant and serves the sole read path (findByUserAndDevice).
       [AuthDbCollection.SettingsConfiguration]: [{ spec: { userId: 1, deviceId: 1 }, options: { unique: true } }],
+      [AuthDbCollection.OptionalEmailPreferences]: [{ spec: { userId: 1 }, options: { unique: true } }],
+      [AuthDbCollection.OptionalEmailWebhookEvents]: [{ spec: { eventId: 1 }, options: { unique: true } }],
+      [AuthDbCollection.OptionalEmailSends]: [
+        { spec: { sendKey: 1 }, options: { unique: true } },
+        { spec: { providerEmailId: 1 }, options: { unique: true, sparse: true } },
+      ],
+      [AuthDbCollection.OptionalEmailDailyQuota]: [],
     },
   } satisfies DatabaseConfig<AuthDbCollection>,
 };

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -11,9 +11,21 @@ import {
 import { normalizedGlossaryWordSchema, projectGlossaryScopeSchema } from "./voice.js";
 import {
   OptionalEmailReminderKind,
+  OptionalEmailSendBlockReason,
   OptionalEmailSendStatus,
   OptionalEmailSuppressionReason,
 } from "../types/optional-email.js";
+
+const utcCalendarDateSchema = z.string().refine(
+  (value) => {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      return false;
+    }
+    const parsed = new Date(`${value}T00:00:00.000Z`);
+    return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+  },
+  { message: "must be a valid UTC calendar date" },
+);
 
 export const userSchema = z.object({
   _id: z.instanceof(ObjectId),
@@ -190,13 +202,14 @@ export const optionalEmailSendSchema = z.object({
   campaignId: z.string().min(1).max(64),
   reminderKind: z.nativeEnum(OptionalEmailReminderKind),
   status: z.nativeEnum(OptionalEmailSendStatus),
+  activeLeaseId: z.instanceof(ObjectId).optional(),
   attemptCount: z.number().int().nonnegative(),
   firstProviderAttemptAt: z.date().optional(),
   lastProviderAttemptAt: z.date().optional(),
   providerEmailId: z.string().min(1).max(256).optional(),
   acceptedAt: z.date().optional(),
   lastFailureCode: z.string().min(1).max(64).optional(),
-  lastBlockReason: z.string().min(1).max(64).optional(),
+  lastBlockReason: z.nativeEnum(OptionalEmailSendBlockReason).optional(),
   lastDeferralReason: z.string().min(1).max(64).optional(),
   createdAt: z.date(),
   updatedAt: z.date(),
@@ -205,7 +218,7 @@ export const optionalEmailSendSchema = z.object({
 export type OptionalEmailSend = z.infer<typeof optionalEmailSendSchema>;
 
 export const optionalEmailDailyQuotaSchema = z.object({
-  _id: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  _id: utcCalendarDateSchema,
   used: z.number().int().nonnegative(),
   createdAt: z.date(),
   updatedAt: z.date(),

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -12,6 +12,7 @@ import { normalizedGlossaryWordSchema, projectGlossaryScopeSchema } from "./voic
 import {
   OptionalEmailReminderKind,
   OptionalEmailSendBlockReason,
+  OptionalEmailSendDeferralReason,
   OptionalEmailSendStatus,
   OptionalEmailSuppressionReason,
 } from "../types/optional-email.js";
@@ -210,7 +211,7 @@ export const optionalEmailSendSchema = z.object({
   acceptedAt: z.date().optional(),
   lastFailureCode: z.string().min(1).max(64).optional(),
   lastBlockReason: z.nativeEnum(OptionalEmailSendBlockReason).optional(),
-  lastDeferralReason: z.string().min(1).max(64).optional(),
+  lastDeferralReason: z.nativeEnum(OptionalEmailSendDeferralReason).optional(),
   createdAt: z.date(),
   updatedAt: z.date(),
 });

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -9,6 +9,11 @@ import {
   productAnalyticsPreferenceSchema,
 } from "../types/product-analytics.js";
 import { normalizedGlossaryWordSchema, projectGlossaryScopeSchema } from "./voice.js";
+import {
+  OptionalEmailReminderKind,
+  OptionalEmailSendStatus,
+  OptionalEmailSuppressionReason,
+} from "../types/optional-email.js";
 
 export const userSchema = z.object({
   _id: z.instanceof(ObjectId),
@@ -152,3 +157,58 @@ export const settingsConfigurationSchema = z.object({
 });
 
 export type SettingsConfiguration = z.infer<typeof settingsConfigurationSchema>;
+
+/**
+ * Optional setup/reactivation mail only. This state must never gate password,
+ * security, deletion, or other essential account messages.
+ */
+export const optionalEmailPreferenceSchema = z.object({
+  _id: z.instanceof(ObjectId),
+  userId: z.instanceof(ObjectId),
+  unsubscribedAt: z.date().optional(),
+  suppressedAt: z.date().optional(),
+  suppressionReason: z.nativeEnum(OptionalEmailSuppressionReason).optional(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type OptionalEmailPreference = z.infer<typeof optionalEmailPreferenceSchema>;
+
+export const optionalEmailWebhookEventSchema = z.object({
+  _id: z.instanceof(ObjectId),
+  eventId: z.string().min(1).max(256),
+  eventType: z.string().min(1).max(128),
+  processedAt: z.date(),
+});
+
+export type OptionalEmailWebhookEvent = z.infer<typeof optionalEmailWebhookEventSchema>;
+
+export const optionalEmailSendSchema = z.object({
+  _id: z.instanceof(ObjectId),
+  sendKey: z.string().min(1).max(256),
+  userId: z.instanceof(ObjectId),
+  campaignId: z.string().min(1).max(64),
+  reminderKind: z.nativeEnum(OptionalEmailReminderKind),
+  status: z.nativeEnum(OptionalEmailSendStatus),
+  attemptCount: z.number().int().nonnegative(),
+  firstProviderAttemptAt: z.date().optional(),
+  lastProviderAttemptAt: z.date().optional(),
+  providerEmailId: z.string().min(1).max(256).optional(),
+  acceptedAt: z.date().optional(),
+  lastFailureCode: z.string().min(1).max(64).optional(),
+  lastBlockReason: z.string().min(1).max(64).optional(),
+  lastDeferralReason: z.string().min(1).max(64).optional(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type OptionalEmailSend = z.infer<typeof optionalEmailSendSchema>;
+
+export const optionalEmailDailyQuotaSchema = z.object({
+  _id: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  used: z.number().int().nonnegative(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type OptionalEmailDailyQuota = z.infer<typeof optionalEmailDailyQuotaSchema>;

--- a/src/repositories/optional-email-daily-quota-repo.ts
+++ b/src/repositories/optional-email-daily-quota-repo.ts
@@ -1,0 +1,82 @@
+import { Collection, MongoServerError } from "mongodb";
+import type { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import { InternalServerError } from "../lib/errors.js";
+import type { OptionalEmailDailyQuota } from "../models/documents.js";
+import { OPTIONAL_EMAIL_MAX_DAILY_CAP } from "../types/optional-email.js";
+import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
+
+export type OptionalEmailDailyQuotaResult = {
+  date: string;
+  used: number;
+  remaining: number;
+};
+
+export class OptionalEmailDailyQuotaRepository {
+  readonly #collection: Collection<OptionalEmailDailyQuota>;
+
+  constructor(accessor: MongoDbAccessor) {
+    this.#collection = accessor.getCollection<OptionalEmailDailyQuota>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.OptionalEmailDailyQuota,
+    );
+  }
+
+  async reserve(input: { at: Date; dailyCap: number }): Promise<OptionalEmailDailyQuotaResult & { reserved: boolean }> {
+    const date = this.#validateAndDate(input);
+    await this.#ensureDay({ date, at: input.at });
+    const updated = await this.#collection.findOneAndUpdate(
+      { _id: date, used: { $lt: input.dailyCap } },
+      { $inc: { used: 1 }, $set: { updatedAt: input.at } },
+      { returnDocument: "after" },
+    );
+    if (!updated) {
+      return { reserved: false, ...(await this.getUsage(input)) };
+    }
+    return {
+      reserved: true,
+      date,
+      used: updated.used,
+      remaining: input.dailyCap - updated.used,
+    };
+  }
+
+  async getUsage(input: { at: Date; dailyCap: number }): Promise<OptionalEmailDailyQuotaResult> {
+    const date = this.#validateAndDate(input);
+    const row = await this.#collection.findOne({ _id: date });
+    const used = row?.used ?? 0;
+    return { date, used, remaining: Math.max(0, input.dailyCap - used) };
+  }
+
+  async #ensureDay(input: { date: string; at: Date }): Promise<void> {
+    try {
+      await this.#collection.updateOne(
+        { _id: input.date },
+        {
+          $setOnInsert: {
+            _id: input.date,
+            used: 0,
+            createdAt: input.at,
+            updatedAt: input.at,
+          },
+        },
+        { upsert: true },
+      );
+    } catch (error) {
+      if (!(error instanceof MongoServerError) || error.code !== 11000) {
+        throw error;
+      }
+    }
+  }
+
+  #validateAndDate(input: { at: Date; dailyCap: number }): string {
+    if (
+      Number.isNaN(input.at.getTime()) ||
+      !Number.isInteger(input.dailyCap) ||
+      input.dailyCap < 1 ||
+      input.dailyCap > OPTIONAL_EMAIL_MAX_DAILY_CAP
+    ) {
+      throw new InternalServerError({ debugMessage: "Invalid optional email daily quota input" });
+    }
+    return input.at.toISOString().slice(0, 10);
+  }
+}

--- a/src/repositories/optional-email-preference-repo.ts
+++ b/src/repositories/optional-email-preference-repo.ts
@@ -51,6 +51,9 @@ export class OptionalEmailPreferenceRepository {
     at: Date;
   }): Promise<OptionalEmailPreference> {
     this.#assertInput({ userId: input.userId, at: input.at });
+    if (!Object.values(OptionalEmailSuppressionReason).includes(input.reason)) {
+      throw new InternalServerError({ debugMessage: "Invalid optional email suppression reason" });
+    }
     return this.#upsertOnce({
       userId: input.userId,
       at: input.at,

--- a/src/repositories/optional-email-preference-repo.ts
+++ b/src/repositories/optional-email-preference-repo.ts
@@ -1,0 +1,105 @@
+import { Collection, MongoServerError, ObjectId } from "mongodb";
+import { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import { InternalServerError } from "../lib/errors.js";
+import type { OptionalEmailPreference } from "../models/documents.js";
+import { OptionalEmailBlockReason, OptionalEmailSuppressionReason } from "../types/optional-email.js";
+import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
+
+export class OptionalEmailPreferenceRepository {
+  readonly #collection: Collection<OptionalEmailPreference>;
+
+  constructor(accessor: MongoDbAccessor) {
+    this.#collection = accessor.getCollection<OptionalEmailPreference>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.OptionalEmailPreferences,
+    );
+  }
+
+  async findByUserId(input: { userId: string }): Promise<OptionalEmailPreference | null> {
+    if (!ObjectId.isValid(input.userId)) {
+      return null;
+    }
+
+    return this.#collection.findOne({ userId: new ObjectId(input.userId) });
+  }
+
+  async findBlockReason(input: { userId: string }): Promise<OptionalEmailBlockReason | null> {
+    const preference = await this.findByUserId(input);
+    if (preference?.unsubscribedAt) {
+      return OptionalEmailBlockReason.Unsubscribed;
+    }
+    if (preference?.suppressedAt) {
+      return OptionalEmailBlockReason.Suppressed;
+    }
+    return null;
+  }
+
+  async unsubscribe(input: { userId: string; at: Date }): Promise<OptionalEmailPreference> {
+    this.#assertInput({ userId: input.userId, at: input.at });
+    return this.#upsertOnce({
+      userId: input.userId,
+      at: input.at,
+      fields: {
+        unsubscribedAt: { $ifNull: ["$unsubscribedAt", input.at] },
+      },
+    });
+  }
+
+  async suppress(input: {
+    userId: string;
+    reason: OptionalEmailSuppressionReason;
+    at: Date;
+  }): Promise<OptionalEmailPreference> {
+    this.#assertInput({ userId: input.userId, at: input.at });
+    return this.#upsertOnce({
+      userId: input.userId,
+      at: input.at,
+      fields: {
+        suppressedAt: { $ifNull: ["$suppressedAt", input.at] },
+        suppressionReason: { $ifNull: ["$suppressionReason", input.reason] },
+      },
+    });
+  }
+
+  #assertInput(input: { userId: string; at: Date }): void {
+    if (!ObjectId.isValid(input.userId) || Number.isNaN(input.at.getTime())) {
+      throw new InternalServerError({ debugMessage: "Invalid optional email preference input" });
+    }
+  }
+
+  async #upsertOnce(input: {
+    userId: string;
+    at: Date;
+    fields: Record<string, unknown>;
+  }): Promise<OptionalEmailPreference> {
+    const userId = new ObjectId(input.userId);
+    try {
+      const preference = await this.#collection.findOneAndUpdate(
+        { userId },
+        [
+          {
+            $set: {
+              ...input.fields,
+              createdAt: { $ifNull: ["$createdAt", input.at] },
+              updatedAt: input.at,
+            },
+          },
+        ],
+        { upsert: true, returnDocument: "after" },
+      );
+      if (preference) {
+        return preference;
+      }
+    } catch (error) {
+      if (!(error instanceof MongoServerError) || error.code !== 11000) {
+        throw error;
+      }
+    }
+
+    const winner = await this.#collection.findOne({ userId });
+    if (!winner) {
+      throw new InternalServerError({ debugMessage: "Failed to persist optional email preference" });
+    }
+    return winner;
+  }
+}

--- a/src/repositories/optional-email-preference-repo.ts
+++ b/src/repositories/optional-email-preference-repo.ts
@@ -76,26 +76,33 @@ export class OptionalEmailPreferenceRepository {
     fields: Record<string, unknown>;
   }): Promise<OptionalEmailPreference> {
     const userId = new ObjectId(input.userId);
+    const update = [
+      {
+        $set: {
+          ...input.fields,
+          createdAt: { $ifNull: ["$createdAt", input.at] },
+          updatedAt: input.at,
+        },
+      },
+    ];
     try {
-      const preference = await this.#collection.findOneAndUpdate(
-        { userId },
-        [
-          {
-            $set: {
-              ...input.fields,
-              createdAt: { $ifNull: ["$createdAt", input.at] },
-              updatedAt: input.at,
-            },
-          },
-        ],
-        { upsert: true, returnDocument: "after" },
-      );
+      const preference = await this.#collection.findOneAndUpdate({ userId }, update, {
+        upsert: true,
+        returnDocument: "after",
+      });
       if (preference) {
         return preference;
       }
     } catch (error) {
       if (!(error instanceof MongoServerError) || error.code !== 11000) {
         throw error;
+      }
+      const preference = await this.#collection.findOneAndUpdate({ userId }, update, {
+        upsert: false,
+        returnDocument: "after",
+      });
+      if (preference) {
+        return preference;
       }
     }
 

--- a/src/repositories/optional-email-send-repo.ts
+++ b/src/repositories/optional-email-send-repo.ts
@@ -2,11 +2,17 @@ import { Collection, MongoServerError, ObjectId } from "mongodb";
 import type { MongoDbAccessor } from "../db/mongo-db-accessor.js";
 import { InternalServerError } from "../lib/errors.js";
 import type { OptionalEmailSend } from "../models/documents.js";
-import { OptionalEmailReminderKind, OptionalEmailSendStatus } from "../types/optional-email.js";
+import {
+  OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS,
+  OPTIONAL_EMAIL_RESERVATION_LEASE_MS,
+  OptionalEmailReminderKind,
+  OptionalEmailSendBlockReason,
+  OptionalEmailSendStatus,
+} from "../types/optional-email.js";
 import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
 
 export type OptionalEmailSendReservation =
-  | { status: "reserved"; send: OptionalEmailSend }
+  | { status: "reserved"; send: OptionalEmailSend; leaseId: string }
   | { status: "duplicate"; send: OptionalEmailSend }
   | { status: "retry_expired"; send: OptionalEmailSend };
 
@@ -28,6 +34,7 @@ export class OptionalEmailSendRepository {
     at: Date;
   }): Promise<OptionalEmailSendReservation> {
     this.#validate(input);
+    const activeLeaseId = new ObjectId();
     const send: OptionalEmailSend = {
       _id: new ObjectId(),
       sendKey: input.sendKey,
@@ -35,13 +42,14 @@ export class OptionalEmailSendRepository {
       campaignId: input.campaignId,
       reminderKind: input.reminderKind,
       status: OptionalEmailSendStatus.Reserved,
+      activeLeaseId,
       attemptCount: 0,
       createdAt: input.at,
       updatedAt: input.at,
     };
     try {
       await this.#collection.insertOne(send);
-      return { status: "reserved", send };
+      return { status: "reserved", send, leaseId: activeLeaseId.toHexString() };
     } catch (error) {
       if (!(error instanceof MongoServerError) || error.code !== 11000) {
         throw error;
@@ -50,20 +58,89 @@ export class OptionalEmailSendRepository {
       if (!existing) {
         throw new InternalServerError({ debugMessage: "Optional email send reservation disappeared" });
       }
+      if (existing.status === OptionalEmailSendStatus.Reserved) {
+        const reservationAgeMs = input.at.getTime() - existing.updatedAt.getTime();
+        if (reservationAgeMs < 0 || reservationAgeMs <= OPTIONAL_EMAIL_RESERVATION_LEASE_MS) {
+          return { status: "duplicate", send: existing };
+        }
+        const reclaimedLeaseId = new ObjectId();
+        const reclaimed = await this.#collection.findOneAndUpdate(
+          {
+            _id: existing._id,
+            status: OptionalEmailSendStatus.Reserved,
+            updatedAt: existing.updatedAt,
+          },
+          { $set: { activeLeaseId: reclaimedLeaseId, updatedAt: input.at } },
+          { returnDocument: "after" },
+        );
+        if (reclaimed) {
+          return { status: "reserved", send: reclaimed, leaseId: reclaimedLeaseId.toHexString() };
+        }
+        const raced = await this.findBySendKey({ sendKey: input.sendKey });
+        if (!raced) {
+          throw new InternalServerError({ debugMessage: "Optional email stale reservation disappeared" });
+        }
+        return { status: "duplicate", send: raced };
+      }
+      if (existing.status === OptionalEmailSendStatus.InFlight) {
+        // Retry only with the same deterministic send key while the provider's
+        // idempotency window can still collapse an uncertain prior request.
+        const leaseAgeMs = input.at.getTime() - existing.updatedAt.getTime();
+        if (leaseAgeMs < 0 || leaseAgeMs <= OPTIONAL_EMAIL_RESERVATION_LEASE_MS) {
+          return { status: "duplicate", send: existing };
+        }
+        const firstAttemptMs = existing.firstProviderAttemptAt?.getTime();
+        const retryAgeMs =
+          firstAttemptMs === undefined ? Number.POSITIVE_INFINITY : input.at.getTime() - firstAttemptMs;
+        if (retryAgeMs < 0 || retryAgeMs > OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS) {
+          return { status: "retry_expired", send: existing };
+        }
+        const reclaimedLeaseId = new ObjectId();
+        const reclaimed = await this.#collection.findOneAndUpdate(
+          {
+            _id: existing._id,
+            status: OptionalEmailSendStatus.InFlight,
+            updatedAt: existing.updatedAt,
+          },
+          {
+            $set: {
+              status: OptionalEmailSendStatus.Reserved,
+              activeLeaseId: reclaimedLeaseId,
+              updatedAt: input.at,
+            },
+          },
+          { returnDocument: "after" },
+        );
+        if (reclaimed) {
+          return { status: "reserved", send: reclaimed, leaseId: reclaimedLeaseId.toHexString() };
+        }
+        const raced = await this.findBySendKey({ sendKey: input.sendKey });
+        if (!raced) {
+          throw new InternalServerError({ debugMessage: "Optional email in-flight reservation disappeared" });
+        }
+        return { status: "duplicate", send: raced };
+      }
       if (existing.status === OptionalEmailSendStatus.Failed) {
         const firstAttemptMs = existing.firstProviderAttemptAt?.getTime();
         const retryAgeMs =
           firstAttemptMs === undefined ? Number.POSITIVE_INFINITY : input.at.getTime() - firstAttemptMs;
-        if (retryAgeMs < 0 || retryAgeMs > 23 * 60 * 60 * 1_000) {
+        if (retryAgeMs < 0 || retryAgeMs > OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS) {
           return { status: "retry_expired", send: existing };
         }
+        const reclaimedLeaseId = new ObjectId();
         const reclaimed = await this.#collection.findOneAndUpdate(
           { _id: existing._id, status: OptionalEmailSendStatus.Failed },
-          { $set: { status: OptionalEmailSendStatus.Reserved, updatedAt: input.at } },
+          {
+            $set: {
+              status: OptionalEmailSendStatus.Reserved,
+              activeLeaseId: reclaimedLeaseId,
+              updatedAt: input.at,
+            },
+          },
           { returnDocument: "after" },
         );
         if (reclaimed) {
-          return { status: "reserved", send: reclaimed };
+          return { status: "reserved", send: reclaimed, leaseId: reclaimedLeaseId.toHexString() };
         }
         const raced = await this.findBySendKey({ sendKey: input.sendKey });
         if (!raced) {
@@ -72,13 +149,20 @@ export class OptionalEmailSendRepository {
         return { status: "duplicate", send: raced };
       }
       if (existing.status === OptionalEmailSendStatus.DeferredDailyLimit) {
+        const reclaimedLeaseId = new ObjectId();
         const reclaimed = await this.#collection.findOneAndUpdate(
           { _id: existing._id, status: OptionalEmailSendStatus.DeferredDailyLimit },
-          { $set: { status: OptionalEmailSendStatus.Reserved, updatedAt: input.at } },
+          {
+            $set: {
+              status: OptionalEmailSendStatus.Reserved,
+              activeLeaseId: reclaimedLeaseId,
+              updatedAt: input.at,
+            },
+          },
           { returnDocument: "after" },
         );
         if (reclaimed) {
-          return { status: "reserved", send: reclaimed };
+          return { status: "reserved", send: reclaimed, leaseId: reclaimedLeaseId.toHexString() };
         }
         const raced = await this.findBySendKey({ sendKey: input.sendKey });
         if (!raced) {
@@ -97,12 +181,21 @@ export class OptionalEmailSendRepository {
     return this.#collection.findOne({ sendKey: input.sendKey });
   }
 
-  async markInFlight(input: { sendKey: string; at: Date }): Promise<boolean> {
-    if (!input.sendKey || input.sendKey.length > 256 || Number.isNaN(input.at.getTime())) {
+  async markInFlight(input: { sendKey: string; leaseId: string; at: Date }): Promise<boolean> {
+    if (
+      !input.sendKey ||
+      input.sendKey.length > 256 ||
+      !ObjectId.isValid(input.leaseId) ||
+      Number.isNaN(input.at.getTime())
+    ) {
       return false;
     }
     const result = await this.#collection.updateOne(
-      { sendKey: input.sendKey, status: OptionalEmailSendStatus.Reserved },
+      {
+        sendKey: input.sendKey,
+        status: OptionalEmailSendStatus.Reserved,
+        activeLeaseId: new ObjectId(input.leaseId),
+      },
       [
         {
           $set: {
@@ -118,10 +211,11 @@ export class OptionalEmailSendRepository {
     return result.modifiedCount === 1;
   }
 
-  async markAccepted(input: { sendKey: string; providerEmailId: string; at: Date }): Promise<boolean> {
+  async markAccepted(input: { sendKey: string; leaseId: string; providerEmailId: string; at: Date }): Promise<boolean> {
     if (
       !input.sendKey ||
       input.sendKey.length > 256 ||
+      !ObjectId.isValid(input.leaseId) ||
       !input.providerEmailId ||
       input.providerEmailId.length > 256 ||
       Number.isNaN(input.at.getTime())
@@ -129,7 +223,11 @@ export class OptionalEmailSendRepository {
       return false;
     }
     const result = await this.#collection.updateOne(
-      { sendKey: input.sendKey, status: OptionalEmailSendStatus.InFlight },
+      {
+        sendKey: input.sendKey,
+        status: OptionalEmailSendStatus.InFlight,
+        activeLeaseId: new ObjectId(input.leaseId),
+      },
       {
         $set: {
           status: OptionalEmailSendStatus.Accepted,
@@ -137,67 +235,95 @@ export class OptionalEmailSendRepository {
           acceptedAt: input.at,
           updatedAt: input.at,
         },
+        $unset: { activeLeaseId: "" },
       },
     );
     return result.modifiedCount === 1;
   }
 
-  async markFailed(input: { sendKey: string; failureCode: string; at: Date }): Promise<boolean> {
+  async markFailed(input: { sendKey: string; leaseId: string; failureCode: string; at: Date }): Promise<boolean> {
     if (
       !input.sendKey ||
       input.sendKey.length > 256 ||
+      !ObjectId.isValid(input.leaseId) ||
       !/^[a-z0-9_]{1,64}$/.test(input.failureCode) ||
       Number.isNaN(input.at.getTime())
     ) {
       return false;
     }
     const result = await this.#collection.updateOne(
-      { sendKey: input.sendKey, status: OptionalEmailSendStatus.InFlight },
+      {
+        sendKey: input.sendKey,
+        status: OptionalEmailSendStatus.InFlight,
+        activeLeaseId: new ObjectId(input.leaseId),
+      },
       {
         $set: {
           status: OptionalEmailSendStatus.Failed,
           lastFailureCode: input.failureCode,
           updatedAt: input.at,
         },
+        $unset: { activeLeaseId: "" },
       },
     );
     return result.modifiedCount === 1;
   }
 
-  async markBlocked(input: { sendKey: string; reason: string; at: Date }): Promise<boolean> {
+  async markBlocked(input: {
+    sendKey: string;
+    leaseId: string;
+    reason: OptionalEmailSendBlockReason;
+    at: Date;
+  }): Promise<boolean> {
     if (
       !input.sendKey ||
       input.sendKey.length > 256 ||
-      !/^[a-z_]{1,64}$/.test(input.reason) ||
+      !ObjectId.isValid(input.leaseId) ||
+      !Object.values(OptionalEmailSendBlockReason).includes(input.reason) ||
       Number.isNaN(input.at.getTime())
     ) {
       return false;
     }
     const result = await this.#collection.updateOne(
-      { sendKey: input.sendKey, status: OptionalEmailSendStatus.Reserved },
+      {
+        sendKey: input.sendKey,
+        status: OptionalEmailSendStatus.Reserved,
+        activeLeaseId: new ObjectId(input.leaseId),
+      },
       {
         $set: {
           status: OptionalEmailSendStatus.Blocked,
           lastBlockReason: input.reason,
           updatedAt: input.at,
         },
+        $unset: { activeLeaseId: "" },
       },
     );
     return result.modifiedCount === 1;
   }
 
-  async markDeferredForDailyLimit(input: { sendKey: string; at: Date }): Promise<boolean> {
-    if (!input.sendKey || input.sendKey.length > 256 || Number.isNaN(input.at.getTime())) {
+  async markDeferredForDailyLimit(input: { sendKey: string; leaseId: string; at: Date }): Promise<boolean> {
+    if (
+      !input.sendKey ||
+      input.sendKey.length > 256 ||
+      !ObjectId.isValid(input.leaseId) ||
+      Number.isNaN(input.at.getTime())
+    ) {
       return false;
     }
     const result = await this.#collection.updateOne(
-      { sendKey: input.sendKey, status: OptionalEmailSendStatus.Reserved },
+      {
+        sendKey: input.sendKey,
+        status: OptionalEmailSendStatus.Reserved,
+        activeLeaseId: new ObjectId(input.leaseId),
+      },
       {
         $set: {
           status: OptionalEmailSendStatus.DeferredDailyLimit,
           lastDeferralReason: "daily_limit",
           updatedAt: input.at,
         },
+        $unset: { activeLeaseId: "" },
       },
     );
     return result.modifiedCount === 1;

--- a/src/repositories/optional-email-send-repo.ts
+++ b/src/repositories/optional-email-send-repo.ts
@@ -7,14 +7,15 @@ import {
   OPTIONAL_EMAIL_RESERVATION_LEASE_MS,
   OptionalEmailReminderKind,
   OptionalEmailSendBlockReason,
+  OptionalEmailSendReservationOutcome,
   OptionalEmailSendStatus,
 } from "../types/optional-email.js";
 import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
 
 export type OptionalEmailSendReservation =
-  | { status: "reserved"; send: OptionalEmailSend; leaseId: string }
-  | { status: "duplicate"; send: OptionalEmailSend }
-  | { status: "retry_expired"; send: OptionalEmailSend };
+  | { status: OptionalEmailSendReservationOutcome.Reserved; send: OptionalEmailSend; leaseId: string }
+  | { status: OptionalEmailSendReservationOutcome.Duplicate; send: OptionalEmailSend }
+  | { status: OptionalEmailSendReservationOutcome.RetryExpired; send: OptionalEmailSend };
 
 export class OptionalEmailSendRepository {
   readonly #collection: Collection<OptionalEmailSend>;
@@ -34,11 +35,12 @@ export class OptionalEmailSendRepository {
     at: Date;
   }): Promise<OptionalEmailSendReservation> {
     this.#validate(input);
+    const userObjectId = new ObjectId(input.userId);
     const activeLeaseId = new ObjectId();
     const send: OptionalEmailSend = {
       _id: new ObjectId(),
       sendKey: input.sendKey,
-      userId: new ObjectId(input.userId),
+      userId: userObjectId,
       campaignId: input.campaignId,
       reminderKind: input.reminderKind,
       status: OptionalEmailSendStatus.Reserved,
@@ -49,19 +51,34 @@ export class OptionalEmailSendRepository {
     };
     try {
       await this.#collection.insertOne(send);
-      return { status: "reserved", send, leaseId: activeLeaseId.toHexString() };
+      return { status: OptionalEmailSendReservationOutcome.Reserved, send, leaseId: activeLeaseId.toHexString() };
     } catch (error) {
       if (!(error instanceof MongoServerError) || error.code !== 11000) {
         throw error;
       }
       const existing = await this.findBySendKey({ sendKey: input.sendKey });
       if (!existing) {
-        throw new InternalServerError({ debugMessage: "Optional email send reservation disappeared" });
+        throw new InternalServerError({
+          debugMessage: "Optional email send reservation collision could not be resolved",
+        });
+      }
+      if (
+        !existing.userId.equals(userObjectId) ||
+        existing.campaignId !== input.campaignId ||
+        existing.reminderKind !== input.reminderKind
+      ) {
+        throw new InternalServerError({ debugMessage: "Optional email send key identity mismatch" });
       }
       if (existing.status === OptionalEmailSendStatus.Reserved) {
         const reservationAgeMs = input.at.getTime() - existing.updatedAt.getTime();
         if (reservationAgeMs < 0 || reservationAgeMs <= OPTIONAL_EMAIL_RESERVATION_LEASE_MS) {
-          return { status: "duplicate", send: existing };
+          return { status: OptionalEmailSendReservationOutcome.Duplicate, send: existing };
+        }
+        if (existing.firstProviderAttemptAt) {
+          const retryAgeMs = input.at.getTime() - existing.firstProviderAttemptAt.getTime();
+          if (retryAgeMs < 0 || retryAgeMs > OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS) {
+            return { status: OptionalEmailSendReservationOutcome.RetryExpired, send: existing };
+          }
         }
         const reclaimedLeaseId = new ObjectId();
         const reclaimed = await this.#collection.findOneAndUpdate(
@@ -74,26 +91,30 @@ export class OptionalEmailSendRepository {
           { returnDocument: "after" },
         );
         if (reclaimed) {
-          return { status: "reserved", send: reclaimed, leaseId: reclaimedLeaseId.toHexString() };
+          return {
+            status: OptionalEmailSendReservationOutcome.Reserved,
+            send: reclaimed,
+            leaseId: reclaimedLeaseId.toHexString(),
+          };
         }
         const raced = await this.findBySendKey({ sendKey: input.sendKey });
         if (!raced) {
           throw new InternalServerError({ debugMessage: "Optional email stale reservation disappeared" });
         }
-        return { status: "duplicate", send: raced };
+        return { status: OptionalEmailSendReservationOutcome.Duplicate, send: raced };
       }
       if (existing.status === OptionalEmailSendStatus.InFlight) {
         // Retry only with the same deterministic send key while the provider's
         // idempotency window can still collapse an uncertain prior request.
         const leaseAgeMs = input.at.getTime() - existing.updatedAt.getTime();
         if (leaseAgeMs < 0 || leaseAgeMs <= OPTIONAL_EMAIL_RESERVATION_LEASE_MS) {
-          return { status: "duplicate", send: existing };
+          return { status: OptionalEmailSendReservationOutcome.Duplicate, send: existing };
         }
         const firstAttemptMs = existing.firstProviderAttemptAt?.getTime();
         const retryAgeMs =
           firstAttemptMs === undefined ? Number.POSITIVE_INFINITY : input.at.getTime() - firstAttemptMs;
         if (retryAgeMs < 0 || retryAgeMs > OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS) {
-          return { status: "retry_expired", send: existing };
+          return { status: OptionalEmailSendReservationOutcome.RetryExpired, send: existing };
         }
         const reclaimedLeaseId = new ObjectId();
         const reclaimed = await this.#collection.findOneAndUpdate(
@@ -112,20 +133,24 @@ export class OptionalEmailSendRepository {
           { returnDocument: "after" },
         );
         if (reclaimed) {
-          return { status: "reserved", send: reclaimed, leaseId: reclaimedLeaseId.toHexString() };
+          return {
+            status: OptionalEmailSendReservationOutcome.Reserved,
+            send: reclaimed,
+            leaseId: reclaimedLeaseId.toHexString(),
+          };
         }
         const raced = await this.findBySendKey({ sendKey: input.sendKey });
         if (!raced) {
           throw new InternalServerError({ debugMessage: "Optional email in-flight reservation disappeared" });
         }
-        return { status: "duplicate", send: raced };
+        return { status: OptionalEmailSendReservationOutcome.Duplicate, send: raced };
       }
       if (existing.status === OptionalEmailSendStatus.Failed) {
         const firstAttemptMs = existing.firstProviderAttemptAt?.getTime();
         const retryAgeMs =
           firstAttemptMs === undefined ? Number.POSITIVE_INFINITY : input.at.getTime() - firstAttemptMs;
         if (retryAgeMs < 0 || retryAgeMs > OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS) {
-          return { status: "retry_expired", send: existing };
+          return { status: OptionalEmailSendReservationOutcome.RetryExpired, send: existing };
         }
         const reclaimedLeaseId = new ObjectId();
         const reclaimed = await this.#collection.findOneAndUpdate(
@@ -140,13 +165,17 @@ export class OptionalEmailSendRepository {
           { returnDocument: "after" },
         );
         if (reclaimed) {
-          return { status: "reserved", send: reclaimed, leaseId: reclaimedLeaseId.toHexString() };
+          return {
+            status: OptionalEmailSendReservationOutcome.Reserved,
+            send: reclaimed,
+            leaseId: reclaimedLeaseId.toHexString(),
+          };
         }
         const raced = await this.findBySendKey({ sendKey: input.sendKey });
         if (!raced) {
           throw new InternalServerError({ debugMessage: "Optional email retry reservation disappeared" });
         }
-        return { status: "duplicate", send: raced };
+        return { status: OptionalEmailSendReservationOutcome.Duplicate, send: raced };
       }
       if (existing.status === OptionalEmailSendStatus.DeferredDailyLimit) {
         const reclaimedLeaseId = new ObjectId();
@@ -162,15 +191,19 @@ export class OptionalEmailSendRepository {
           { returnDocument: "after" },
         );
         if (reclaimed) {
-          return { status: "reserved", send: reclaimed, leaseId: reclaimedLeaseId.toHexString() };
+          return {
+            status: OptionalEmailSendReservationOutcome.Reserved,
+            send: reclaimed,
+            leaseId: reclaimedLeaseId.toHexString(),
+          };
         }
         const raced = await this.findBySendKey({ sendKey: input.sendKey });
         if (!raced) {
           throw new InternalServerError({ debugMessage: "Optional email deferred reservation disappeared" });
         }
-        return { status: "duplicate", send: raced };
+        return { status: OptionalEmailSendReservationOutcome.Duplicate, send: raced };
       }
-      return { status: "duplicate", send: existing };
+      return { status: OptionalEmailSendReservationOutcome.Duplicate, send: existing };
     }
   }
 

--- a/src/repositories/optional-email-send-repo.ts
+++ b/src/repositories/optional-email-send-repo.ts
@@ -1,0 +1,235 @@
+import { Collection, MongoServerError, ObjectId } from "mongodb";
+import type { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import { InternalServerError } from "../lib/errors.js";
+import type { OptionalEmailSend } from "../models/documents.js";
+import { OptionalEmailReminderKind, OptionalEmailSendStatus } from "../types/optional-email.js";
+import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
+
+export type OptionalEmailSendReservation =
+  | { status: "reserved"; send: OptionalEmailSend }
+  | { status: "duplicate"; send: OptionalEmailSend }
+  | { status: "retry_expired"; send: OptionalEmailSend };
+
+export class OptionalEmailSendRepository {
+  readonly #collection: Collection<OptionalEmailSend>;
+
+  constructor(accessor: MongoDbAccessor) {
+    this.#collection = accessor.getCollection<OptionalEmailSend>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.OptionalEmailSends,
+    );
+  }
+
+  async reserve(input: {
+    sendKey: string;
+    userId: string;
+    campaignId: string;
+    reminderKind: OptionalEmailReminderKind;
+    at: Date;
+  }): Promise<OptionalEmailSendReservation> {
+    this.#validate(input);
+    const send: OptionalEmailSend = {
+      _id: new ObjectId(),
+      sendKey: input.sendKey,
+      userId: new ObjectId(input.userId),
+      campaignId: input.campaignId,
+      reminderKind: input.reminderKind,
+      status: OptionalEmailSendStatus.Reserved,
+      attemptCount: 0,
+      createdAt: input.at,
+      updatedAt: input.at,
+    };
+    try {
+      await this.#collection.insertOne(send);
+      return { status: "reserved", send };
+    } catch (error) {
+      if (!(error instanceof MongoServerError) || error.code !== 11000) {
+        throw error;
+      }
+      const existing = await this.findBySendKey({ sendKey: input.sendKey });
+      if (!existing) {
+        throw new InternalServerError({ debugMessage: "Optional email send reservation disappeared" });
+      }
+      if (existing.status === OptionalEmailSendStatus.Failed) {
+        const firstAttemptMs = existing.firstProviderAttemptAt?.getTime();
+        const retryAgeMs =
+          firstAttemptMs === undefined ? Number.POSITIVE_INFINITY : input.at.getTime() - firstAttemptMs;
+        if (retryAgeMs < 0 || retryAgeMs > 23 * 60 * 60 * 1_000) {
+          return { status: "retry_expired", send: existing };
+        }
+        const reclaimed = await this.#collection.findOneAndUpdate(
+          { _id: existing._id, status: OptionalEmailSendStatus.Failed },
+          { $set: { status: OptionalEmailSendStatus.Reserved, updatedAt: input.at } },
+          { returnDocument: "after" },
+        );
+        if (reclaimed) {
+          return { status: "reserved", send: reclaimed };
+        }
+        const raced = await this.findBySendKey({ sendKey: input.sendKey });
+        if (!raced) {
+          throw new InternalServerError({ debugMessage: "Optional email retry reservation disappeared" });
+        }
+        return { status: "duplicate", send: raced };
+      }
+      if (existing.status === OptionalEmailSendStatus.DeferredDailyLimit) {
+        const reclaimed = await this.#collection.findOneAndUpdate(
+          { _id: existing._id, status: OptionalEmailSendStatus.DeferredDailyLimit },
+          { $set: { status: OptionalEmailSendStatus.Reserved, updatedAt: input.at } },
+          { returnDocument: "after" },
+        );
+        if (reclaimed) {
+          return { status: "reserved", send: reclaimed };
+        }
+        const raced = await this.findBySendKey({ sendKey: input.sendKey });
+        if (!raced) {
+          throw new InternalServerError({ debugMessage: "Optional email deferred reservation disappeared" });
+        }
+        return { status: "duplicate", send: raced };
+      }
+      return { status: "duplicate", send: existing };
+    }
+  }
+
+  async findBySendKey(input: { sendKey: string }): Promise<OptionalEmailSend | null> {
+    if (!input.sendKey || input.sendKey.length > 256) {
+      return null;
+    }
+    return this.#collection.findOne({ sendKey: input.sendKey });
+  }
+
+  async markInFlight(input: { sendKey: string; at: Date }): Promise<boolean> {
+    if (!input.sendKey || input.sendKey.length > 256 || Number.isNaN(input.at.getTime())) {
+      return false;
+    }
+    const result = await this.#collection.updateOne(
+      { sendKey: input.sendKey, status: OptionalEmailSendStatus.Reserved },
+      [
+        {
+          $set: {
+            status: OptionalEmailSendStatus.InFlight,
+            firstProviderAttemptAt: { $ifNull: ["$firstProviderAttemptAt", input.at] },
+            lastProviderAttemptAt: input.at,
+            updatedAt: input.at,
+            attemptCount: { $add: ["$attemptCount", 1] },
+          },
+        },
+      ],
+    );
+    return result.modifiedCount === 1;
+  }
+
+  async markAccepted(input: { sendKey: string; providerEmailId: string; at: Date }): Promise<boolean> {
+    if (
+      !input.sendKey ||
+      input.sendKey.length > 256 ||
+      !input.providerEmailId ||
+      input.providerEmailId.length > 256 ||
+      Number.isNaN(input.at.getTime())
+    ) {
+      return false;
+    }
+    const result = await this.#collection.updateOne(
+      { sendKey: input.sendKey, status: OptionalEmailSendStatus.InFlight },
+      {
+        $set: {
+          status: OptionalEmailSendStatus.Accepted,
+          providerEmailId: input.providerEmailId,
+          acceptedAt: input.at,
+          updatedAt: input.at,
+        },
+      },
+    );
+    return result.modifiedCount === 1;
+  }
+
+  async markFailed(input: { sendKey: string; failureCode: string; at: Date }): Promise<boolean> {
+    if (
+      !input.sendKey ||
+      input.sendKey.length > 256 ||
+      !/^[a-z0-9_]{1,64}$/.test(input.failureCode) ||
+      Number.isNaN(input.at.getTime())
+    ) {
+      return false;
+    }
+    const result = await this.#collection.updateOne(
+      { sendKey: input.sendKey, status: OptionalEmailSendStatus.InFlight },
+      {
+        $set: {
+          status: OptionalEmailSendStatus.Failed,
+          lastFailureCode: input.failureCode,
+          updatedAt: input.at,
+        },
+      },
+    );
+    return result.modifiedCount === 1;
+  }
+
+  async markBlocked(input: { sendKey: string; reason: string; at: Date }): Promise<boolean> {
+    if (
+      !input.sendKey ||
+      input.sendKey.length > 256 ||
+      !/^[a-z_]{1,64}$/.test(input.reason) ||
+      Number.isNaN(input.at.getTime())
+    ) {
+      return false;
+    }
+    const result = await this.#collection.updateOne(
+      { sendKey: input.sendKey, status: OptionalEmailSendStatus.Reserved },
+      {
+        $set: {
+          status: OptionalEmailSendStatus.Blocked,
+          lastBlockReason: input.reason,
+          updatedAt: input.at,
+        },
+      },
+    );
+    return result.modifiedCount === 1;
+  }
+
+  async markDeferredForDailyLimit(input: { sendKey: string; at: Date }): Promise<boolean> {
+    if (!input.sendKey || input.sendKey.length > 256 || Number.isNaN(input.at.getTime())) {
+      return false;
+    }
+    const result = await this.#collection.updateOne(
+      { sendKey: input.sendKey, status: OptionalEmailSendStatus.Reserved },
+      {
+        $set: {
+          status: OptionalEmailSendStatus.DeferredDailyLimit,
+          lastDeferralReason: "daily_limit",
+          updatedAt: input.at,
+        },
+      },
+    );
+    return result.modifiedCount === 1;
+  }
+
+  async findUserIdByProviderEmailId(input: { providerEmailId: string }): Promise<string | null> {
+    if (!input.providerEmailId || input.providerEmailId.length > 256) {
+      return null;
+    }
+    const send = await this.#collection.findOne(
+      { providerEmailId: input.providerEmailId, status: OptionalEmailSendStatus.Accepted },
+      { projection: { userId: 1 } },
+    );
+    return send?.userId.toHexString() ?? null;
+  }
+
+  #validate(input: {
+    sendKey: string;
+    userId: string;
+    campaignId: string;
+    reminderKind: OptionalEmailReminderKind;
+    at: Date;
+  }): void {
+    if (
+      !input.sendKey ||
+      input.sendKey.length > 256 ||
+      !ObjectId.isValid(input.userId) ||
+      !/^[A-Za-z0-9_-]{1,64}$/.test(input.campaignId) ||
+      !Object.values(OptionalEmailReminderKind).includes(input.reminderKind) ||
+      Number.isNaN(input.at.getTime())
+    ) {
+      throw new InternalServerError({ debugMessage: "Invalid optional email send reservation" });
+    }
+  }
+}

--- a/src/repositories/optional-email-send-repo.ts
+++ b/src/repositories/optional-email-send-repo.ts
@@ -7,6 +7,7 @@ import {
   OPTIONAL_EMAIL_RESERVATION_LEASE_MS,
   OptionalEmailReminderKind,
   OptionalEmailSendBlockReason,
+  OptionalEmailSendDeferralReason,
   OptionalEmailSendReservationOutcome,
   OptionalEmailSendStatus,
 } from "../types/optional-email.js";
@@ -74,11 +75,8 @@ export class OptionalEmailSendRepository {
         if (reservationAgeMs < 0 || reservationAgeMs <= OPTIONAL_EMAIL_RESERVATION_LEASE_MS) {
           return { status: OptionalEmailSendReservationOutcome.Duplicate, send: existing };
         }
-        if (existing.firstProviderAttemptAt) {
-          const retryAgeMs = input.at.getTime() - existing.firstProviderAttemptAt.getTime();
-          if (retryAgeMs < 0 || retryAgeMs > OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS) {
-            return { status: OptionalEmailSendReservationOutcome.RetryExpired, send: existing };
-          }
+        if (this.#providerRetryExpired(existing, input.at)) {
+          return { status: OptionalEmailSendReservationOutcome.RetryExpired, send: existing };
         }
         const reclaimedLeaseId = new ObjectId();
         const reclaimed = await this.#collection.findOneAndUpdate(
@@ -110,10 +108,7 @@ export class OptionalEmailSendRepository {
         if (leaseAgeMs < 0 || leaseAgeMs <= OPTIONAL_EMAIL_RESERVATION_LEASE_MS) {
           return { status: OptionalEmailSendReservationOutcome.Duplicate, send: existing };
         }
-        const firstAttemptMs = existing.firstProviderAttemptAt?.getTime();
-        const retryAgeMs =
-          firstAttemptMs === undefined ? Number.POSITIVE_INFINITY : input.at.getTime() - firstAttemptMs;
-        if (retryAgeMs < 0 || retryAgeMs > OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS) {
+        if (!existing.firstProviderAttemptAt || this.#providerRetryExpired(existing, input.at)) {
           return { status: OptionalEmailSendReservationOutcome.RetryExpired, send: existing };
         }
         const reclaimedLeaseId = new ObjectId();
@@ -146,10 +141,7 @@ export class OptionalEmailSendRepository {
         return { status: OptionalEmailSendReservationOutcome.Duplicate, send: raced };
       }
       if (existing.status === OptionalEmailSendStatus.Failed) {
-        const firstAttemptMs = existing.firstProviderAttemptAt?.getTime();
-        const retryAgeMs =
-          firstAttemptMs === undefined ? Number.POSITIVE_INFINITY : input.at.getTime() - firstAttemptMs;
-        if (retryAgeMs < 0 || retryAgeMs > OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS) {
+        if (!existing.firstProviderAttemptAt || this.#providerRetryExpired(existing, input.at)) {
           return { status: OptionalEmailSendReservationOutcome.RetryExpired, send: existing };
         }
         const reclaimedLeaseId = new ObjectId();
@@ -178,11 +170,8 @@ export class OptionalEmailSendRepository {
         return { status: OptionalEmailSendReservationOutcome.Duplicate, send: raced };
       }
       if (existing.status === OptionalEmailSendStatus.DeferredDailyLimit) {
-        if (existing.firstProviderAttemptAt) {
-          const retryAgeMs = input.at.getTime() - existing.firstProviderAttemptAt.getTime();
-          if (retryAgeMs < 0 || retryAgeMs > OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS) {
-            return { status: OptionalEmailSendReservationOutcome.RetryExpired, send: existing };
-          }
+        if (this.#providerRetryExpired(existing, input.at)) {
+          return { status: OptionalEmailSendReservationOutcome.RetryExpired, send: existing };
         }
         const reclaimedLeaseId = new ObjectId();
         const reclaimed = await this.#collection.findOneAndUpdate(
@@ -211,6 +200,14 @@ export class OptionalEmailSendRepository {
       }
       return { status: OptionalEmailSendReservationOutcome.Duplicate, send: existing };
     }
+  }
+
+  #providerRetryExpired(send: OptionalEmailSend, at: Date): boolean {
+    if (!send.firstProviderAttemptAt) {
+      return false;
+    }
+    const retryAgeMs = at.getTime() - send.firstProviderAttemptAt.getTime();
+    return retryAgeMs < 0 || retryAgeMs > OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS;
   }
 
   async findBySendKey(input: { sendKey: string }): Promise<OptionalEmailSend | null> {
@@ -368,7 +365,7 @@ export class OptionalEmailSendRepository {
       {
         $set: {
           status: OptionalEmailSendStatus.DeferredDailyLimit,
-          lastDeferralReason: "daily_limit",
+          lastDeferralReason: OptionalEmailSendDeferralReason.DailyLimit,
           updatedAt: input.at,
         },
         $unset: { activeLeaseId: "" },

--- a/src/repositories/optional-email-send-repo.ts
+++ b/src/repositories/optional-email-send-repo.ts
@@ -178,6 +178,12 @@ export class OptionalEmailSendRepository {
         return { status: OptionalEmailSendReservationOutcome.Duplicate, send: raced };
       }
       if (existing.status === OptionalEmailSendStatus.DeferredDailyLimit) {
+        if (existing.firstProviderAttemptAt) {
+          const retryAgeMs = input.at.getTime() - existing.firstProviderAttemptAt.getTime();
+          if (retryAgeMs < 0 || retryAgeMs > OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS) {
+            return { status: OptionalEmailSendReservationOutcome.RetryExpired, send: existing };
+          }
+        }
         const reclaimedLeaseId = new ObjectId();
         const reclaimed = await this.#collection.findOneAndUpdate(
           { _id: existing._id, status: OptionalEmailSendStatus.DeferredDailyLimit },
@@ -223,11 +229,20 @@ export class OptionalEmailSendRepository {
     ) {
       return false;
     }
+    const earliestLeaseAt = new Date(input.at.getTime() - OPTIONAL_EMAIL_RESERVATION_LEASE_MS);
+    const earliestProviderAttemptAt = new Date(
+      input.at.getTime() - OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS,
+    );
     const result = await this.#collection.updateOne(
       {
         sendKey: input.sendKey,
         status: OptionalEmailSendStatus.Reserved,
         activeLeaseId: new ObjectId(input.leaseId),
+        updatedAt: { $gte: earliestLeaseAt, $lte: input.at },
+        $or: [
+          { firstProviderAttemptAt: { $exists: false } },
+          { firstProviderAttemptAt: { $gte: earliestProviderAttemptAt, $lte: input.at } },
+        ],
       },
       [
         {

--- a/src/types/mongo.ts
+++ b/src/types/mongo.ts
@@ -12,4 +12,8 @@ export enum AuthDbCollection {
   Bridges = "bridges",
   ActivationStates = "activationStates",
   SettingsConfiguration = "settingsConfiguration",
+  OptionalEmailPreferences = "optionalEmailPreferences",
+  OptionalEmailWebhookEvents = "optionalEmailWebhookEvents",
+  OptionalEmailSends = "optionalEmailSends",
+  OptionalEmailDailyQuota = "optionalEmailDailyQuota",
 }

--- a/src/types/optional-email.ts
+++ b/src/types/optional-email.ts
@@ -14,6 +14,21 @@ export enum OptionalEmailBlockReason {
   Suppressed = "suppressed",
 }
 
+export enum OptionalEmailSendBlockReason {
+  SendingDisabled = "sending_disabled",
+  RecipientBasisUnapproved = "recipient_basis_unapproved",
+  MissingUser = "missing_user",
+  MissingRecipient = "missing_recipient",
+  AmbiguousRecipient = "ambiguous_recipient",
+  MilestoneCompleted = "milestone_completed",
+  PrerequisiteIncomplete = "prerequisite_incomplete",
+  Unsubscribed = "unsubscribed",
+  Suppressed = "suppressed",
+  TestSendingDisabled = "test_sending_disabled",
+  TestRecipientNotAllowed = "test_recipient_not_allowed",
+  RetryWindowExpired = "retry_window_expired",
+}
+
 export enum OptionalEmailReminderKind {
   BridgeSetup = "bridge_setup",
   FirstSession = "first_session",
@@ -27,6 +42,14 @@ export enum OptionalEmailSendStatus {
   Blocked = "blocked",
   DeferredDailyLimit = "deferred_daily_limit",
 }
+
+// Reserved and in-flight rows carry a lease owner. Once this interval expires,
+// one contender may rotate that owner with compare-and-set; transition methods
+// fence stale workers by requiring the current lease ID.
+export const OPTIONAL_EMAIL_RESERVATION_LEASE_MS = 5 * 60 * 1_000;
+
+// Leave an hour of headroom inside Resend's 24-hour idempotency-key window.
+export const OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS = 23 * 60 * 60 * 1_000;
 
 // Resend's free transactional plan permits 100 emails/day. Optional mail is
 // capped lower so account/security traffic and inbound quota use retain room.

--- a/src/types/optional-email.ts
+++ b/src/types/optional-email.ts
@@ -43,6 +43,12 @@ export enum OptionalEmailSendStatus {
   DeferredDailyLimit = "deferred_daily_limit",
 }
 
+export enum OptionalEmailSendReservationOutcome {
+  Reserved = "reserved",
+  Duplicate = "duplicate",
+  RetryExpired = "retry_expired",
+}
+
 // Reserved and in-flight rows carry a lease owner. Once this interval expires,
 // one contender may rotate that owner with compare-and-set; transition methods
 // fence stale workers by requiring the current lease ID.

--- a/src/types/optional-email.ts
+++ b/src/types/optional-email.ts
@@ -29,6 +29,10 @@ export enum OptionalEmailSendBlockReason {
   RetryWindowExpired = "retry_window_expired",
 }
 
+export enum OptionalEmailSendDeferralReason {
+  DailyLimit = "daily_limit",
+}
+
 export enum OptionalEmailReminderKind {
   BridgeSetup = "bridge_setup",
   FirstSession = "first_session",

--- a/src/types/optional-email.ts
+++ b/src/types/optional-email.ts
@@ -1,0 +1,33 @@
+export enum OptionalEmailRecipientBasis {
+  Unapproved = "unapproved",
+  AccountActivityApproved = "account_activity_approved",
+}
+
+export enum OptionalEmailSuppressionReason {
+  HardBounce = "hard_bounce",
+  Complaint = "complaint",
+  ProviderSuppressed = "provider_suppressed",
+}
+
+export enum OptionalEmailBlockReason {
+  Unsubscribed = "unsubscribed",
+  Suppressed = "suppressed",
+}
+
+export enum OptionalEmailReminderKind {
+  BridgeSetup = "bridge_setup",
+  FirstSession = "first_session",
+}
+
+export enum OptionalEmailSendStatus {
+  Reserved = "reserved",
+  InFlight = "in_flight",
+  Accepted = "accepted",
+  Failed = "failed",
+  Blocked = "blocked",
+  DeferredDailyLimit = "deferred_daily_limit",
+}
+
+// Resend's free transactional plan permits 100 emails/day. Optional mail is
+// capped lower so account/security traffic and inbound quota use retain room.
+export const OPTIONAL_EMAIL_MAX_DAILY_CAP = 80;

--- a/tests/repositories/optional-email-daily-quota-repo.test.ts
+++ b/tests/repositories/optional-email-daily-quota-repo.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { OptionalEmailDailyQuotaRepository } from "../../src/repositories/optional-email-daily-quota-repo.js";
+import { InternalServerError } from "../../src/lib/errors.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+describe("OptionalEmailDailyQuotaRepository", () => {
+  let ctx: TestContext;
+  let repo: OptionalEmailDailyQuotaRepository;
+
+  before(async () => {
+    ctx = await createTestApp();
+    repo = new OptionalEmailDailyQuotaRepository(ctx.dbAccessor);
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("atomically enforces a UTC daily limit and starts a new counter the next day", async () => {
+    const firstDay = new Date("2026-09-06T23:59:59.000Z");
+    const attempts = await Promise.all(Array.from({ length: 20 }, () => repo.reserve({ at: firstDay, dailyCap: 3 })));
+
+    assert.equal(attempts.filter((attempt) => attempt.reserved).length, 3);
+    assert.deepEqual(await repo.getUsage({ at: firstDay, dailyCap: 3 }), {
+      date: "2026-09-06",
+      used: 3,
+      remaining: 0,
+    });
+    assert.deepEqual(await repo.reserve({ at: new Date("2026-09-07T00:00:00.000Z"), dailyCap: 3 }), {
+      reserved: true,
+      date: "2026-09-07",
+      used: 1,
+      remaining: 2,
+    });
+  });
+
+  it("rejects a cap above 80 so free-plan headroom cannot be configured away", async () => {
+    await assert.rejects(repo.reserve({ at: new Date("2026-09-08T00:00:00.000Z"), dailyCap: 81 }), InternalServerError);
+  });
+});

--- a/tests/repositories/optional-email-daily-quota-repo.test.ts
+++ b/tests/repositories/optional-email-daily-quota-repo.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
 import { OptionalEmailDailyQuotaRepository } from "../../src/repositories/optional-email-daily-quota-repo.js";
 import { InternalServerError } from "../../src/lib/errors.js";
+import { optionalEmailDailyQuotaSchema } from "../../src/models/documents.js";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
 
 describe("OptionalEmailDailyQuotaRepository", () => {
@@ -22,6 +23,11 @@ describe("OptionalEmailDailyQuotaRepository", () => {
     const attempts = await Promise.all(Array.from({ length: 20 }, () => repo.reserve({ at: firstDay, dailyCap: 3 })));
 
     assert.equal(attempts.filter((attempt) => attempt.reserved).length, 3);
+    const deferred = attempts.filter((attempt) => !attempt.reserved);
+    assert.equal(deferred.length, 17);
+    for (const attempt of deferred) {
+      assert.deepEqual(attempt, { reserved: false, date: "2026-09-06", used: 3, remaining: 0 });
+    }
     assert.deepEqual(await repo.getUsage({ at: firstDay, dailyCap: 3 }), {
       date: "2026-09-06",
       used: 3,
@@ -37,5 +43,18 @@ describe("OptionalEmailDailyQuotaRepository", () => {
 
   it("rejects a cap above 80 so free-plan headroom cannot be configured away", async () => {
     await assert.rejects(repo.reserve({ at: new Date("2026-09-08T00:00:00.000Z"), dailyCap: 81 }), InternalServerError);
+  });
+
+  it("rejects impossible UTC calendar date document IDs", () => {
+    const document = {
+      _id: "2028-02-29",
+      used: 0,
+      createdAt: new Date("2028-02-29T00:00:00.000Z"),
+      updatedAt: new Date("2028-02-29T00:00:00.000Z"),
+    };
+
+    assert.equal(optionalEmailDailyQuotaSchema.safeParse(document).success, true);
+    assert.equal(optionalEmailDailyQuotaSchema.safeParse({ ...document, _id: "2026-02-30" }).success, false);
+    assert.equal(optionalEmailDailyQuotaSchema.safeParse({ ...document, _id: "2026-99-99" }).success, false);
   });
 });

--- a/tests/repositories/optional-email-preference-repo.test.ts
+++ b/tests/repositories/optional-email-preference-repo.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
-import { ObjectId } from "mongodb";
+import { MongoServerError, ObjectId } from "mongodb";
+import type { MongoDbAccessor } from "../../src/db/mongo-db-accessor.js";
 import type { OptionalEmailPreference } from "../../src/models/documents.js";
 import { OptionalEmailPreferenceRepository } from "../../src/repositories/optional-email-preference-repo.js";
 import { OptionalEmailBlockReason, OptionalEmailSuppressionReason } from "../../src/types/optional-email.js";
@@ -74,6 +75,47 @@ describe("OptionalEmailPreferenceRepository", () => {
     assert.equal(stored?.unsubscribedAt?.toISOString(), unsubscribeAt.toISOString());
     assert.equal(stored?.suppressedAt?.toISOString(), complaintAt.toISOString());
     assert.equal(await repo.findBlockReason({ userId: user.userId }), OptionalEmailBlockReason.Unsubscribed);
+  });
+
+  it("replays a losing update after a duplicate-key creation race", async () => {
+    const userId = new ObjectId();
+    const at = new Date("2026-09-06T10:00:00.000Z");
+    const duplicateKeyError = new MongoServerError({ ok: 0, code: 11000, errmsg: "duplicate preference" });
+    const winner: OptionalEmailPreference = {
+      _id: new ObjectId(),
+      userId,
+      unsubscribedAt: at,
+      createdAt: at,
+      updatedAt: at,
+    };
+    let updateAttempts = 0;
+    const racingRepo = new OptionalEmailPreferenceRepository({
+      getCollection: () => ({
+        findOneAndUpdate: async (_filter: unknown, _update: unknown, options: { upsert: boolean }) => {
+          updateAttempts += 1;
+          if (updateAttempts === 1) {
+            throw duplicateKeyError;
+          }
+          assert.equal(options.upsert, false);
+          return {
+            ...winner,
+            suppressedAt: at,
+            suppressionReason: OptionalEmailSuppressionReason.HardBounce,
+          };
+        },
+        findOne: async () => winner,
+      }),
+    } as unknown as MongoDbAccessor);
+
+    const preference = await racingRepo.suppress({
+      userId: userId.toHexString(),
+      reason: OptionalEmailSuppressionReason.HardBounce,
+      at,
+    });
+
+    assert.equal(updateAttempts, 2);
+    assert.equal(preference.unsubscribedAt?.toISOString(), at.toISOString());
+    assert.equal(preference.suppressionReason, OptionalEmailSuppressionReason.HardBounce);
   });
 
   it("keeps one preference document when concurrent unsubscribe requests race", async () => {

--- a/tests/repositories/optional-email-preference-repo.test.ts
+++ b/tests/repositories/optional-email-preference-repo.test.ts
@@ -88,7 +88,7 @@ describe("OptionalEmailPreferenceRepository", () => {
     assert.equal(count, 1);
   });
 
-  it("rejects malformed user IDs and dates at the repository boundary", async () => {
+  it("rejects malformed values at the repository boundary", async () => {
     await assert.rejects(() => repo.unsubscribe({ userId: "not-an-id", at: new Date() }), /internal_server_error/);
     await assert.rejects(
       () =>
@@ -96,6 +96,15 @@ describe("OptionalEmailPreferenceRepository", () => {
           userId: new ObjectId().toHexString(),
           reason: OptionalEmailSuppressionReason.HardBounce,
           at: new Date("invalid"),
+        }),
+      /internal_server_error/,
+    );
+    await assert.rejects(
+      () =>
+        repo.suppress({
+          userId: new ObjectId().toHexString(),
+          reason: "soft_bounce" as OptionalEmailSuppressionReason,
+          at: new Date(),
         }),
       /internal_server_error/,
     );

--- a/tests/repositories/optional-email-preference-repo.test.ts
+++ b/tests/repositories/optional-email-preference-repo.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { ObjectId } from "mongodb";
+import type { OptionalEmailPreference } from "../../src/models/documents.js";
+import { OptionalEmailPreferenceRepository } from "../../src/repositories/optional-email-preference-repo.js";
+import { OptionalEmailBlockReason, OptionalEmailSuppressionReason } from "../../src/types/optional-email.js";
+import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+describe("OptionalEmailPreferenceRepository", () => {
+  let ctx: TestContext;
+  let repo: OptionalEmailPreferenceRepository;
+
+  before(async () => {
+    ctx = await createTestApp();
+    repo = new OptionalEmailPreferenceRepository(ctx.dbAccessor);
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("treats an absent optional-mail preference as not locally blocked", async () => {
+    const user = await ctx.createUser();
+
+    assert.equal(await repo.findByUserId({ userId: user.userId }), null);
+    assert.equal(await repo.findBlockReason({ userId: user.userId }), null);
+  });
+
+  it("persists an unsubscribe once and never resets it on replay", async () => {
+    const user = await ctx.createUser();
+    const first = new Date("2026-09-06T10:00:00.000Z");
+    const replay = new Date("2026-09-06T11:00:00.000Z");
+
+    await repo.unsubscribe({ userId: user.userId, at: first });
+    await repo.unsubscribe({ userId: user.userId, at: replay });
+
+    const stored = await repo.findByUserId({ userId: user.userId });
+    assert.equal(stored?.unsubscribedAt?.toISOString(), first.toISOString());
+    assert.equal(await repo.findBlockReason({ userId: user.userId }), OptionalEmailBlockReason.Unsubscribed);
+  });
+
+  it("durably suppresses hard bounces, complaints, and provider suppressions", async () => {
+    for (const reason of [
+      OptionalEmailSuppressionReason.HardBounce,
+      OptionalEmailSuppressionReason.Complaint,
+      OptionalEmailSuppressionReason.ProviderSuppressed,
+    ]) {
+      const user = await ctx.createUser();
+      const at = new Date("2026-09-06T12:00:00.000Z");
+
+      await repo.suppress({ userId: user.userId, reason, at });
+
+      const stored = await repo.findByUserId({ userId: user.userId });
+      assert.equal(stored?.suppressedAt?.toISOString(), at.toISOString());
+      assert.equal(stored?.suppressionReason, reason);
+      assert.equal(await repo.findBlockReason({ userId: user.userId }), OptionalEmailBlockReason.Suppressed);
+    }
+  });
+
+  it("preserves both independent blockers when suppression follows unsubscribe", async () => {
+    const user = await ctx.createUser();
+    const unsubscribeAt = new Date("2026-09-06T10:00:00.000Z");
+    const complaintAt = new Date("2026-09-06T12:00:00.000Z");
+
+    await repo.unsubscribe({ userId: user.userId, at: unsubscribeAt });
+    await repo.suppress({
+      userId: user.userId,
+      reason: OptionalEmailSuppressionReason.Complaint,
+      at: complaintAt,
+    });
+
+    const stored = await repo.findByUserId({ userId: user.userId });
+    assert.equal(stored?.unsubscribedAt?.toISOString(), unsubscribeAt.toISOString());
+    assert.equal(stored?.suppressedAt?.toISOString(), complaintAt.toISOString());
+    assert.equal(await repo.findBlockReason({ userId: user.userId }), OptionalEmailBlockReason.Unsubscribed);
+  });
+
+  it("keeps one preference document when concurrent unsubscribe requests race", async () => {
+    const user = await ctx.createUser();
+    const at = new Date("2026-09-06T10:00:00.000Z");
+
+    await Promise.all([repo.unsubscribe({ userId: user.userId, at }), repo.unsubscribe({ userId: user.userId, at })]);
+
+    const count = await ctx.dbAccessor
+      .getCollection<OptionalEmailPreference>(MongoDbDatabase.Auth, AuthDbCollection.OptionalEmailPreferences)
+      .countDocuments({ userId: new ObjectId(user.userId) });
+    assert.equal(count, 1);
+  });
+
+  it("rejects malformed user IDs and dates at the repository boundary", async () => {
+    await assert.rejects(() => repo.unsubscribe({ userId: "not-an-id", at: new Date() }), /internal_server_error/);
+    await assert.rejects(
+      () =>
+        repo.suppress({
+          userId: new ObjectId().toHexString(),
+          reason: OptionalEmailSuppressionReason.HardBounce,
+          at: new Date("invalid"),
+        }),
+      /internal_server_error/,
+    );
+  });
+});

--- a/tests/repositories/optional-email-send-repo.test.ts
+++ b/tests/repositories/optional-email-send-repo.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { OptionalEmailSendRepository } from "../../src/repositories/optional-email-send-repo.js";
+import { OptionalEmailReminderKind } from "../../src/types/optional-email.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+const NOW = new Date("2026-09-06T12:00:00.000Z");
+
+describe("OptionalEmailSendRepository", () => {
+  let ctx: TestContext;
+  let repo: OptionalEmailSendRepository;
+
+  before(async () => {
+    ctx = await createTestApp();
+    repo = new OptionalEmailSendRepository(ctx.dbAccessor);
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("atomically reserves one send per key without persisting a recipient address", async () => {
+    const user = await ctx.createUser();
+    const input = {
+      sendKey: "optional/setup-2026-09/user-key-1",
+      userId: user.userId,
+      campaignId: "setup-2026-09",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+      at: NOW,
+    };
+
+    const results = await Promise.all([repo.reserve(input), repo.reserve(input), repo.reserve(input)]);
+    const statuses = results.map((result) => result.status).sort();
+    const stored = await repo.findBySendKey({ sendKey: input.sendKey });
+
+    assert.deepEqual(statuses, ["duplicate", "duplicate", "reserved"]);
+    assert.equal(stored?.status, "reserved");
+    assert.equal(stored?.attemptCount, 0);
+    assert.equal(stored?.userId.toHexString(), user.userId);
+    assert.equal(stored && "recipient" in stored, false);
+    assert.equal(stored && "email" in stored, false);
+  });
+
+  it("records one provider attempt and keeps an accepted send permanently duplicate-blocked", async () => {
+    const user = await ctx.createUser();
+    const input = {
+      sendKey: "optional/setup-2026-09/user-key-accepted",
+      userId: user.userId,
+      campaignId: "setup-2026-09",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+      at: NOW,
+    };
+    await repo.reserve(input);
+
+    assert.equal(await repo.markInFlight({ sendKey: input.sendKey, at: NOW }), true);
+    assert.equal(
+      await repo.markAccepted({
+        sendKey: input.sendKey,
+        providerEmailId: "resend-email-accepted-1",
+        at: new Date(NOW.getTime() + 1_000),
+      }),
+      true,
+    );
+
+    const stored = await repo.findBySendKey({ sendKey: input.sendKey });
+    const duplicate = await repo.reserve({ ...input, at: new Date(NOW.getTime() + 10_000) });
+    assert.equal(stored?.status, "accepted");
+    assert.equal(stored?.attemptCount, 1);
+    assert.equal(stored?.firstProviderAttemptAt?.toISOString(), NOW.toISOString());
+    assert.equal(stored?.providerEmailId, "resend-email-accepted-1");
+    assert.equal(await repo.findUserIdByProviderEmailId({ providerEmailId: "resend-email-accepted-1" }), user.userId);
+    assert.equal(duplicate.status, "duplicate");
+    assert.equal(duplicate.send.status, "accepted");
+  });
+
+  it("reclaims a failed send only inside the provider idempotency safety window", async () => {
+    const user = await ctx.createUser();
+    const input = {
+      sendKey: "optional/setup-2026-09/user-key-retry",
+      userId: user.userId,
+      campaignId: "setup-2026-09",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+      at: NOW,
+    };
+    await repo.reserve(input);
+    await repo.markInFlight({ sendKey: input.sendKey, at: NOW });
+    await repo.markFailed({
+      sendKey: input.sendKey,
+      failureCode: "provider_unavailable",
+      at: new Date(NOW.getTime() + 1_000),
+    });
+
+    const retryAt = new Date(NOW.getTime() + 60 * 60 * 1_000);
+    const retry = await repo.reserve({ ...input, at: retryAt });
+    assert.equal(retry.status, "reserved");
+    assert.equal(await repo.markInFlight({ sendKey: input.sendKey, at: retryAt }), true);
+    await repo.markFailed({
+      sendKey: input.sendKey,
+      failureCode: "provider_unavailable",
+      at: new Date(retryAt.getTime() + 1_000),
+    });
+
+    const stored = await repo.findBySendKey({ sendKey: input.sendKey });
+    assert.equal(stored?.attemptCount, 2);
+    assert.equal(stored?.firstProviderAttemptAt?.toISOString(), NOW.toISOString());
+    assert.equal(stored?.lastProviderAttemptAt?.toISOString(), retryAt.toISOString());
+    assert.equal(stored?.lastFailureCode, "provider_unavailable");
+
+    const expired = await repo.reserve({
+      ...input,
+      at: new Date(NOW.getTime() + 23 * 60 * 60 * 1_000 + 1),
+    });
+    assert.equal(expired.status, "retry_expired");
+    assert.equal(expired.send.status, "failed");
+  });
+});

--- a/tests/repositories/optional-email-send-repo.test.ts
+++ b/tests/repositories/optional-email-send-repo.test.ts
@@ -7,6 +7,8 @@ import {
   OPTIONAL_EMAIL_RESERVATION_LEASE_MS,
   OptionalEmailReminderKind,
   OptionalEmailSendBlockReason,
+  OptionalEmailSendReservationOutcome,
+  OptionalEmailSendStatus,
 } from "../../src/types/optional-email.js";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
 
@@ -39,12 +41,36 @@ describe("OptionalEmailSendRepository", () => {
     const statuses = results.map((result) => result.status).sort();
     const stored = await repo.findBySendKey({ sendKey: input.sendKey });
 
-    assert.deepEqual(statuses, ["duplicate", "duplicate", "reserved"]);
-    assert.equal(stored?.status, "reserved");
+    assert.deepEqual(statuses, [
+      OptionalEmailSendReservationOutcome.Duplicate,
+      OptionalEmailSendReservationOutcome.Duplicate,
+      OptionalEmailSendReservationOutcome.Reserved,
+    ]);
+    assert.equal(stored?.status, OptionalEmailSendStatus.Reserved);
     assert.equal(stored?.attemptCount, 0);
     assert.equal(stored?.userId.toHexString(), user.userId);
     assert.equal(stored && "recipient" in stored, false);
     assert.equal(stored && "email" in stored, false);
+  });
+
+  it("rejects immutable identity mismatches for an existing send key", async () => {
+    const firstUser = await ctx.createUser();
+    const secondUser = await ctx.createUser();
+    const input = {
+      sendKey: "optional/setup-2026-09/user-key-identity",
+      userId: firstUser.userId,
+      campaignId: "setup-2026-09",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+      at: NOW,
+    };
+    await repo.reserve(input);
+
+    await assert.rejects(() => repo.reserve({ ...input, userId: secondUser.userId }), /internal_server_error/);
+    await assert.rejects(() => repo.reserve({ ...input, campaignId: "setup-2026-10" }), /internal_server_error/);
+    await assert.rejects(
+      () => repo.reserve({ ...input, reminderKind: OptionalEmailReminderKind.FirstSession }),
+      /internal_server_error/,
+    );
   });
 
   it("reclaims exactly one stale reservation while preserving an active lease", async () => {
@@ -57,14 +83,14 @@ describe("OptionalEmailSendRepository", () => {
       at: NOW,
     };
     const initialReservation = await repo.reserve(input);
-    assert.equal(initialReservation.status, "reserved");
+    assert.equal(initialReservation.status, OptionalEmailSendReservationOutcome.Reserved);
     assert.equal(typeof initialReservation.leaseId, "string");
 
     const activeLease = await repo.reserve({
       ...input,
       at: new Date(NOW.getTime() + OPTIONAL_EMAIL_RESERVATION_LEASE_MS),
     });
-    assert.equal(activeLease.status, "duplicate");
+    assert.equal(activeLease.status, OptionalEmailSendReservationOutcome.Duplicate);
 
     const reclaimedAt = new Date(NOW.getTime() + OPTIONAL_EMAIL_RESERVATION_LEASE_MS + 1);
     const contenders = await Promise.all([
@@ -72,13 +98,17 @@ describe("OptionalEmailSendRepository", () => {
       repo.reserve({ ...input, at: reclaimedAt }),
       repo.reserve({ ...input, at: reclaimedAt }),
     ]);
-    assert.deepEqual(contenders.map((result) => result.status).sort(), ["duplicate", "duplicate", "reserved"]);
-    const reclaimed = contenders.find((result) => result.status === "reserved");
+    assert.deepEqual(contenders.map((result) => result.status).sort(), [
+      OptionalEmailSendReservationOutcome.Duplicate,
+      OptionalEmailSendReservationOutcome.Duplicate,
+      OptionalEmailSendReservationOutcome.Reserved,
+    ]);
+    const reclaimed = contenders.find((result) => result.status === OptionalEmailSendReservationOutcome.Reserved);
     assert.ok(reclaimed);
     assert.notEqual(reclaimed.leaseId, initialReservation.leaseId);
 
     const stored = await repo.findBySendKey({ sendKey: input.sendKey });
-    assert.equal(stored?.status, "reserved");
+    assert.equal(stored?.status, OptionalEmailSendStatus.Reserved);
     assert.equal(stored?.attemptCount, 0);
     assert.equal(stored?.updatedAt.toISOString(), reclaimedAt.toISOString());
 
@@ -89,7 +119,7 @@ describe("OptionalEmailSendRepository", () => {
     ]);
     assert.deepEqual(providerClaims.sort(), [false, false, true]);
     const claimed = await repo.findBySendKey({ sendKey: input.sendKey });
-    assert.equal(claimed?.status, "in_flight");
+    assert.equal(claimed?.status, OptionalEmailSendStatus.InFlight);
     assert.equal(claimed?.attemptCount, 1);
   });
 
@@ -103,7 +133,7 @@ describe("OptionalEmailSendRepository", () => {
       at: NOW,
     };
     const reservation = await repo.reserve(input);
-    assert.equal(reservation.status, "reserved");
+    assert.equal(reservation.status, OptionalEmailSendReservationOutcome.Reserved);
 
     assert.equal(
       await repo.markBlocked({
@@ -125,7 +155,7 @@ describe("OptionalEmailSendRepository", () => {
     );
 
     const stored = await repo.findBySendKey({ sendKey: input.sendKey });
-    assert.equal(stored?.status, "blocked");
+    assert.equal(stored?.status, OptionalEmailSendStatus.Blocked);
     assert.equal(stored?.lastBlockReason, OptionalEmailSendBlockReason.MilestoneCompleted);
   });
 
@@ -139,18 +169,18 @@ describe("OptionalEmailSendRepository", () => {
       at: NOW,
     };
     const initial = await repo.reserve(input);
-    assert.equal(initial.status, "reserved");
+    assert.equal(initial.status, OptionalEmailSendReservationOutcome.Reserved);
     assert.equal(await repo.markInFlight({ sendKey: input.sendKey, leaseId: initial.leaseId, at: NOW }), true);
 
     const active = await repo.reserve({
       ...input,
       at: new Date(NOW.getTime() + OPTIONAL_EMAIL_RESERVATION_LEASE_MS),
     });
-    assert.equal(active.status, "duplicate");
+    assert.equal(active.status, OptionalEmailSendReservationOutcome.Duplicate);
 
     const reclaimedAt = new Date(NOW.getTime() + OPTIONAL_EMAIL_RESERVATION_LEASE_MS + 1);
     const reclaimed = await repo.reserve({ ...input, at: reclaimedAt });
-    assert.equal(reclaimed.status, "reserved");
+    assert.equal(reclaimed.status, OptionalEmailSendReservationOutcome.Reserved);
     assert.notEqual(reclaimed.leaseId, initial.leaseId);
     assert.equal(
       await repo.markInFlight({ sendKey: input.sendKey, leaseId: reclaimed.leaseId, at: reclaimedAt }),
@@ -176,7 +206,7 @@ describe("OptionalEmailSendRepository", () => {
     );
 
     const stored = await repo.findBySendKey({ sendKey: input.sendKey });
-    assert.equal(stored?.status, "accepted");
+    assert.equal(stored?.status, OptionalEmailSendStatus.Accepted);
     assert.equal(stored?.attemptCount, 2);
     assert.equal(stored?.providerEmailId, "recovered-provider-result");
     assert.equal(stored?.activeLeaseId, undefined);
@@ -192,7 +222,7 @@ describe("OptionalEmailSendRepository", () => {
       at: NOW,
     };
     const initial = await repo.reserve(input);
-    assert.equal(initial.status, "reserved");
+    assert.equal(initial.status, OptionalEmailSendReservationOutcome.Reserved);
     assert.equal(
       await repo.markDeferredForDailyLimit({
         sendKey: input.sendKey,
@@ -207,10 +237,10 @@ describe("OptionalEmailSendRepository", () => {
     );
 
     const deferred = await repo.findBySendKey({ sendKey: input.sendKey });
-    assert.equal(deferred?.status, "deferred_daily_limit");
+    assert.equal(deferred?.status, OptionalEmailSendStatus.DeferredDailyLimit);
     assert.equal(deferred?.activeLeaseId, undefined);
     const retry = await repo.reserve({ ...input, at: new Date(NOW.getTime() + 1_000) });
-    assert.equal(retry.status, "reserved");
+    assert.equal(retry.status, OptionalEmailSendReservationOutcome.Reserved);
     assert.notEqual(retry.leaseId, initial.leaseId);
   });
 
@@ -224,15 +254,42 @@ describe("OptionalEmailSendRepository", () => {
       at: NOW,
     };
     const initial = await repo.reserve(input);
-    assert.equal(initial.status, "reserved");
+    assert.equal(initial.status, OptionalEmailSendReservationOutcome.Reserved);
     assert.equal(await repo.markInFlight({ sendKey: input.sendKey, leaseId: initial.leaseId, at: NOW }), true);
 
     const expired = await repo.reserve({
       ...input,
       at: new Date(NOW.getTime() + OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS + 1),
     });
-    assert.equal(expired.status, "retry_expired");
-    assert.equal(expired.send.status, "in_flight");
+    assert.equal(expired.status, OptionalEmailSendReservationOutcome.RetryExpired);
+    assert.equal(expired.send.status, OptionalEmailSendStatus.InFlight);
+  });
+
+  it("fails closed when a reclaimed in-flight attempt crashes past the idempotency window", async () => {
+    const user = await ctx.createUser();
+    const input = {
+      sendKey: "optional/setup-2026-09/user-key-expired-reclaimed-in-flight",
+      userId: user.userId,
+      campaignId: "setup-2026-09",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+      at: NOW,
+    };
+    const initial = await repo.reserve(input);
+    assert.equal(initial.status, OptionalEmailSendReservationOutcome.Reserved);
+    assert.equal(await repo.markInFlight({ sendKey: input.sendKey, leaseId: initial.leaseId, at: NOW }), true);
+
+    const recovered = await repo.reserve({
+      ...input,
+      at: new Date(NOW.getTime() + OPTIONAL_EMAIL_RESERVATION_LEASE_MS + 1),
+    });
+    assert.equal(recovered.status, OptionalEmailSendReservationOutcome.Reserved);
+
+    const expired = await repo.reserve({
+      ...input,
+      at: new Date(NOW.getTime() + OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS + 1),
+    });
+    assert.equal(expired.status, OptionalEmailSendReservationOutcome.RetryExpired);
+    assert.equal(expired.send.status, OptionalEmailSendStatus.Reserved);
   });
 
   it("records one provider attempt and keeps an accepted send permanently duplicate-blocked", async () => {
@@ -245,7 +302,7 @@ describe("OptionalEmailSendRepository", () => {
       at: NOW,
     };
     const reservation = await repo.reserve(input);
-    assert.equal(reservation.status, "reserved");
+    assert.equal(reservation.status, OptionalEmailSendReservationOutcome.Reserved);
 
     assert.equal(await repo.markInFlight({ sendKey: input.sendKey, leaseId: reservation.leaseId, at: NOW }), true);
     assert.equal(
@@ -260,14 +317,14 @@ describe("OptionalEmailSendRepository", () => {
 
     const stored = await repo.findBySendKey({ sendKey: input.sendKey });
     const duplicate = await repo.reserve({ ...input, at: new Date(NOW.getTime() + 10_000) });
-    assert.equal(stored?.status, "accepted");
+    assert.equal(stored?.status, OptionalEmailSendStatus.Accepted);
     assert.equal(stored?.attemptCount, 1);
     assert.equal(stored?.firstProviderAttemptAt?.toISOString(), NOW.toISOString());
     assert.equal(stored?.providerEmailId, "resend-email-accepted-1");
     assert.equal(stored?.activeLeaseId, undefined);
     assert.equal(await repo.findUserIdByProviderEmailId({ providerEmailId: "resend-email-accepted-1" }), user.userId);
-    assert.equal(duplicate.status, "duplicate");
-    assert.equal(duplicate.send.status, "accepted");
+    assert.equal(duplicate.status, OptionalEmailSendReservationOutcome.Duplicate);
+    assert.equal(duplicate.send.status, OptionalEmailSendStatus.Accepted);
   });
 
   it("reclaims a failed send only inside the provider idempotency safety window", async () => {
@@ -280,7 +337,7 @@ describe("OptionalEmailSendRepository", () => {
       at: NOW,
     };
     const reservation = await repo.reserve(input);
-    assert.equal(reservation.status, "reserved");
+    assert.equal(reservation.status, OptionalEmailSendReservationOutcome.Reserved);
     await repo.markInFlight({ sendKey: input.sendKey, leaseId: reservation.leaseId, at: NOW });
     await repo.markFailed({
       sendKey: input.sendKey,
@@ -291,7 +348,7 @@ describe("OptionalEmailSendRepository", () => {
 
     const retryAt = new Date(NOW.getTime() + 60 * 60 * 1_000);
     const retry = await repo.reserve({ ...input, at: retryAt });
-    assert.equal(retry.status, "reserved");
+    assert.equal(retry.status, OptionalEmailSendReservationOutcome.Reserved);
     assert.equal(await repo.markInFlight({ sendKey: input.sendKey, leaseId: retry.leaseId, at: retryAt }), true);
     await repo.markFailed({
       sendKey: input.sendKey,
@@ -310,7 +367,7 @@ describe("OptionalEmailSendRepository", () => {
       ...input,
       at: new Date(NOW.getTime() + 23 * 60 * 60 * 1_000 + 1),
     });
-    assert.equal(expired.status, "retry_expired");
-    assert.equal(expired.send.status, "failed");
+    assert.equal(expired.status, OptionalEmailSendReservationOutcome.RetryExpired);
+    assert.equal(expired.send.status, OptionalEmailSendStatus.Failed);
   });
 });

--- a/tests/repositories/optional-email-send-repo.test.ts
+++ b/tests/repositories/optional-email-send-repo.test.ts
@@ -123,6 +123,72 @@ describe("OptionalEmailSendRepository", () => {
     assert.equal(claimed?.attemptCount, 1);
   });
 
+  it("rejects a reservation lease that expires before provider start", async () => {
+    const user = await ctx.createUser();
+    const input = {
+      sendKey: "setup:bridge:user-expired-reservation-lease:v1",
+      userId: user.userId,
+      campaignId: "setup-reminders-2026-09",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+      at: NOW,
+    };
+
+    const reservation = await repo.reserve(input);
+    assert.equal(reservation.status, OptionalEmailSendReservationOutcome.Reserved);
+    assert.equal(
+      await repo.markInFlight({
+        sendKey: input.sendKey,
+        leaseId: reservation.leaseId,
+        at: new Date(NOW.getTime() + OPTIONAL_EMAIL_RESERVATION_LEASE_MS + 1),
+      }),
+      false,
+    );
+
+    const stored = await repo.findBySendKey({ sendKey: input.sendKey });
+    assert.equal(stored?.status, OptionalEmailSendStatus.Reserved);
+    assert.equal(stored?.attemptCount, 0);
+  });
+
+  it("rejects a retry lease that crosses the provider idempotency window before provider start", async () => {
+    const user = await ctx.createUser();
+    const input = {
+      sendKey: "setup:bridge:user-retry-crosses-provider-window:v1",
+      userId: user.userId,
+      campaignId: "setup-reminders-2026-09",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+      at: NOW,
+    };
+
+    const initial = await repo.reserve(input);
+    assert.equal(initial.status, OptionalEmailSendReservationOutcome.Reserved);
+    assert.equal(await repo.markInFlight({ sendKey: input.sendKey, leaseId: initial.leaseId, at: NOW }), true);
+    assert.equal(
+      await repo.markFailed({
+        sendKey: input.sendKey,
+        leaseId: initial.leaseId,
+        failureCode: "timeout",
+        at: NOW,
+      }),
+      true,
+    );
+
+    const retryAt = new Date(NOW.getTime() + OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS - 1);
+    const retry = await repo.reserve({ ...input, at: retryAt });
+    assert.equal(retry.status, OptionalEmailSendReservationOutcome.Reserved);
+    assert.equal(
+      await repo.markInFlight({
+        sendKey: input.sendKey,
+        leaseId: retry.leaseId,
+        at: new Date(NOW.getTime() + OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS + 1),
+      }),
+      false,
+    );
+
+    const stored = await repo.findBySendKey({ sendKey: input.sendKey });
+    assert.equal(stored?.status, OptionalEmailSendStatus.Reserved);
+    assert.equal(stored?.attemptCount, 1);
+  });
+
   it("persists only enum-backed block reasons", async () => {
     const user = await ctx.createUser();
     const input = {
@@ -369,5 +435,44 @@ describe("OptionalEmailSendRepository", () => {
     });
     assert.equal(expired.status, OptionalEmailSendReservationOutcome.RetryExpired);
     assert.equal(expired.send.status, OptionalEmailSendStatus.Failed);
+  });
+
+  it("expires a daily-limit deferral that follows a provider attempt", async () => {
+    const user = await ctx.createUser();
+    const input = {
+      sendKey: "setup:first_session:user-deferred-after-failure:v1",
+      userId: user.userId,
+      campaignId: "setup-reminders-2026-09",
+      reminderKind: OptionalEmailReminderKind.FirstSession,
+      at: NOW,
+    };
+
+    const initial = await repo.reserve(input);
+    assert.equal(initial.status, OptionalEmailSendReservationOutcome.Reserved);
+    assert.equal(await repo.markInFlight({ sendKey: input.sendKey, leaseId: initial.leaseId, at: NOW }), true);
+    assert.equal(
+      await repo.markFailed({
+        sendKey: input.sendKey,
+        leaseId: initial.leaseId,
+        failureCode: "timeout",
+        at: NOW,
+      }),
+      true,
+    );
+
+    const retryAt = new Date(NOW.getTime() + 60_000);
+    const retry = await repo.reserve({ ...input, at: retryAt });
+    assert.equal(retry.status, OptionalEmailSendReservationOutcome.Reserved);
+    assert.equal(
+      await repo.markDeferredForDailyLimit({ sendKey: input.sendKey, leaseId: retry.leaseId, at: retryAt }),
+      true,
+    );
+
+    const expired = await repo.reserve({
+      ...input,
+      at: new Date(NOW.getTime() + OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS + 1),
+    });
+    assert.equal(expired.status, OptionalEmailSendReservationOutcome.RetryExpired);
+    assert.equal(expired.send.status, OptionalEmailSendStatus.DeferredDailyLimit);
   });
 });

--- a/tests/repositories/optional-email-send-repo.test.ts
+++ b/tests/repositories/optional-email-send-repo.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
+import { ObjectId } from "mongodb";
 import { OptionalEmailSendRepository } from "../../src/repositories/optional-email-send-repo.js";
-import { OptionalEmailReminderKind } from "../../src/types/optional-email.js";
+import {
+  OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS,
+  OPTIONAL_EMAIL_RESERVATION_LEASE_MS,
+  OptionalEmailReminderKind,
+  OptionalEmailSendBlockReason,
+} from "../../src/types/optional-email.js";
 import { createTestApp, type TestContext } from "../helpers/setup.js";
 
 const NOW = new Date("2026-09-06T12:00:00.000Z");
@@ -41,6 +47,194 @@ describe("OptionalEmailSendRepository", () => {
     assert.equal(stored && "email" in stored, false);
   });
 
+  it("reclaims exactly one stale reservation while preserving an active lease", async () => {
+    const user = await ctx.createUser();
+    const input = {
+      sendKey: "optional/setup-2026-09/user-key-stale-reservation",
+      userId: user.userId,
+      campaignId: "setup-2026-09",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+      at: NOW,
+    };
+    const initialReservation = await repo.reserve(input);
+    assert.equal(initialReservation.status, "reserved");
+    assert.equal(typeof initialReservation.leaseId, "string");
+
+    const activeLease = await repo.reserve({
+      ...input,
+      at: new Date(NOW.getTime() + OPTIONAL_EMAIL_RESERVATION_LEASE_MS),
+    });
+    assert.equal(activeLease.status, "duplicate");
+
+    const reclaimedAt = new Date(NOW.getTime() + OPTIONAL_EMAIL_RESERVATION_LEASE_MS + 1);
+    const contenders = await Promise.all([
+      repo.reserve({ ...input, at: reclaimedAt }),
+      repo.reserve({ ...input, at: reclaimedAt }),
+      repo.reserve({ ...input, at: reclaimedAt }),
+    ]);
+    assert.deepEqual(contenders.map((result) => result.status).sort(), ["duplicate", "duplicate", "reserved"]);
+    const reclaimed = contenders.find((result) => result.status === "reserved");
+    assert.ok(reclaimed);
+    assert.notEqual(reclaimed.leaseId, initialReservation.leaseId);
+
+    const stored = await repo.findBySendKey({ sendKey: input.sendKey });
+    assert.equal(stored?.status, "reserved");
+    assert.equal(stored?.attemptCount, 0);
+    assert.equal(stored?.updatedAt.toISOString(), reclaimedAt.toISOString());
+
+    const providerClaims = await Promise.all([
+      repo.markInFlight({ sendKey: input.sendKey, leaseId: initialReservation.leaseId, at: reclaimedAt }),
+      repo.markInFlight({ sendKey: input.sendKey, leaseId: reclaimed.leaseId, at: reclaimedAt }),
+      repo.markInFlight({ sendKey: input.sendKey, leaseId: reclaimed.leaseId, at: reclaimedAt }),
+    ]);
+    assert.deepEqual(providerClaims.sort(), [false, false, true]);
+    const claimed = await repo.findBySendKey({ sendKey: input.sendKey });
+    assert.equal(claimed?.status, "in_flight");
+    assert.equal(claimed?.attemptCount, 1);
+  });
+
+  it("persists only enum-backed block reasons", async () => {
+    const user = await ctx.createUser();
+    const input = {
+      sendKey: "optional/setup-2026-09/user-key-blocked",
+      userId: user.userId,
+      campaignId: "setup-2026-09",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+      at: NOW,
+    };
+    const reservation = await repo.reserve(input);
+    assert.equal(reservation.status, "reserved");
+
+    assert.equal(
+      await repo.markBlocked({
+        sendKey: input.sendKey,
+        leaseId: reservation.leaseId,
+        reason: "unsubcribed" as OptionalEmailSendBlockReason,
+        at: NOW,
+      }),
+      false,
+    );
+    assert.equal(
+      await repo.markBlocked({
+        sendKey: input.sendKey,
+        leaseId: reservation.leaseId,
+        reason: OptionalEmailSendBlockReason.MilestoneCompleted,
+        at: NOW,
+      }),
+      true,
+    );
+
+    const stored = await repo.findBySendKey({ sendKey: input.sendKey });
+    assert.equal(stored?.status, "blocked");
+    assert.equal(stored?.lastBlockReason, OptionalEmailSendBlockReason.MilestoneCompleted);
+  });
+
+  it("reclaims a stale in-flight attempt inside the idempotency window and fences its old lease", async () => {
+    const user = await ctx.createUser();
+    const input = {
+      sendKey: "optional/setup-2026-09/user-key-stale-in-flight",
+      userId: user.userId,
+      campaignId: "setup-2026-09",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+      at: NOW,
+    };
+    const initial = await repo.reserve(input);
+    assert.equal(initial.status, "reserved");
+    assert.equal(await repo.markInFlight({ sendKey: input.sendKey, leaseId: initial.leaseId, at: NOW }), true);
+
+    const active = await repo.reserve({
+      ...input,
+      at: new Date(NOW.getTime() + OPTIONAL_EMAIL_RESERVATION_LEASE_MS),
+    });
+    assert.equal(active.status, "duplicate");
+
+    const reclaimedAt = new Date(NOW.getTime() + OPTIONAL_EMAIL_RESERVATION_LEASE_MS + 1);
+    const reclaimed = await repo.reserve({ ...input, at: reclaimedAt });
+    assert.equal(reclaimed.status, "reserved");
+    assert.notEqual(reclaimed.leaseId, initial.leaseId);
+    assert.equal(
+      await repo.markInFlight({ sendKey: input.sendKey, leaseId: reclaimed.leaseId, at: reclaimedAt }),
+      true,
+    );
+    assert.equal(
+      await repo.markAccepted({
+        sendKey: input.sendKey,
+        leaseId: initial.leaseId,
+        providerEmailId: "stale-provider-result",
+        at: reclaimedAt,
+      }),
+      false,
+    );
+    assert.equal(
+      await repo.markAccepted({
+        sendKey: input.sendKey,
+        leaseId: reclaimed.leaseId,
+        providerEmailId: "recovered-provider-result",
+        at: reclaimedAt,
+      }),
+      true,
+    );
+
+    const stored = await repo.findBySendKey({ sendKey: input.sendKey });
+    assert.equal(stored?.status, "accepted");
+    assert.equal(stored?.attemptCount, 2);
+    assert.equal(stored?.providerEmailId, "recovered-provider-result");
+    assert.equal(stored?.activeLeaseId, undefined);
+  });
+
+  it("fences daily-limit deferral and issues a new lease for the retry", async () => {
+    const user = await ctx.createUser();
+    const input = {
+      sendKey: "optional/setup-2026-09/user-key-deferred",
+      userId: user.userId,
+      campaignId: "setup-2026-09",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+      at: NOW,
+    };
+    const initial = await repo.reserve(input);
+    assert.equal(initial.status, "reserved");
+    assert.equal(
+      await repo.markDeferredForDailyLimit({
+        sendKey: input.sendKey,
+        leaseId: new ObjectId().toHexString(),
+        at: NOW,
+      }),
+      false,
+    );
+    assert.equal(
+      await repo.markDeferredForDailyLimit({ sendKey: input.sendKey, leaseId: initial.leaseId, at: NOW }),
+      true,
+    );
+
+    const deferred = await repo.findBySendKey({ sendKey: input.sendKey });
+    assert.equal(deferred?.status, "deferred_daily_limit");
+    assert.equal(deferred?.activeLeaseId, undefined);
+    const retry = await repo.reserve({ ...input, at: new Date(NOW.getTime() + 1_000) });
+    assert.equal(retry.status, "reserved");
+    assert.notEqual(retry.leaseId, initial.leaseId);
+  });
+
+  it("fails closed when a stale in-flight attempt exceeds the provider idempotency window", async () => {
+    const user = await ctx.createUser();
+    const input = {
+      sendKey: "optional/setup-2026-09/user-key-expired-in-flight",
+      userId: user.userId,
+      campaignId: "setup-2026-09",
+      reminderKind: OptionalEmailReminderKind.BridgeSetup,
+      at: NOW,
+    };
+    const initial = await repo.reserve(input);
+    assert.equal(initial.status, "reserved");
+    assert.equal(await repo.markInFlight({ sendKey: input.sendKey, leaseId: initial.leaseId, at: NOW }), true);
+
+    const expired = await repo.reserve({
+      ...input,
+      at: new Date(NOW.getTime() + OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS + 1),
+    });
+    assert.equal(expired.status, "retry_expired");
+    assert.equal(expired.send.status, "in_flight");
+  });
+
   it("records one provider attempt and keeps an accepted send permanently duplicate-blocked", async () => {
     const user = await ctx.createUser();
     const input = {
@@ -50,12 +244,14 @@ describe("OptionalEmailSendRepository", () => {
       reminderKind: OptionalEmailReminderKind.BridgeSetup,
       at: NOW,
     };
-    await repo.reserve(input);
+    const reservation = await repo.reserve(input);
+    assert.equal(reservation.status, "reserved");
 
-    assert.equal(await repo.markInFlight({ sendKey: input.sendKey, at: NOW }), true);
+    assert.equal(await repo.markInFlight({ sendKey: input.sendKey, leaseId: reservation.leaseId, at: NOW }), true);
     assert.equal(
       await repo.markAccepted({
         sendKey: input.sendKey,
+        leaseId: reservation.leaseId,
         providerEmailId: "resend-email-accepted-1",
         at: new Date(NOW.getTime() + 1_000),
       }),
@@ -68,6 +264,7 @@ describe("OptionalEmailSendRepository", () => {
     assert.equal(stored?.attemptCount, 1);
     assert.equal(stored?.firstProviderAttemptAt?.toISOString(), NOW.toISOString());
     assert.equal(stored?.providerEmailId, "resend-email-accepted-1");
+    assert.equal(stored?.activeLeaseId, undefined);
     assert.equal(await repo.findUserIdByProviderEmailId({ providerEmailId: "resend-email-accepted-1" }), user.userId);
     assert.equal(duplicate.status, "duplicate");
     assert.equal(duplicate.send.status, "accepted");
@@ -82,10 +279,12 @@ describe("OptionalEmailSendRepository", () => {
       reminderKind: OptionalEmailReminderKind.BridgeSetup,
       at: NOW,
     };
-    await repo.reserve(input);
-    await repo.markInFlight({ sendKey: input.sendKey, at: NOW });
+    const reservation = await repo.reserve(input);
+    assert.equal(reservation.status, "reserved");
+    await repo.markInFlight({ sendKey: input.sendKey, leaseId: reservation.leaseId, at: NOW });
     await repo.markFailed({
       sendKey: input.sendKey,
+      leaseId: reservation.leaseId,
       failureCode: "provider_unavailable",
       at: new Date(NOW.getTime() + 1_000),
     });
@@ -93,9 +292,10 @@ describe("OptionalEmailSendRepository", () => {
     const retryAt = new Date(NOW.getTime() + 60 * 60 * 1_000);
     const retry = await repo.reserve({ ...input, at: retryAt });
     assert.equal(retry.status, "reserved");
-    assert.equal(await repo.markInFlight({ sendKey: input.sendKey, at: retryAt }), true);
+    assert.equal(await repo.markInFlight({ sendKey: input.sendKey, leaseId: retry.leaseId, at: retryAt }), true);
     await repo.markFailed({
       sendKey: input.sendKey,
+      leaseId: retry.leaseId,
       failureCode: "provider_unavailable",
       at: new Date(retryAt.getTime() + 1_000),
     });

--- a/tests/repositories/optional-email-send-repo.test.ts
+++ b/tests/repositories/optional-email-send-repo.test.ts
@@ -1,12 +1,14 @@
 import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
 import { ObjectId } from "mongodb";
+import { optionalEmailSendSchema } from "../../src/models/documents.js";
 import { OptionalEmailSendRepository } from "../../src/repositories/optional-email-send-repo.js";
 import {
   OPTIONAL_EMAIL_PROVIDER_IDEMPOTENCY_SAFETY_WINDOW_MS,
   OPTIONAL_EMAIL_RESERVATION_LEASE_MS,
   OptionalEmailReminderKind,
   OptionalEmailSendBlockReason,
+  OptionalEmailSendDeferralReason,
   OptionalEmailSendReservationOutcome,
   OptionalEmailSendStatus,
 } from "../../src/types/optional-email.js";
@@ -304,7 +306,10 @@ describe("OptionalEmailSendRepository", () => {
 
     const deferred = await repo.findBySendKey({ sendKey: input.sendKey });
     assert.equal(deferred?.status, OptionalEmailSendStatus.DeferredDailyLimit);
+    assert.equal(deferred?.lastDeferralReason, OptionalEmailSendDeferralReason.DailyLimit);
     assert.equal(deferred?.activeLeaseId, undefined);
+    assert.ok(deferred);
+    assert.equal(optionalEmailSendSchema.safeParse({ ...deferred, lastDeferralReason: "quota_typo" }).success, false);
     const retry = await repo.reserve({ ...input, at: new Date(NOW.getTime() + 1_000) });
     assert.equal(retry.status, OptionalEmailSendReservationOutcome.Reserved);
     assert.notEqual(retry.leaseId, initial.leaseId);


### PR DESCRIPTION
## Summary

- add the dormant optional-email domain enums and four MongoDB document shapes, collections, and indexes
- add product-owned optional-mail preference/suppression persistence with set-once timestamps and duplicate-key race replay
- add send-history state transitions, immutable send-key identity checks, permanent accepted-send idempotency, and bounded retry handling without storing recipient addresses
- add fenced compare-and-set leases for stale `reserved` and `in_flight` recovery, including repeated-crash and daily-deferral paths, while failing closed after lease or provider-idempotency expiry
- add an atomic UTC daily-attempt quota with a hard maximum of 80
- add focused repository tests for concurrency, lease ownership, retry expiry, enum validation, real calendar dates, race replay, identity mismatch, and fail-closed behavior

This PR supersedes draft #85 only as slice 1 of the required sequential replacement series. The original branch and commit remain preserved.

## Series plan

This is **slice 1 of 5**. Base: `master`. Dependencies: none.

1. **This PR — dormant optional-email data layer:** 1,451 additions, 0 deletions after automated-review fixes.
2. **Unsubscribe and webhook safety ingress:** planned original allocation 1,110 additions, 0 deletions; wait for slice 1 to merge, then recount against the actual base.
3. **Fail-closed eligibility and aggregate dry run:** planned original allocation 1,190 additions, 0 deletions; wait for slice 2.
4. **Guarded Resend delivery core:** planned original allocation 1,105 additions, 0 deletions; wait for slice 3.
5. **Single-recipient test operator path and runbook:** planned original allocation 629 additions, 0 deletions; wait for slice 4.

No later slice branch or PR has been pushed/opened. The full saved dependency plan and production blockers are in:

`/Users/alexandrudochioiu/sesori-ai/sesori-distribution/Research/Resend Integration Readiness.md`

## Production behavior

- normal startup will create the four bounded collections/indexes when this slice is deployed
- no sender configuration, HTTP route, Resend adapter, provider call, campaign, scheduler, or executable send path exists in this slice
- production sending therefore remains impossible in this slice
- existing essential/security email behavior is untouched

## Safety details

- optional-mail preference and provider-suppression state is product-owned and set-once
- first-write unsubscribe/suppression races replay the losing update after `E11000`, preserving both blockers
- send history stores user/campaign/reminder identity but no recipient address
- reusing a send key with mismatched immutable identity fails closed
- active reservation attempts carry an opaque lease ID; stale owners cannot complete transitions after lease rotation
- stale uncertain attempts and deferred retries are reclaimable only inside the 23-hour provider-idempotency safety window
- `markInFlight` atomically enforces both the five-minute lease and provider retry cutoff before any future provider call
- retry-window comparison is centralized across reserved, in-flight, failed, and deferred states
- reservation outcomes, block reasons, and deferral reasons use centralized string-valued enums
- quota reservations are atomic, never refunded, and cannot be configured above 80 attempts/day
- impossible UTC date identifiers fail model validation
- no credentials or production data were used

## Automated review

All findings were inspected rather than rubber-stamped:

- `f952fcfd68e9bc460e6463a31ce672988e1f5447` fixes stale reservation/in-flight recovery, persisted block/suppression validation, real-calendar validation, and missing quota assertions. One Cubic “JSON block” comment was unrelated to the cited TypeScript and explicitly answered as non-actionable.
- `e66f039820c9d5777d5ff87280ed27c15a59b42c` fixes the repeated-crash retry-window gap, raw reservation outcome literals, first-write preference race, and send-key identity reuse.
- `6f16f460b02f44e594dfc38ad3744a0115671926` fixes the deferred-retry window gap and atomically rejects expired leases/provider windows before `markInFlight`.
- `999b9ef9638cd52510d5eaae6c06e6ada9d35051` enum-validates the persisted deferral reason and centralizes the four retry-window comparisons.

The latest `999b9ef` push is fully settled: `cla`, `docker`, and `test` passed; optional `[code]smith` skipped; Cubic approved with 0 issues; Codex completed with no new inline findings; and GraphQL review-thread readback reports 0 unresolved threads.

## Verification

Node `v22.23.2`:

- `git diff --check` — passed
- `npm run build` — passed
- `npm run lint` — passed
- `npm run format:check` — passed
- `npm run circular-dependencies` — passed; no circular dependency
- focused repository tests — 23/23 passed
- `npm test` — 954 total, 953 passed, one pre-existing skip, zero failed

## Provenance and non-goals

The initial coherent subset was copied without implementation edits from preserved commit `616d84c21f9f689495e9400c740cfd99ffd47b28`. Commits `f952fcf`, `e66f039`, `6f16f46`, and `999b9ef` contain only tests, fixes, and line-reducing refactors for inspected automated-review findings. No send occurred. No production DB, deployment, DNS/provider-account operation, secret, scheduler, or merge was used or performed.
