### PR TITLE
feat(optional-email): add unsubscribe and webhook ingress

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { AsyncTranscriptionProvider, SonioxRegion } from "./types/transcription.js";
 import { clientIpSourceSchema, ClientIpSource, trustedIngressCidrsSchema } from "./types/client-ip.js";
 import { productAnalyticsPseudonymizationKeySchema } from "./types/product-analytics.js";
+import { isValidResendWebhookSigningSecret } from "./services/resend-webhook-verifier.js";
 
 const appleConfigSchema = z.object({
   APPLE_CLIENT_ID: z.string().min(1, "APPLE_CLIENT_ID is required"),
@@ -73,6 +74,17 @@ const baseConfigSchema = z.object({
   ACTIVATION_BRIDGE_REMINDER_2_DELAY_MS: z.coerce.number().int().positive().default(86_400_000),
   ACTIVATION_SESSION_REMINDER_DELAY_MS: z.coerce.number().int().positive().default(86_400_000),
   ACTIVATION_SWEEP_BATCH_LIMIT: z.coerce.number().int().positive().default(100),
+  RESEND_WEBHOOK_SECRET: z
+    .string()
+    .refine(isValidResendWebhookSigningSecret, "RESEND_WEBHOOK_SECRET must be a valid Svix signing secret")
+    .optional(),
+  OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET: z
+    .string()
+    .refine(
+      (value) => Buffer.byteLength(value, "utf8") >= 32,
+      "OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET must be at least 32 bytes",
+    )
+    .optional(),
   OPENAI_API_KEY: z.string().min(1, "OPENAI_API_KEY is required"),
   OPENAI_TRANSCRIPTION_MODEL: z.string().min(1).default("gpt-4o-mini-transcribe"),
   OPENAI_METADATA_MODEL: z.string().min(1).default("gpt-5-nano"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import { AppClientPresenceService } from "./services/app-client-presence-service
 import { ProductAnalyticsPreferenceService } from "./services/product-analytics-preference-service.js";
 import { SettingsService } from "./services/settings-service.js";
 import { createShutdownHandler } from "./shutdown.js";
+import { createOptionalEmailRouteServices } from "./optional-email-composition.js";
 
 async function main() {
   const config = loadConfig();
@@ -69,6 +70,12 @@ async function main() {
   });
 
   const dbAccessor = new MongoDbAccessor(dbConnector);
+
+  const optionalEmail = createOptionalEmailRouteServices({
+    dbAccessor,
+    unsubscribeSigningSecret: config.OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET,
+    webhookSigningSecret: config.RESEND_WEBHOOK_SECRET,
+  });
 
   console.log("Creating indexes...");
   await dbAccessor.ensureIndexes();
@@ -270,6 +277,7 @@ async function main() {
     appleNativeVerifier,
     pendingAuthStore,
     productAnalyticsPreferenceService,
+    optionalEmail,
     realtime,
   });
 

--- a/src/optional-email-composition.ts
+++ b/src/optional-email-composition.ts
@@ -1,0 +1,52 @@
+import type { MongoDbAccessor } from "./db/mongo-db-accessor.js";
+import { OptionalEmailPreferenceRepository } from "./repositories/optional-email-preference-repo.js";
+import { OptionalEmailSendRepository } from "./repositories/optional-email-send-repo.js";
+import { OptionalEmailWebhookEventRepository } from "./repositories/optional-email-webhook-event-repo.js";
+import {
+  OptionalEmailUnsubscribeService,
+  OptionalEmailUnsubscribeTokenService,
+} from "./services/optional-email-unsubscribe-service.js";
+import { OptionalEmailWebhookService } from "./services/optional-email-webhook-service.js";
+import { ResendWebhookVerifier } from "./services/resend-webhook-verifier.js";
+
+export type OptionalEmailRouteServices = {
+  unsubscribeService?: OptionalEmailUnsubscribeService;
+  webhook?: {
+    verifier: ResendWebhookVerifier;
+    service: OptionalEmailWebhookService;
+  };
+};
+
+export function createOptionalEmailRouteServices(input: {
+  dbAccessor: MongoDbAccessor;
+  unsubscribeSigningSecret: string | undefined;
+  webhookSigningSecret: string | undefined;
+}): OptionalEmailRouteServices | undefined {
+  if (!input.unsubscribeSigningSecret && !input.webhookSigningSecret) {
+    return undefined;
+  }
+
+  const preferenceRepo = new OptionalEmailPreferenceRepository(input.dbAccessor);
+  const services: OptionalEmailRouteServices = {};
+  if (input.unsubscribeSigningSecret) {
+    services.unsubscribeService = new OptionalEmailUnsubscribeService({
+      tokenService: new OptionalEmailUnsubscribeTokenService({
+        signingSecret: Buffer.from(input.unsubscribeSigningSecret, "utf8"),
+      }),
+      preferenceRepo,
+    });
+  }
+
+  if (input.webhookSigningSecret) {
+    services.webhook = {
+      verifier: new ResendWebhookVerifier({ signingSecret: input.webhookSigningSecret }),
+      service: new OptionalEmailWebhookService({
+        eventRepo: new OptionalEmailWebhookEventRepository(input.dbAccessor),
+        preferenceRepo,
+        sendHistory: new OptionalEmailSendRepository(input.dbAccessor),
+      }),
+    };
+  }
+
+  return services;
+}

--- a/src/repositories/optional-email-webhook-event-repo.ts
+++ b/src/repositories/optional-email-webhook-event-repo.ts
@@ -1,0 +1,49 @@
+import { Collection, MongoServerError, ObjectId } from "mongodb";
+import type { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import { InternalServerError } from "../lib/errors.js";
+import type { OptionalEmailWebhookEvent } from "../models/documents.js";
+import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
+
+export class OptionalEmailWebhookEventRepository {
+  readonly #collection: Collection<OptionalEmailWebhookEvent>;
+
+  constructor(accessor: MongoDbAccessor) {
+    this.#collection = accessor.getCollection<OptionalEmailWebhookEvent>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.OptionalEmailWebhookEvents,
+    );
+  }
+
+  async wasProcessed(input: { eventId: string }): Promise<boolean> {
+    this.#validateEventId(input.eventId);
+    return (await this.#collection.countDocuments({ eventId: input.eventId }, { limit: 1 })) > 0;
+  }
+
+  async recordProcessed(input: { eventId: string; eventType: string; processedAt: Date }): Promise<boolean> {
+    this.#validateEventId(input.eventId);
+    if (!input.eventType || input.eventType.length > 128 || Number.isNaN(input.processedAt.getTime())) {
+      throw new InternalServerError({ debugMessage: "Invalid optional email webhook event" });
+    }
+
+    try {
+      await this.#collection.insertOne({
+        _id: new ObjectId(),
+        eventId: input.eventId,
+        eventType: input.eventType,
+        processedAt: input.processedAt,
+      });
+      return true;
+    } catch (error) {
+      if (error instanceof MongoServerError && error.code === 11000) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  #validateEventId(eventId: string): void {
+    if (!eventId || eventId.length > 256) {
+      throw new InternalServerError({ debugMessage: "Invalid optional email webhook event id" });
+    }
+  }
+}

--- a/src/routes/optional-email-unsubscribe.ts
+++ b/src/routes/optional-email-unsubscribe.ts
@@ -53,7 +53,7 @@ export const optionalEmailUnsubscribeRoutes: FastifyPluginAsync<OptionalEmailUns
 </html>`);
   });
 
-  app.post("/email/optional/unsubscribe", async (request, reply) => {
+  app.post("/email/optional/unsubscribe", { config: { rateLimit: false } }, async (request, reply) => {
     setSafetyHeaders(reply);
     const query = querySchema.safeParse(request.query);
     const body = typeof request.body === "string" ? new URLSearchParams(request.body) : null;

--- a/src/routes/optional-email-unsubscribe.ts
+++ b/src/routes/optional-email-unsubscribe.ts
@@ -1,0 +1,70 @@
+import type { FastifyPluginAsync, FastifyReply } from "fastify";
+import { z } from "zod";
+import type { OptionalEmailUnsubscribeService } from "../services/optional-email-unsubscribe-service.js";
+
+const querySchema = z.object({ token: z.string().min(1).max(2_048) }).strict();
+
+export type OptionalEmailUnsubscribeRouteOptions = {
+  service: OptionalEmailUnsubscribeService;
+};
+
+function setSafetyHeaders(reply: FastifyReply): void {
+  reply.header("Cache-Control", "no-store");
+  reply.header("X-Content-Type-Options", "nosniff");
+  reply.header("Referrer-Policy", "no-referrer");
+  reply.header(
+    "Content-Security-Policy",
+    "default-src 'none'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
+  );
+}
+
+export const optionalEmailUnsubscribeRoutes: FastifyPluginAsync<OptionalEmailUnsubscribeRouteOptions> = async (
+  app,
+  options,
+) => {
+  app.addContentTypeParser(
+    "application/x-www-form-urlencoded",
+    { parseAs: "string", bodyLimit: 1_024 },
+    (_request, body, done) => done(null, body),
+  );
+
+  app.get("/email/optional/unsubscribe", async (request, reply) => {
+    setSafetyHeaders(reply);
+    const query = querySchema.safeParse(request.query);
+    if (!query.success || !options.service.isValid({ token: query.data.token })) {
+      return reply.status(400).type("text/plain; charset=utf-8").send("Invalid unsubscribe link");
+    }
+
+    const action = `/email/optional/unsubscribe?token=${encodeURIComponent(query.data.token)}`;
+    return reply.type("text/html; charset=utf-8").send(`<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>Unsubscribe</title></head>
+  <body>
+    <main>
+      <h1>Unsubscribe from optional Sesori setup reminders</h1>
+      <p>Security and essential account messages are not affected.</p>
+      <form method="post" action="${action}">
+        <input type="hidden" name="List-Unsubscribe" value="One-Click">
+        <button type="submit">Unsubscribe</button>
+      </form>
+    </main>
+  </body>
+</html>`);
+  });
+
+  app.post("/email/optional/unsubscribe", async (request, reply) => {
+    setSafetyHeaders(reply);
+    const query = querySchema.safeParse(request.query);
+    const body = typeof request.body === "string" ? new URLSearchParams(request.body) : null;
+    const validBody =
+      body !== null &&
+      [...body.keys()].length === 1 &&
+      body.getAll("List-Unsubscribe").length === 1 &&
+      body.get("List-Unsubscribe") === "One-Click";
+    if (!query.success || !validBody || !(await options.service.unsubscribe({ token: query.data.token }))) {
+      return reply.status(400).type("text/plain; charset=utf-8").send("Invalid unsubscribe request");
+    }
+
+    return reply.status(200).type("text/plain; charset=utf-8").send("");
+  });
+};

--- a/src/routes/optional-email-unsubscribe.ts
+++ b/src/routes/optional-email-unsubscribe.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { OptionalEmailUnsubscribeService } from "../services/optional-email-unsubscribe-service.js";
 
 const querySchema = z.object({ token: z.string().min(1).max(2_048) }).strict();
+const oneClickBodySchema = z.object({ "List-Unsubscribe": z.literal("One-Click") }).strict();
 
 export type OptionalEmailUnsubscribeRouteOptions = {
   service: OptionalEmailUnsubscribeService;
@@ -56,12 +57,10 @@ export const optionalEmailUnsubscribeRoutes: FastifyPluginAsync<OptionalEmailUns
     setSafetyHeaders(reply);
     const query = querySchema.safeParse(request.query);
     const body = typeof request.body === "string" ? new URLSearchParams(request.body) : null;
-    const validBody =
-      body !== null &&
-      [...body.keys()].length === 1 &&
-      body.getAll("List-Unsubscribe").length === 1 &&
-      body.get("List-Unsubscribe") === "One-Click";
-    if (!query.success || !validBody || !(await options.service.unsubscribe({ token: query.data.token }))) {
+    const parsedBody = oneClickBodySchema.safeParse(
+      body !== null && [...body.keys()].length === 1 ? Object.fromEntries(body.entries()) : null,
+    );
+    if (!query.success || !parsedBody.success || !(await options.service.unsubscribe({ token: query.data.token }))) {
       return reply.status(400).type("text/plain; charset=utf-8").send("Invalid unsubscribe request");
     }
 

--- a/src/routes/optional-email-webhook.ts
+++ b/src/routes/optional-email-webhook.ts
@@ -27,7 +27,7 @@ export const optionalEmailWebhookRoutes: FastifyPluginAsync<OptionalEmailWebhook
     (_request, body, done) => done(null, body),
   );
 
-  app.post("/webhooks/resend", async (request, reply) => {
+  app.post("/webhooks/resend", { config: { rateLimit: false } }, async (request, reply) => {
     reply.header("Cache-Control", "no-store");
     const messageId = request.headers["svix-id"];
     const timestamp = request.headers["svix-timestamp"];

--- a/src/routes/optional-email-webhook.ts
+++ b/src/routes/optional-email-webhook.ts
@@ -1,0 +1,67 @@
+import type { FastifyPluginAsync } from "fastify";
+import {
+  InvalidResendWebhookEventError,
+  type OptionalEmailWebhookService,
+} from "../services/optional-email-webhook-service.js";
+import type { ResendWebhookVerifier } from "../services/resend-webhook-verifier.js";
+import { OptionalEmailWebhookStatus } from "../types/optional-email.js";
+
+const MAX_WEBHOOK_BODY_BYTES = 256 * 1_024;
+const RETRY_AFTER_SECONDS = 60;
+
+export type OptionalEmailWebhookRouteOptions = {
+  service: OptionalEmailWebhookService;
+  verifier: ResendWebhookVerifier;
+};
+
+export const optionalEmailWebhookRoutes: FastifyPluginAsync<OptionalEmailWebhookRouteOptions> = async (
+  app,
+  options,
+) => {
+  // Keep the exact bytes represented by the incoming UTF-8 JSON string. Parsing
+  // and re-serializing before HMAC verification would invalidate the signature.
+  app.removeContentTypeParser("application/json");
+  app.addContentTypeParser(
+    "application/json",
+    { parseAs: "string", bodyLimit: MAX_WEBHOOK_BODY_BYTES },
+    (_request, body, done) => done(null, body),
+  );
+
+  app.post("/webhooks/resend", async (request, reply) => {
+    reply.header("Cache-Control", "no-store");
+    const messageId = request.headers["svix-id"];
+    const timestamp = request.headers["svix-timestamp"];
+    const signature = request.headers["svix-signature"];
+    if (
+      typeof request.body !== "string" ||
+      typeof messageId !== "string" ||
+      typeof timestamp !== "string" ||
+      typeof signature !== "string"
+    ) {
+      return reply.status(400).type("text/plain; charset=utf-8").send("Invalid webhook");
+    }
+
+    let event: unknown;
+    try {
+      event = options.verifier.verify({ rawBody: request.body, messageId, timestamp, signature });
+    } catch {
+      return reply.status(400).type("text/plain; charset=utf-8").send("Invalid webhook");
+    }
+
+    let result;
+    try {
+      result = await options.service.handleVerified({ eventId: messageId, event });
+    } catch (error) {
+      if (error instanceof InvalidResendWebhookEventError) {
+        return reply.status(400).type("text/plain; charset=utf-8").send("Invalid webhook");
+      }
+      throw error;
+    }
+
+    if (result.status === OptionalEmailWebhookStatus.Retry) {
+      reply.header("Retry-After", String(RETRY_AFTER_SECONDS));
+      return reply.status(503).send();
+    }
+    return reply.status(204).send();
+  });
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,7 @@ import type { PendingAuthStore } from "./services/pending-auth-store.js";
 import type { AppClientPresenceService } from "./services/app-client-presence-service.js";
 import type { ProductAnalyticsPreferenceService } from "./services/product-analytics-preference-service.js";
 import type { SettingsService } from "./services/settings-service.js";
+import type { OptionalEmailRouteServices } from "./optional-email-composition.js";
 import { installRoutes } from "./routes/install.js";
 import { legalRoutes } from "./routes/legal.js";
 import { tokenRoutes } from "./routes/token.js";
@@ -43,6 +44,8 @@ import { sessionStatusRoutes } from "./routes/auth/session-status.js";
 import { appClientRoutes } from "./routes/app-clients.js";
 import { productAnalyticsRoutes } from "./routes/product-analytics.js";
 import { settingsRoutes } from "./routes/settings/settings.js";
+import { optionalEmailUnsubscribeRoutes } from "./routes/optional-email-unsubscribe.js";
+import { optionalEmailWebhookRoutes } from "./routes/optional-email-webhook.js";
 import { voiceRealtimeRoutes, type VoiceRealtimeRouteOptions } from "./routes/voice-realtime.js";
 import { MAX_TRANSPORT_PAYLOAD_BYTES } from "./routes/voice-realtime-support.js";
 
@@ -68,6 +71,7 @@ export type AppServices = {
   appleNativeVerifier: AppleNativeVerifier;
   pendingAuthStore: PendingAuthStore;
   productAnalyticsPreferenceService: ProductAnalyticsPreferenceService;
+  optionalEmail?: OptionalEmailRouteServices;
   realtime?: Omit<VoiceRealtimeRouteOptions, "preAuthRateLimit" | "requireAuth">;
 };
 
@@ -162,6 +166,16 @@ export async function buildApp(services: AppServices): Promise<FastifyInstance> 
   await app.register(legalRoutes, {
     legalDocumentService: services.legalDocumentService,
   });
+
+  if (services.optionalEmail?.unsubscribeService) {
+    await app.register(optionalEmailUnsubscribeRoutes, {
+      service: services.optionalEmail.unsubscribeService,
+    });
+  }
+
+  if (services.optionalEmail?.webhook) {
+    await app.register(optionalEmailWebhookRoutes, services.optionalEmail.webhook);
+  }
 
   const requireAuth = createAuthMiddleware(services.tokenService, {
     devBypassEnabled: services.config.AUTH_DEV_BYPASS_ENABLED,

--- a/src/services/optional-email-unsubscribe-service.ts
+++ b/src/services/optional-email-unsubscribe-service.ts
@@ -50,7 +50,11 @@ export class OptionalEmailUnsubscribeTokenService {
     const unsigned = `${parts[0]}.${parts[1]}`;
     const expected = Buffer.from(this.#signatureFor(unsigned), "base64url");
     const actual = Buffer.from(encodedSignature, "base64url");
-    if (actual.byteLength !== expected.byteLength || !timingSafeEqual(actual, expected)) {
+    if (
+      actual.toString("base64url") !== encodedSignature ||
+      actual.byteLength !== expected.byteLength ||
+      !timingSafeEqual(actual, expected)
+    ) {
       return null;
     }
 

--- a/src/services/optional-email-unsubscribe-service.ts
+++ b/src/services/optional-email-unsubscribe-service.ts
@@ -1,0 +1,121 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { z } from "zod";
+import type { OptionalEmailPreferenceRepository } from "../repositories/optional-email-preference-repo.js";
+
+const TOKEN_VERSION = "v1";
+const TOKEN_PURPOSE = "optional_email_unsubscribe";
+const MAX_TOKEN_LENGTH = 2_048;
+const USER_ID_PATTERN = /^[a-f0-9]{24}$/;
+const SIGNATURE_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const tokenPayloadSchema = z
+  .object({
+    purpose: z.literal(TOKEN_PURPOSE),
+    userId: z.string().regex(USER_ID_PATTERN),
+  })
+  .strict();
+
+export class OptionalEmailUnsubscribeTokenService {
+  readonly #signingSecret: Buffer;
+
+  constructor(input: { signingSecret: Buffer }) {
+    if (input.signingSecret.byteLength < 32) {
+      throw new Error("OptionalEmailUnsubscribeSigningSecretTooShort");
+    }
+
+    this.#signingSecret = Buffer.from(input.signingSecret);
+  }
+
+  create(input: { userId: string }): string {
+    const userId = input.userId.toLowerCase();
+    if (!USER_ID_PATTERN.test(userId)) {
+      throw new Error("InvalidOptionalEmailUnsubscribeUserId");
+    }
+
+    const payload = Buffer.from(JSON.stringify({ purpose: TOKEN_PURPOSE, userId }), "utf8").toString("base64url");
+    const unsigned = `${TOKEN_VERSION}.${payload}`;
+    return `${unsigned}.${this.#signatureFor(unsigned)}`;
+  }
+
+  verify(input: { token: string }): string | null {
+    if (!input.token || input.token.length > MAX_TOKEN_LENGTH) {
+      return null;
+    }
+
+    const parts = input.token.split(".");
+    const encodedSignature = parts[2] ?? "";
+    if (parts.length !== 3 || parts[0] !== TOKEN_VERSION || !SIGNATURE_PATTERN.test(encodedSignature)) {
+      return null;
+    }
+
+    const unsigned = `${parts[0]}.${parts[1]}`;
+    const expected = Buffer.from(this.#signatureFor(unsigned), "base64url");
+    const actual = Buffer.from(encodedSignature, "base64url");
+    if (actual.byteLength !== expected.byteLength || !timingSafeEqual(actual, expected)) {
+      return null;
+    }
+
+    try {
+      const decoded = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString("utf8")) as unknown;
+      const result = tokenPayloadSchema.safeParse(decoded);
+      return result.success ? result.data.userId : null;
+    } catch {
+      return null;
+    }
+  }
+
+  #signatureFor(unsigned: string): string {
+    return createHmac("sha256", this.#signingSecret).update(unsigned, "utf8").digest("base64url");
+  }
+}
+
+export class OptionalEmailUnsubscribeService {
+  readonly #preferenceRepo: OptionalEmailPreferenceRepository;
+  readonly #tokenService: OptionalEmailUnsubscribeTokenService;
+  readonly #clock: () => Date;
+
+  constructor(input: {
+    preferenceRepo: OptionalEmailPreferenceRepository;
+    tokenService: OptionalEmailUnsubscribeTokenService;
+    clock?: () => Date;
+  }) {
+    this.#preferenceRepo = input.preferenceRepo;
+    this.#tokenService = input.tokenService;
+    this.#clock = input.clock ?? (() => new Date());
+  }
+
+  isValid(input: { token: string }): boolean {
+    return this.#tokenService.verify(input) !== null;
+  }
+
+  async unsubscribe(input: { token: string }): Promise<boolean> {
+    const userId = this.#tokenService.verify(input);
+    if (!userId) {
+      return false;
+    }
+
+    await this.#preferenceRepo.unsubscribe({ userId, at: this.#clock() });
+    return true;
+  }
+}
+
+export function buildOptionalEmailUnsubscribeHeaders(input: {
+  publicBaseUrl: string;
+  token: string;
+}): Record<"List-Unsubscribe" | "List-Unsubscribe-Post", string> {
+  let baseUrl: URL;
+  try {
+    baseUrl = new URL(input.publicBaseUrl);
+  } catch {
+    throw new Error("InvalidOptionalEmailPublicBaseUrl");
+  }
+  if (baseUrl.protocol !== "https:" || baseUrl.username || baseUrl.password || !input.token) {
+    throw new Error("InvalidOptionalEmailPublicBaseUrl");
+  }
+
+  const url = new URL("/email/optional/unsubscribe", baseUrl);
+  url.searchParams.set("token", input.token);
+  return {
+    "List-Unsubscribe": `<${url.toString()}>`,
+    "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+  };
+}

--- a/src/services/optional-email-webhook-service.ts
+++ b/src/services/optional-email-webhook-service.ts
@@ -16,7 +16,11 @@ const webhookEnvelopeSchema = z
     event_type: webhookEventTypeSchema.optional(),
   })
   .passthrough()
-  .refine((event) => event.type !== undefined || event.event_type !== undefined)
+  .refine(
+    (event) =>
+      (event.type !== undefined || event.event_type !== undefined) &&
+      (event.type === undefined || event.event_type === undefined || event.type === event.event_type),
+  )
   .transform((event) => event.type ?? event.event_type!);
 
 const webhookEventSchema = z

--- a/src/services/optional-email-webhook-service.ts
+++ b/src/services/optional-email-webhook-service.ts
@@ -8,9 +8,20 @@ import {
   OptionalEmailWebhookOutcome,
   OptionalEmailWebhookStatus,
 } from "../types/optional-email.js";
+
+const webhookEventTypeSchema = z.string().min(1).max(128);
+const webhookEnvelopeSchema = z
+  .object({
+    type: webhookEventTypeSchema.optional(),
+    event_type: webhookEventTypeSchema.optional(),
+  })
+  .passthrough()
+  .refine((event) => event.type !== undefined || event.event_type !== undefined)
+  .transform((event) => event.type ?? event.event_type!);
+
 const webhookEventSchema = z
   .object({
-    type: z.string().min(1).max(128),
+    type: webhookEventTypeSchema,
     data: z
       .object({
         email_id: z.string().min(1).max(256),
@@ -23,6 +34,14 @@ const webhookEventSchema = z
       .passthrough(),
   })
   .passthrough();
+
+function isSuppressionEventType(eventType: string): eventType is OptionalEmailWebhookEventType {
+  return (
+    eventType === OptionalEmailWebhookEventType.Bounced ||
+    eventType === OptionalEmailWebhookEventType.Complained ||
+    eventType === OptionalEmailWebhookEventType.Suppressed
+  );
+}
 
 export interface OptionalEmailSendHistoryLookup {
   findUserIdByProviderEmailId(input: { providerEmailId: string }): Promise<string | null>;
@@ -63,23 +82,25 @@ export class OptionalEmailWebhookService {
       return { status: OptionalEmailWebhookStatus.Replayed };
     }
 
+    const envelope = webhookEnvelopeSchema.safeParse(input.event);
+    if (!envelope.success) {
+      throw new InvalidResendWebhookEventError();
+    }
+
     const parsed = webhookEventSchema.safeParse(input.event);
     if (!parsed.success) {
-      throw new InvalidResendWebhookEventError();
+      if (isSuppressionEventType(envelope.data)) {
+        throw new InvalidResendWebhookEventError();
+      }
+
+      return this.#recordIgnored({ eventId: input.eventId, eventType: envelope.data });
     }
 
     const event = parsed.data;
     const optionalEvent = event.data.tags?.category === OptionalEmailCategory.SetupReminder;
     const reason = this.#suppressionReason(event);
     if (!optionalEvent || !reason) {
-      const inserted = await this.#eventRepo.recordProcessed({
-        eventId: input.eventId,
-        eventType: event.type,
-        processedAt: this.#clock(),
-      });
-      return inserted
-        ? { status: OptionalEmailWebhookStatus.Processed, outcome: OptionalEmailWebhookOutcome.Ignored }
-        : { status: OptionalEmailWebhookStatus.Replayed };
+      return this.#recordIgnored({ eventId: input.eventId, eventType: event.type });
     }
 
     const userId = await this.#sendHistory.findUserIdByProviderEmailId({
@@ -97,6 +118,16 @@ export class OptionalEmailWebhookService {
     });
     return inserted
       ? { status: OptionalEmailWebhookStatus.Processed, outcome: OptionalEmailWebhookOutcome.Suppressed }
+      : { status: OptionalEmailWebhookStatus.Replayed };
+  }
+
+  async #recordIgnored(input: { eventId: string; eventType: string }): Promise<OptionalEmailWebhookResult> {
+    const inserted = await this.#eventRepo.recordProcessed({
+      ...input,
+      processedAt: this.#clock(),
+    });
+    return inserted
+      ? { status: OptionalEmailWebhookStatus.Processed, outcome: OptionalEmailWebhookOutcome.Ignored }
       : { status: OptionalEmailWebhookStatus.Replayed };
   }
 

--- a/src/services/optional-email-webhook-service.ts
+++ b/src/services/optional-email-webhook-service.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+import type { OptionalEmailPreferenceRepository } from "../repositories/optional-email-preference-repo.js";
+import type { OptionalEmailWebhookEventRepository } from "../repositories/optional-email-webhook-event-repo.js";
+import {
+  OptionalEmailSuppressionReason,
+  OptionalEmailWebhookEventType,
+  OptionalEmailWebhookOutcome,
+  OptionalEmailWebhookStatus,
+} from "../types/optional-email.js";
+
+const OPTIONAL_EMAIL_CATEGORY = "optional_setup_reminder";
+const webhookEventSchema = z
+  .object({
+    type: z.string().min(1).max(128),
+    data: z
+      .object({
+        email_id: z.string().min(1).max(256),
+        bounce: z
+          .object({ type: z.string().min(1).max(64) })
+          .passthrough()
+          .optional(),
+        tags: z.record(z.string().min(1).max(64), z.string().max(256)).optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+export interface OptionalEmailSendHistoryLookup {
+  findUserIdByProviderEmailId(input: { providerEmailId: string }): Promise<string | null>;
+}
+
+export type OptionalEmailWebhookResult =
+  | { status: OptionalEmailWebhookStatus.Processed; outcome: OptionalEmailWebhookOutcome }
+  | { status: OptionalEmailWebhookStatus.Replayed }
+  | { status: OptionalEmailWebhookStatus.Retry };
+
+export class InvalidResendWebhookEventError extends Error {
+  constructor() {
+    super("InvalidResendWebhookEvent");
+    this.name = "InvalidResendWebhookEventError";
+  }
+}
+
+export class OptionalEmailWebhookService {
+  readonly #eventRepo: OptionalEmailWebhookEventRepository;
+  readonly #preferenceRepo: OptionalEmailPreferenceRepository;
+  readonly #sendHistory: OptionalEmailSendHistoryLookup;
+  readonly #clock: () => Date;
+
+  constructor(input: {
+    eventRepo: OptionalEmailWebhookEventRepository;
+    preferenceRepo: OptionalEmailPreferenceRepository;
+    sendHistory: OptionalEmailSendHistoryLookup;
+    clock?: () => Date;
+  }) {
+    this.#eventRepo = input.eventRepo;
+    this.#preferenceRepo = input.preferenceRepo;
+    this.#sendHistory = input.sendHistory;
+    this.#clock = input.clock ?? (() => new Date());
+  }
+
+  async handleVerified(input: { eventId: string; event: unknown }): Promise<OptionalEmailWebhookResult> {
+    if (await this.#eventRepo.wasProcessed({ eventId: input.eventId })) {
+      return { status: OptionalEmailWebhookStatus.Replayed };
+    }
+
+    const parsed = webhookEventSchema.safeParse(input.event);
+    if (!parsed.success) {
+      throw new InvalidResendWebhookEventError();
+    }
+
+    const event = parsed.data;
+    const optionalEvent = event.data.tags?.category === OPTIONAL_EMAIL_CATEGORY;
+    const reason = this.#suppressionReason(event);
+    if (!optionalEvent || !reason) {
+      const inserted = await this.#eventRepo.recordProcessed({
+        eventId: input.eventId,
+        eventType: event.type,
+        processedAt: this.#clock(),
+      });
+      return inserted
+        ? { status: OptionalEmailWebhookStatus.Processed, outcome: OptionalEmailWebhookOutcome.Ignored }
+        : { status: OptionalEmailWebhookStatus.Replayed };
+    }
+
+    const userId = await this.#sendHistory.findUserIdByProviderEmailId({
+      providerEmailId: event.data.email_id,
+    });
+    if (!userId) {
+      return { status: OptionalEmailWebhookStatus.Retry };
+    }
+
+    await this.#preferenceRepo.suppress({ userId, reason, at: this.#clock() });
+    const inserted = await this.#eventRepo.recordProcessed({
+      eventId: input.eventId,
+      eventType: event.type,
+      processedAt: this.#clock(),
+    });
+    return inserted
+      ? { status: OptionalEmailWebhookStatus.Processed, outcome: OptionalEmailWebhookOutcome.Suppressed }
+      : { status: OptionalEmailWebhookStatus.Replayed };
+  }
+
+  #suppressionReason(event: z.infer<typeof webhookEventSchema>): OptionalEmailSuppressionReason | null {
+    if (event.type === OptionalEmailWebhookEventType.Bounced && event.data.bounce?.type === "Permanent") {
+      return OptionalEmailSuppressionReason.HardBounce;
+    }
+    if (event.type === OptionalEmailWebhookEventType.Complained) {
+      return OptionalEmailSuppressionReason.Complaint;
+    }
+    if (event.type === OptionalEmailWebhookEventType.Suppressed) {
+      return OptionalEmailSuppressionReason.ProviderSuppressed;
+    }
+    return null;
+  }
+}

--- a/src/services/optional-email-webhook-service.ts
+++ b/src/services/optional-email-webhook-service.ts
@@ -2,13 +2,12 @@ import { z } from "zod";
 import type { OptionalEmailPreferenceRepository } from "../repositories/optional-email-preference-repo.js";
 import type { OptionalEmailWebhookEventRepository } from "../repositories/optional-email-webhook-event-repo.js";
 import {
+  OptionalEmailCategory,
   OptionalEmailSuppressionReason,
   OptionalEmailWebhookEventType,
   OptionalEmailWebhookOutcome,
   OptionalEmailWebhookStatus,
 } from "../types/optional-email.js";
-
-const OPTIONAL_EMAIL_CATEGORY = "optional_setup_reminder";
 const webhookEventSchema = z
   .object({
     type: z.string().min(1).max(128),
@@ -70,7 +69,7 @@ export class OptionalEmailWebhookService {
     }
 
     const event = parsed.data;
-    const optionalEvent = event.data.tags?.category === OPTIONAL_EMAIL_CATEGORY;
+    const optionalEvent = event.data.tags?.category === OptionalEmailCategory.SetupReminder;
     const reason = this.#suppressionReason(event);
     if (!optionalEvent || !reason) {
       const inserted = await this.#eventRepo.recordProcessed({
@@ -105,12 +104,15 @@ export class OptionalEmailWebhookService {
     if (event.type === OptionalEmailWebhookEventType.Bounced && event.data.bounce?.type === "Permanent") {
       return OptionalEmailSuppressionReason.HardBounce;
     }
+
     if (event.type === OptionalEmailWebhookEventType.Complained) {
       return OptionalEmailSuppressionReason.Complaint;
     }
+
     if (event.type === OptionalEmailWebhookEventType.Suppressed) {
       return OptionalEmailSuppressionReason.ProviderSuppressed;
     }
+
     return null;
   }
 }

--- a/src/services/resend-webhook-verifier.ts
+++ b/src/services/resend-webhook-verifier.ts
@@ -11,8 +11,9 @@ function decodeCanonicalBase64(value: string): Buffer | null {
   }
 
   const decoded = Buffer.from(value, "base64");
-  const canonical = decoded.toString("base64").replace(/=+$/u, "");
-  return canonical === value.replace(/=+$/u, "") ? decoded : null;
+  const canonical = decoded.toString("base64");
+  const unpaddedCanonical = canonical.replace(/=+$/u, "");
+  return value === canonical || value === unpaddedCanonical ? decoded : null;
 }
 
 function decodeSigningSecret(signingSecret: string): Buffer | null {

--- a/src/services/resend-webhook-verifier.ts
+++ b/src/services/resend-webhook-verifier.ts
@@ -1,0 +1,84 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const SIGNING_SECRET_PATTERN = /^whsec_([A-Za-z0-9+/]+={0,2})$/;
+const SIGNATURE_PATTERN = /^v1,([A-Za-z0-9+/]+={0,2})$/;
+const MAX_WEBHOOK_EVENT_ID_LENGTH = 256;
+const WEBHOOK_TOLERANCE_SECONDS = 5 * 60;
+
+function decodeCanonicalBase64(value: string): Buffer | null {
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value) || value.length % 4 === 1) {
+    return null;
+  }
+
+  const decoded = Buffer.from(value, "base64");
+  const canonical = decoded.toString("base64").replace(/=+$/u, "");
+  return canonical === value.replace(/=+$/u, "") ? decoded : null;
+}
+
+function decodeSigningSecret(signingSecret: string): Buffer | null {
+  const match = SIGNING_SECRET_PATTERN.exec(signingSecret);
+  if (!match) {
+    return null;
+  }
+
+  const decoded = decodeCanonicalBase64(match[1] ?? "");
+  return decoded && decoded.byteLength >= 16 ? decoded : null;
+}
+
+export function isValidResendWebhookSigningSecret(signingSecret: string): boolean {
+  return decodeSigningSecret(signingSecret) !== null;
+}
+
+export class ResendWebhookVerifier {
+  readonly #secret: Buffer;
+  readonly #clock: () => Date;
+
+  constructor(input: { signingSecret: string; clock?: () => Date }) {
+    const secret = decodeSigningSecret(input.signingSecret);
+    if (!secret) {
+      throw new Error("InvalidResendWebhookSigningSecret");
+    }
+
+    this.#secret = Buffer.from(secret);
+    this.#clock = input.clock ?? (() => new Date());
+  }
+
+  verify(input: { rawBody: string; messageId: string; timestamp: string; signature: string }): unknown {
+    if (!input.messageId || input.messageId.length > MAX_WEBHOOK_EVENT_ID_LENGTH) {
+      throw new Error("InvalidResendWebhookMessageId");
+    }
+    if (!/^\d{1,12}$/.test(input.timestamp)) {
+      throw new Error("InvalidResendWebhookTimestamp");
+    }
+
+    const timestampSeconds = Number(input.timestamp);
+    const nowSeconds = Math.floor(this.#clock().getTime() / 1_000);
+    if (
+      !Number.isSafeInteger(timestampSeconds) ||
+      !Number.isSafeInteger(nowSeconds) ||
+      Math.abs(nowSeconds - timestampSeconds) > WEBHOOK_TOLERANCE_SECONDS
+    ) {
+      throw new Error("InvalidResendWebhookTimestamp");
+    }
+
+    const signedContent = `${input.messageId}.${input.timestamp}.${input.rawBody}`;
+    const expected = createHmac("sha256", this.#secret).update(signedContent, "utf8").digest();
+    const valid = input.signature
+      .trim()
+      .split(/\s+/u)
+      .some((candidate) => {
+        const match = SIGNATURE_PATTERN.exec(candidate);
+        const actual = match ? decodeCanonicalBase64(match[1] ?? "") : null;
+        return actual !== null && actual.byteLength === expected.byteLength && timingSafeEqual(actual, expected);
+      });
+    if (!valid) {
+      throw new Error("InvalidResendWebhookSignature");
+    }
+
+    try {
+      return JSON.parse(input.rawBody) as unknown;
+    } catch {
+      throw new Error("InvalidResendWebhookPayload");
+    }
+  }
+}

--- a/src/types/optional-email.ts
+++ b/src/types/optional-email.ts
@@ -9,6 +9,10 @@ export enum OptionalEmailSuppressionReason {
   ProviderSuppressed = "provider_suppressed",
 }
 
+export enum OptionalEmailCategory {
+  SetupReminder = "optional_setup_reminder",
+}
+
 export enum OptionalEmailWebhookEventType {
   Bounced = "email.bounced",
   Complained = "email.complained",

--- a/src/types/optional-email.ts
+++ b/src/types/optional-email.ts
@@ -9,6 +9,23 @@ export enum OptionalEmailSuppressionReason {
   ProviderSuppressed = "provider_suppressed",
 }
 
+export enum OptionalEmailWebhookEventType {
+  Bounced = "email.bounced",
+  Complained = "email.complained",
+  Suppressed = "email.suppressed",
+}
+
+export enum OptionalEmailWebhookStatus {
+  Processed = "processed",
+  Replayed = "replayed",
+  Retry = "retry",
+}
+
+export enum OptionalEmailWebhookOutcome {
+  Suppressed = "suppressed",
+  Ignored = "ignored",
+}
+
 export enum OptionalEmailBlockReason {
   Unsubscribed = "unsubscribed",
   Suppressed = "suppressed",

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -367,6 +367,43 @@ function restoreEnv(name: string, value: string | undefined): void {
   process.env[name] = value;
 }
 
+describe("optional email safety ingress configuration", () => {
+  it("keeps both public safety routes absent unless their independent secrets are configured", () => {
+    const result = configSchema.safeParse(validEnv());
+
+    assert.equal(result.success, true);
+    if (!result.success) {
+      throw new Error("expected baseline config parse success");
+    }
+
+    const config = result.data as Record<string, unknown>;
+    assert.equal(config.RESEND_WEBHOOK_SECRET, undefined);
+    assert.equal(config.OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET, undefined);
+  });
+
+  it("accepts independently configured webhook and unsubscribe signing secrets", () => {
+    const webhook = configSchema.safeParse(validEnv({ RESEND_WEBHOOK_SECRET: "whsec_plJ3nmyCDGBKInavdOK15jsl" }));
+    const unsubscribe = configSchema.safeParse(validEnv({ OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET: "u".repeat(32) }));
+
+    assert.equal(webhook.success, true);
+    assert.equal(webhook.data?.RESEND_WEBHOOK_SECRET, "whsec_plJ3nmyCDGBKInavdOK15jsl");
+    assert.equal(unsubscribe.success, true);
+    assert.equal(unsubscribe.data?.OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET, "u".repeat(32));
+  });
+
+  it("rejects malformed webhook secrets and short unsubscribe secrets", () => {
+    for (const secret of ["not-a-svix-secret", "whsec_%%%", "whsec_YQ=="]) {
+      const result = configSchema.safeParse(validEnv({ RESEND_WEBHOOK_SECRET: secret }));
+      assert.equal(result.success, false, `${secret} must be rejected`);
+    }
+
+    const shortUnsubscribe = configSchema.safeParse(
+      validEnv({ OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET: "u".repeat(31) }),
+    );
+    assert.equal(shortUnsubscribe.success, false);
+  });
+});
+
 describe("configSchema", () => {
   it("accepts the baseline environment", () => {
     assert.equal(configSchema.safeParse(validEnv()).success, true);

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -43,6 +43,9 @@ import { MAX_BINARY_BYTES, MAX_TEXT_BYTES } from "../../src/routes/voice-realtim
 import { AppClientPresenceService } from "../../src/services/app-client-presence-service.js";
 import { ProductAnalyticsPreferenceService } from "../../src/services/product-analytics-preference-service.js";
 import { SettingsService } from "../../src/services/settings-service.js";
+import type { OptionalEmailUnsubscribeService } from "../../src/services/optional-email-unsubscribe-service.js";
+import type { OptionalEmailWebhookService } from "../../src/services/optional-email-webhook-service.js";
+import type { ResendWebhookVerifier } from "../../src/services/resend-webhook-verifier.js";
 import { loadConfig, type Config } from "../../src/config.js";
 import { ProductAnalyticsPreference } from "../../src/types/product-analytics.js";
 import { AsyncTranscriptionPublicErrorPolicy } from "../../src/types/transcription.js";
@@ -93,6 +96,13 @@ export type TestAppOverrides = {
   asyncTranscriptionClient?: AsyncTranscriptionClient;
   asyncTranscriptionPublicErrorPolicy?: AsyncTranscriptionPublicErrorPolicy;
   configOverrides?: Partial<Config>;
+  optionalEmail?: {
+    unsubscribeService?: OptionalEmailUnsubscribeService;
+    webhook?: {
+      verifier: ResendWebhookVerifier;
+      service: OptionalEmailWebhookService;
+    };
+  };
 };
 
 export type { OAuthClient };
@@ -259,6 +269,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
     appleNativeVerifier,
     pendingAuthStore,
     productAnalyticsPreferenceService,
+    optionalEmail: overrides?.optionalEmail,
     realtime:
       overrides?.realtimeService && effectiveConfig.REALTIME_TRANSCRIPTION_ENABLED
         ? {

--- a/tests/optional-email-composition.test.ts
+++ b/tests/optional-email-composition.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { createOptionalEmailRouteServices } from "../src/optional-email-composition.js";
+import { createTestApp, type TestContext } from "./helpers/setup.js";
+
+describe("optional email route composition", () => {
+  let ctx: TestContext;
+
+  before(async () => {
+    ctx = await createTestApp();
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("constructs only the safety routes backed by configured signing secrets", () => {
+    assert.equal(
+      createOptionalEmailRouteServices({
+        dbAccessor: ctx.dbAccessor,
+        unsubscribeSigningSecret: undefined,
+        webhookSigningSecret: undefined,
+      }),
+      undefined,
+    );
+
+    const unsubscribeOnly = createOptionalEmailRouteServices({
+      dbAccessor: ctx.dbAccessor,
+      unsubscribeSigningSecret: "u".repeat(32),
+      webhookSigningSecret: undefined,
+    });
+    assert.ok(unsubscribeOnly?.unsubscribeService);
+    assert.equal(unsubscribeOnly?.webhook, undefined);
+
+    const webhookOnly = createOptionalEmailRouteServices({
+      dbAccessor: ctx.dbAccessor,
+      unsubscribeSigningSecret: undefined,
+      webhookSigningSecret: `whsec_${Buffer.alloc(32, 7).toString("base64")}`,
+    });
+    assert.equal(webhookOnly?.unsubscribeService, undefined);
+    assert.ok(webhookOnly?.webhook?.verifier);
+    assert.ok(webhookOnly?.webhook?.service);
+  });
+});

--- a/tests/routes/optional-email-server-wiring.test.ts
+++ b/tests/routes/optional-email-server-wiring.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { OptionalEmailUnsubscribeService } from "../../src/services/optional-email-unsubscribe-service.js";
+import type { OptionalEmailWebhookService } from "../../src/services/optional-email-webhook-service.js";
+import type { ResendWebhookVerifier } from "../../src/services/resend-webhook-verifier.js";
+import { createTestApp } from "../helpers/setup.js";
+
+describe("optional email server wiring", () => {
+  it("registers the public unsubscribe route only when its service is configured", async () => {
+    const defaultContext = await createTestApp();
+    try {
+      const absent = await defaultContext.app.inject({
+        method: "GET",
+        url: "/email/optional/unsubscribe?token=signed-token",
+      });
+      assert.equal(absent.statusCode, 404);
+    } finally {
+      await defaultContext.cleanup();
+    }
+
+    const unsubscribeService = {
+      isValid: ({ token }: { token: string }) => token === "signed-token",
+      unsubscribe: async ({ token }: { token: string }) => token === "signed-token",
+    } as unknown as OptionalEmailUnsubscribeService;
+    const configuredContext = await createTestApp({
+      optionalEmail: { unsubscribeService },
+    });
+    try {
+      const available = await configuredContext.app.inject({
+        method: "GET",
+        url: "/email/optional/unsubscribe?token=signed-token",
+      });
+      assert.equal(available.statusCode, 200);
+      assert.match(available.body, /Security and essential account messages are not affected/);
+    } finally {
+      await configuredContext.cleanup();
+    }
+  });
+
+  it("registers the Resend webhook route only when its verifier and handler are configured", async () => {
+    const verifier = {
+      verify: () => ({ type: "email.sent", data: { email_id: "provider-id" } }),
+    } as unknown as ResendWebhookVerifier;
+    const service = {
+      handleVerified: async () => ({ status: "processed", outcome: "ignored" }),
+    } as unknown as OptionalEmailWebhookService;
+    const context = await createTestApp({
+      optionalEmail: { webhook: { verifier, service } },
+    });
+    try {
+      const response = await context.app.inject({
+        method: "POST",
+        url: "/webhooks/resend",
+        headers: {
+          "content-type": "application/json",
+          "svix-id": "msg_test",
+          "svix-timestamp": "1",
+          "svix-signature": "v1,test",
+        },
+        payload: '{"type":"email.sent"}',
+      });
+
+      assert.equal(response.statusCode, 204);
+    } finally {
+      await context.cleanup();
+    }
+  });
+});

--- a/tests/routes/optional-email-server-wiring.test.ts
+++ b/tests/routes/optional-email-server-wiring.test.ts
@@ -37,7 +37,17 @@ describe("optional email server wiring", () => {
     }
   });
 
-  it("registers the Resend webhook route only when its verifier and handler are configured", async () => {
+  it("leaves the Resend webhook route absent by default", async () => {
+    const context = await createTestApp();
+    try {
+      const response = await context.app.inject({ method: "POST", url: "/webhooks/resend" });
+      assert.equal(response.statusCode, 404);
+    } finally {
+      await context.cleanup();
+    }
+  });
+
+  it("exempts configured webhook callbacks from the global client-IP limiter", async () => {
     const verifier = {
       verify: () => ({ type: "email.sent", data: { email_id: "provider-id" } }),
     } as unknown as ResendWebhookVerifier;
@@ -48,19 +58,26 @@ describe("optional email server wiring", () => {
       optionalEmail: { webhook: { verifier, service } },
     });
     try {
-      const response = await context.app.inject({
-        method: "POST",
-        url: "/webhooks/resend",
-        headers: {
-          "content-type": "application/json",
-          "svix-id": "msg_test",
-          "svix-timestamp": "1",
-          "svix-signature": "v1,test",
-        },
-        payload: '{"type":"email.sent"}',
-      });
-
-      assert.equal(response.statusCode, 204);
+      const responses = await Promise.all(
+        Array.from({ length: 101 }, (_, index) =>
+          context.app.inject({
+            method: "POST",
+            url: "/webhooks/resend",
+            remoteAddress: "203.0.113.7",
+            headers: {
+              "content-type": "application/json",
+              "svix-id": `msg_test_${index}`,
+              "svix-timestamp": "1",
+              "svix-signature": "v1,test",
+            },
+            payload: '{"type":"email.sent"}',
+          }),
+        ),
+      );
+      assert.equal(
+        responses.every((response) => response.statusCode === 204),
+        true,
+      );
     } finally {
       await context.cleanup();
     }

--- a/tests/routes/optional-email-server-wiring.test.ts
+++ b/tests/routes/optional-email-server-wiring.test.ts
@@ -32,6 +32,22 @@ describe("optional email server wiring", () => {
       });
       assert.equal(available.statusCode, 200);
       assert.match(available.body, /Security and essential account messages are not affected/);
+
+      const oneClickResponses = await Promise.all(
+        Array.from({ length: 101 }, () =>
+          configuredContext.app.inject({
+            method: "POST",
+            url: "/email/optional/unsubscribe?token=signed-token",
+            remoteAddress: "203.0.113.8",
+            headers: { "content-type": "application/x-www-form-urlencoded" },
+            payload: "List-Unsubscribe=One-Click",
+          }),
+        ),
+      );
+      assert.equal(
+        oneClickResponses.every((response) => response.statusCode === 200),
+        true,
+      );
     } finally {
       await configuredContext.cleanup();
     }

--- a/tests/routes/optional-email-unsubscribe.test.ts
+++ b/tests/routes/optional-email-unsubscribe.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import Fastify, { type FastifyInstance } from "fastify";
+import { after, before, describe, it } from "node:test";
+import { OptionalEmailPreferenceRepository } from "../../src/repositories/optional-email-preference-repo.js";
+import { optionalEmailUnsubscribeRoutes } from "../../src/routes/optional-email-unsubscribe.js";
+import {
+  OptionalEmailUnsubscribeService,
+  OptionalEmailUnsubscribeTokenService,
+  buildOptionalEmailUnsubscribeHeaders,
+} from "../../src/services/optional-email-unsubscribe-service.js";
+import { OptionalEmailBlockReason } from "../../src/types/optional-email.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+const SECRET = Buffer.alloc(32, 7);
+const NOW = new Date("2026-09-06T12:00:00.000Z");
+
+describe("optional email unsubscribe token and headers", () => {
+  it("rejects weak signing secrets and malformed user ids", () => {
+    assert.throws(
+      () => new OptionalEmailUnsubscribeTokenService({ signingSecret: Buffer.alloc(31) }),
+      /OptionalEmailUnsubscribeSigningSecretTooShort/,
+    );
+    const tokens = new OptionalEmailUnsubscribeTokenService({ signingSecret: SECRET });
+    assert.throws(() => tokens.create({ userId: "not-an-object-id" }), /InvalidOptionalEmailUnsubscribeUserId/);
+  });
+
+  it("round-trips a signed persistent token and rejects tampering", () => {
+    const tokens = new OptionalEmailUnsubscribeTokenService({ signingSecret: SECRET });
+    const userId = "000000000000000000000001";
+
+    const token = tokens.create({ userId });
+
+    assert.equal(tokens.verify({ token }), userId);
+    const finalCharacter = token.endsWith("a") ? "b" : "a";
+    assert.equal(tokens.verify({ token: `${token.slice(0, -1)}${finalCharacter}` }), null);
+    assert.equal(tokens.verify({ token: "not-a-token" }), null);
+  });
+
+  it("builds the RFC 8058 one-click headers against the signed no-login URL", () => {
+    const tokens = new OptionalEmailUnsubscribeTokenService({ signingSecret: SECRET });
+    const token = tokens.create({ userId: "000000000000000000000001" });
+
+    const result = buildOptionalEmailUnsubscribeHeaders({
+      publicBaseUrl: "https://api.sesori.com",
+      token,
+    });
+
+    assert.deepEqual(result, {
+      "List-Unsubscribe": `<https://api.sesori.com/email/optional/unsubscribe?token=${encodeURIComponent(token)}>`,
+      "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+    });
+    assert.throws(
+      () => buildOptionalEmailUnsubscribeHeaders({ publicBaseUrl: "http://api.sesori.com", token }),
+      /InvalidOptionalEmailPublicBaseUrl/,
+    );
+  });
+});
+
+describe("optional email unsubscribe routes", () => {
+  let ctx: TestContext;
+  let preferenceRepo: OptionalEmailPreferenceRepository;
+  let tokens: OptionalEmailUnsubscribeTokenService;
+  let app: FastifyInstance;
+
+  before(async () => {
+    ctx = await createTestApp();
+    preferenceRepo = new OptionalEmailPreferenceRepository(ctx.dbAccessor);
+    tokens = new OptionalEmailUnsubscribeTokenService({ signingSecret: SECRET });
+    const service = new OptionalEmailUnsubscribeService({
+      preferenceRepo,
+      tokenService: tokens,
+      clock: () => NOW,
+    });
+    app = Fastify();
+    await app.register(optionalEmailUnsubscribeRoutes, { service });
+    await app.ready();
+  });
+
+  after(async () => {
+    await app.close();
+    await ctx.cleanup();
+  });
+
+  it("shows a confirmation form on GET without changing preference state", async () => {
+    const user = await ctx.createUser();
+    const token = tokens.create({ userId: user.userId });
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/email/optional/unsubscribe?token=${encodeURIComponent(token)}`,
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.match(response.headers["content-type"] ?? "", /^text\/html/);
+    assert.equal(response.headers["cache-control"], "no-store");
+    assert.equal(response.headers["referrer-policy"], "no-referrer");
+    assert.match(response.headers["content-security-policy"] ?? "", /form-action 'self'/);
+    assert.match(response.body, /Unsubscribe from optional Sesori setup reminders/);
+    assert.match(response.body, /method="post"/);
+    assert.equal(await preferenceRepo.findBlockReason({ userId: user.userId }), null);
+  });
+
+  it("accepts an unauthenticated RFC 8058 POST and remains idempotent on replay", async () => {
+    const user = await ctx.createUser();
+    const token = tokens.create({ userId: user.userId });
+    const request = {
+      method: "POST" as const,
+      url: `/email/optional/unsubscribe?token=${encodeURIComponent(token)}`,
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      payload: "List-Unsubscribe=One-Click",
+    };
+
+    const first = await app.inject(request);
+    const replay = await app.inject(request);
+
+    assert.equal(first.statusCode, 200);
+    assert.equal(first.body, "");
+    assert.equal(first.headers["cache-control"], "no-store");
+    assert.equal(replay.statusCode, 200);
+    assert.equal(await preferenceRepo.findBlockReason({ userId: user.userId }), OptionalEmailBlockReason.Unsubscribed);
+    assert.equal(
+      (await preferenceRepo.findByUserId({ userId: user.userId }))?.unsubscribedAt?.toISOString(),
+      NOW.toISOString(),
+    );
+  });
+
+  it("rejects a tampered token and malformed one-click body without writing", async () => {
+    const user = await ctx.createUser();
+    const token = tokens.create({ userId: user.userId });
+    const tampered = `${token.slice(0, -1)}${token.endsWith("a") ? "b" : "a"}`;
+
+    const badToken = await app.inject({
+      method: "POST",
+      url: `/email/optional/unsubscribe?token=${encodeURIComponent(tampered)}`,
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      payload: "List-Unsubscribe=One-Click",
+    });
+    const badBody = await app.inject({
+      method: "POST",
+      url: `/email/optional/unsubscribe?token=${encodeURIComponent(token)}`,
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      payload: "List-Unsubscribe=No",
+    });
+    const extraField = await app.inject({
+      method: "POST",
+      url: `/email/optional/unsubscribe?token=${encodeURIComponent(token)}`,
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      payload: "List-Unsubscribe=One-Click&confirm=yes",
+    });
+    const duplicateField = await app.inject({
+      method: "POST",
+      url: `/email/optional/unsubscribe?token=${encodeURIComponent(token)}`,
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      payload: "List-Unsubscribe=One-Click&List-Unsubscribe=One-Click",
+    });
+
+    assert.equal(badToken.statusCode, 400);
+    assert.equal(badBody.statusCode, 400);
+    assert.equal(extraField.statusCode, 400);
+    assert.equal(duplicateField.statusCode, 400);
+    assert.equal(await preferenceRepo.findByUserId({ userId: user.userId }), null);
+  });
+});

--- a/tests/routes/optional-email-unsubscribe.test.ts
+++ b/tests/routes/optional-email-unsubscribe.test.ts
@@ -14,6 +14,13 @@ import { createTestApp, type TestContext } from "../helpers/setup.js";
 const SECRET = Buffer.alloc(32, 7);
 const NOW = new Date("2026-09-06T12:00:00.000Z");
 
+function nonCanonicalSignatureAlias(token: string): string {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  const canonicalIndex = alphabet.indexOf(token.at(-1) ?? "");
+  assert.equal(canonicalIndex % 4, 0);
+  return `${token.slice(0, -1)}${alphabet[canonicalIndex + 1]}`;
+}
+
 describe("optional email unsubscribe token and headers", () => {
   it("rejects weak signing secrets and malformed user ids", () => {
     assert.throws(
@@ -127,7 +134,7 @@ describe("optional email unsubscribe routes", () => {
   it("rejects a tampered token and malformed one-click body without writing", async () => {
     const user = await ctx.createUser();
     const token = tokens.create({ userId: user.userId });
-    const tampered = `${token.slice(0, -1)}${token.endsWith("a") ? "b" : "a"}`;
+    const tampered = nonCanonicalSignatureAlias(token);
 
     const badToken = await app.inject({
       method: "POST",

--- a/tests/routes/optional-email-webhook.test.ts
+++ b/tests/routes/optional-email-webhook.test.ts
@@ -1,0 +1,141 @@
+import { createHmac } from "node:crypto";
+import assert from "node:assert/strict";
+import Fastify, { type FastifyInstance } from "fastify";
+import { after, before, describe, it } from "node:test";
+import { OptionalEmailPreferenceRepository } from "../../src/repositories/optional-email-preference-repo.js";
+import { OptionalEmailWebhookEventRepository } from "../../src/repositories/optional-email-webhook-event-repo.js";
+import { optionalEmailWebhookRoutes } from "../../src/routes/optional-email-webhook.js";
+import { OptionalEmailWebhookService } from "../../src/services/optional-email-webhook-service.js";
+import { ResendWebhookVerifier } from "../../src/services/resend-webhook-verifier.js";
+import { OptionalEmailBlockReason } from "../../src/types/optional-email.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+const NOW = new Date("2026-09-06T12:00:00.000Z");
+const SECRET_BYTES = Buffer.alloc(32, 3);
+const SIGNING_SECRET = `whsec_${SECRET_BYTES.toString("base64")}`;
+
+function signatureFor(input: { rawBody: string; messageId: string; timestamp: string }): string {
+  const value = createHmac("sha256", SECRET_BYTES)
+    .update(`${input.messageId}.${input.timestamp}.${input.rawBody}`, "utf8")
+    .digest("base64");
+  return `v1,${value}`;
+}
+
+function injectSigned(input: { app: FastifyInstance; rawBody: string; messageId: string; signature?: string }) {
+  const timestamp = String(Math.floor(NOW.getTime() / 1_000));
+  return input.app.inject({
+    method: "POST",
+    url: "/webhooks/resend",
+    headers: {
+      "content-type": "application/json",
+      "svix-id": input.messageId,
+      "svix-timestamp": timestamp,
+      "svix-signature": input.signature ?? signatureFor({ ...input, timestamp }),
+    },
+    payload: input.rawBody,
+  });
+}
+
+describe("POST /webhooks/resend", () => {
+  let ctx: TestContext;
+  let app: FastifyInstance;
+  let userId: string;
+
+  before(async () => {
+    ctx = await createTestApp();
+    userId = (await ctx.createUser()).userId;
+    const service = new OptionalEmailWebhookService({
+      eventRepo: new OptionalEmailWebhookEventRepository(ctx.dbAccessor),
+      preferenceRepo: new OptionalEmailPreferenceRepository(ctx.dbAccessor),
+      sendHistory: { findUserIdByProviderEmailId: async () => userId },
+      clock: () => NOW,
+    });
+    app = Fastify();
+    await app.register(optionalEmailWebhookRoutes, {
+      service,
+      verifier: new ResendWebhookVerifier({ signingSecret: SIGNING_SECRET, clock: () => NOW }),
+    });
+    await app.ready();
+  });
+
+  after(async () => {
+    await app.close();
+    await ctx.cleanup();
+  });
+
+  it("verifies the raw request before suppressing and rejects a modified signature", async () => {
+    const rawBody = JSON.stringify({
+      type: "email.complained",
+      data: {
+        email_id: "resend-route-complaint-1",
+        tags: { category: "optional_setup_reminder" },
+      },
+    });
+    const messageId = "msg_route_complaint_1";
+    const valid = await injectSigned({ app, rawBody, messageId });
+    const invalid = await injectSigned({
+      app,
+      rawBody,
+      messageId,
+      signature: "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+    });
+
+    assert.equal(valid.statusCode, 204);
+    assert.equal(invalid.statusCode, 400);
+    assert.equal(
+      await new OptionalEmailPreferenceRepository(ctx.dbAccessor).findBlockReason({ userId }),
+      OptionalEmailBlockReason.Suppressed,
+    );
+  });
+
+  it("returns a retryable response when optional send history is not yet correlated", async () => {
+    const retryApp = Fastify();
+    await retryApp.register(optionalEmailWebhookRoutes, {
+      service: new OptionalEmailWebhookService({
+        eventRepo: new OptionalEmailWebhookEventRepository(ctx.dbAccessor),
+        preferenceRepo: new OptionalEmailPreferenceRepository(ctx.dbAccessor),
+        sendHistory: { findUserIdByProviderEmailId: async () => null },
+        clock: () => NOW,
+      }),
+      verifier: new ResendWebhookVerifier({ signingSecret: SIGNING_SECRET, clock: () => NOW }),
+    });
+    await retryApp.ready();
+    const rawBody = JSON.stringify({
+      type: "email.complained",
+      data: {
+        email_id: "resend-route-not-correlated-yet",
+        tags: { category: "optional_setup_reminder" },
+      },
+    });
+    const messageId = "msg_route_not_correlated_1";
+
+    try {
+      const response = await injectSigned({ app: retryApp, rawBody, messageId });
+
+      assert.equal(response.statusCode, 503);
+      assert.equal(response.headers["retry-after"], "60");
+    } finally {
+      await retryApp.close();
+    }
+  });
+
+  it("rejects a malformed verified event without consuming its replay id", async () => {
+    const rawBody = JSON.stringify({ type: "email.complained", data: {} });
+    const messageId = "msg_route_malformed_1";
+    const response = await injectSigned({ app, rawBody, messageId });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(
+      await new OptionalEmailWebhookEventRepository(ctx.dbAccessor).wasProcessed({ eventId: messageId }),
+      false,
+    );
+  });
+
+  it("rejects a raw body above the ingress limit before handling it", async () => {
+    const rawBody = JSON.stringify({ value: "x".repeat(256 * 1_024) });
+    const messageId = "msg_route_oversized_1";
+    const response = await injectSigned({ app, rawBody, messageId });
+
+    assert.equal(response.statusCode, 413);
+  });
+});

--- a/tests/routes/optional-email-webhook.test.ts
+++ b/tests/routes/optional-email-webhook.test.ts
@@ -124,15 +124,23 @@ describe("POST /webhooks/resend", () => {
   });
 
   it("rejects a malformed verified event without consuming its replay id", async () => {
-    const rawBody = JSON.stringify({ type: "email.complained", data: {} });
-    const messageId = "msg_route_malformed_1";
-    const response = await injectSigned({ app, rawBody, messageId });
+    for (const [messageId, rawBody] of [
+      ["msg_route_malformed_1", JSON.stringify({ type: "email.complained", data: {} })],
+      [
+        "msg_route_conflicting_alias_1",
+        JSON.stringify({ type: "email.sent", event_type: "email.complained", data: {} }),
+      ],
+    ]) {
+      const response = await injectSigned({ app, rawBody, messageId });
 
-    assert.equal(response.statusCode, 400);
-    assert.equal(
-      await new OptionalEmailWebhookEventRepository(ctx.dbAccessor).wasProcessed({ eventId: messageId }),
-      false,
-    );
+      assert.equal(response.statusCode, 400);
+      assert.equal(
+        await new OptionalEmailWebhookEventRepository(ctx.dbAccessor).wasProcessed({
+          eventId: messageId,
+        }),
+        false,
+      );
+    }
   });
 
   it("acknowledges and records a signed Svix ping control event as ignored", async () => {

--- a/tests/routes/optional-email-webhook.test.ts
+++ b/tests/routes/optional-email-webhook.test.ts
@@ -114,6 +114,10 @@ describe("POST /webhooks/resend", () => {
 
       assert.equal(response.statusCode, 503);
       assert.equal(response.headers["retry-after"], "60");
+      assert.equal(
+        await new OptionalEmailWebhookEventRepository(ctx.dbAccessor).wasProcessed({ eventId: messageId }),
+        false,
+      );
     } finally {
       await retryApp.close();
     }
@@ -128,6 +132,18 @@ describe("POST /webhooks/resend", () => {
     assert.equal(
       await new OptionalEmailWebhookEventRepository(ctx.dbAccessor).wasProcessed({ eventId: messageId }),
       false,
+    );
+  });
+
+  it("acknowledges and records a signed Svix ping control event as ignored", async () => {
+    const rawBody = JSON.stringify({ event_type: "ping", data: { success: true } });
+    const messageId = "msg_route_ping_1";
+    const response = await injectSigned({ app, rawBody, messageId });
+
+    assert.equal(response.statusCode, 204);
+    assert.equal(
+      await new OptionalEmailWebhookEventRepository(ctx.dbAccessor).wasProcessed({ eventId: messageId }),
+      true,
     );
   });
 

--- a/tests/services/optional-email-webhook-service.test.ts
+++ b/tests/services/optional-email-webhook-service.test.ts
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { OptionalEmailPreferenceRepository } from "../../src/repositories/optional-email-preference-repo.js";
+import { OptionalEmailWebhookEventRepository } from "../../src/repositories/optional-email-webhook-event-repo.js";
+import { OptionalEmailWebhookService } from "../../src/services/optional-email-webhook-service.js";
+import {
+  OptionalEmailBlockReason,
+  OptionalEmailSuppressionReason,
+  OptionalEmailWebhookOutcome,
+  OptionalEmailWebhookStatus,
+} from "../../src/types/optional-email.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+const NOW = new Date("2026-09-06T12:00:00.000Z");
+
+describe("OptionalEmailWebhookService", () => {
+  let ctx: TestContext;
+  let preferenceRepo: OptionalEmailPreferenceRepository;
+  let eventRepo: OptionalEmailWebhookEventRepository;
+
+  before(async () => {
+    ctx = await createTestApp();
+    preferenceRepo = new OptionalEmailPreferenceRepository(ctx.dbAccessor);
+    eventRepo = new OptionalEmailWebhookEventRepository(ctx.dbAccessor);
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("maps permanent provider outcomes to durable optional-mail suppression and replay", async () => {
+    for (const testCase of [
+      {
+        suffix: "hard_bounce",
+        type: "email.bounced",
+        bounce: { type: "Permanent", subType: "General" },
+        reason: OptionalEmailSuppressionReason.HardBounce,
+      },
+      { suffix: "complaint", type: "email.complained", reason: OptionalEmailSuppressionReason.Complaint },
+      {
+        suffix: "provider_suppressed",
+        type: "email.suppressed",
+        reason: OptionalEmailSuppressionReason.ProviderSuppressed,
+      },
+    ]) {
+      const user = await ctx.createUser();
+      let lookups = 0;
+      const service = new OptionalEmailWebhookService({
+        eventRepo,
+        preferenceRepo,
+        sendHistory: {
+          findUserIdByProviderEmailId: async () => {
+            lookups += 1;
+            return user.userId;
+          },
+        },
+        clock: () => NOW,
+      });
+      const input = {
+        eventId: `msg_optional_${testCase.suffix}`,
+        event: {
+          type: testCase.type,
+          data: {
+            email_id: `resend-email-${testCase.suffix}`,
+            ...(testCase.bounce ? { bounce: testCase.bounce } : {}),
+            tags: { category: "optional_setup_reminder" },
+          },
+        },
+      };
+
+      assert.deepEqual(await service.handleVerified(input), {
+        status: OptionalEmailWebhookStatus.Processed,
+        outcome: OptionalEmailWebhookOutcome.Suppressed,
+      });
+      assert.deepEqual(await service.handleVerified(input), { status: OptionalEmailWebhookStatus.Replayed });
+      assert.equal(lookups, 1);
+      assert.equal((await preferenceRepo.findByUserId({ userId: user.userId }))?.suppressionReason, testCase.reason);
+    }
+  });
+
+  it("leaves an unmatched optional-mail event retryable without recording it as processed", async () => {
+    const service = new OptionalEmailWebhookService({
+      eventRepo,
+      preferenceRepo,
+      sendHistory: { findUserIdByProviderEmailId: async () => null },
+      clock: () => NOW,
+    });
+
+    const result = await service.handleVerified({
+      eventId: "msg_optional_unmatched_1",
+      event: {
+        type: "email.complained",
+        data: {
+          email_id: "resend-email-not-recorded-yet",
+          tags: { category: "optional_setup_reminder" },
+        },
+      },
+    });
+
+    assert.deepEqual(result, { status: OptionalEmailWebhookStatus.Retry });
+    assert.equal(await eventRepo.wasProcessed({ eventId: "msg_optional_unmatched_1" }), false);
+  });
+
+  it("records unrelated and non-permanent events as ignored without looking up a user", async () => {
+    let lookups = 0;
+    const service = new OptionalEmailWebhookService({
+      eventRepo,
+      preferenceRepo,
+      sendHistory: {
+        findUserIdByProviderEmailId: async () => {
+          lookups += 1;
+          return null;
+        },
+      },
+      clock: () => NOW,
+    });
+
+    for (const input of [
+      {
+        eventId: "msg_unrelated_delivered_1",
+        event: { type: "email.delivered", data: { email_id: "other-email", tags: { category: "account_security" } } },
+      },
+      {
+        eventId: "msg_optional_transient_bounce_1",
+        event: {
+          type: "email.bounced",
+          data: {
+            email_id: "temporary-bounce",
+            bounce: { type: "Transient" },
+            tags: { category: "optional_setup_reminder" },
+          },
+        },
+      },
+    ]) {
+      assert.deepEqual(await service.handleVerified(input), {
+        status: OptionalEmailWebhookStatus.Processed,
+        outcome: OptionalEmailWebhookOutcome.Ignored,
+      });
+    }
+    assert.equal(lookups, 0);
+  });
+
+  it("bounds concurrent replay races to repeated idempotent suppression writes", async () => {
+    const user = await ctx.createUser();
+    let lookups = 0;
+    let releaseLookups: (() => void) | undefined;
+    const bothLookupsStarted = new Promise<void>((resolve) => {
+      releaseLookups = resolve;
+    });
+    const service = new OptionalEmailWebhookService({
+      eventRepo,
+      preferenceRepo,
+      sendHistory: {
+        findUserIdByProviderEmailId: async () => {
+          lookups += 1;
+          if (lookups === 2) {
+            releaseLookups?.();
+          }
+          await bothLookupsStarted;
+          return user.userId;
+        },
+      },
+      clock: () => NOW,
+    });
+    const input = {
+      eventId: "msg_concurrent_complaint_1",
+      event: {
+        type: "email.complained",
+        data: {
+          email_id: "resend-email-concurrent-1",
+          tags: { category: "optional_setup_reminder" },
+        },
+      },
+    };
+
+    const results = await Promise.all([service.handleVerified(input), service.handleVerified(input)]);
+
+    assert.equal(lookups, 2);
+    assert.deepEqual(
+      results.map((result) => result.status).sort(),
+      [OptionalEmailWebhookStatus.Processed, OptionalEmailWebhookStatus.Replayed].sort(),
+    );
+    assert.equal(await preferenceRepo.findBlockReason({ userId: user.userId }), OptionalEmailBlockReason.Suppressed);
+  });
+});

--- a/tests/services/resend-webhook-verifier.test.ts
+++ b/tests/services/resend-webhook-verifier.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { createHmac } from "node:crypto";
 import { describe, it } from "node:test";
-import { ResendWebhookVerifier } from "../../src/services/resend-webhook-verifier.js";
+import {
+  isValidResendWebhookSigningSecret,
+  ResendWebhookVerifier,
+} from "../../src/services/resend-webhook-verifier.js";
 
 const DOCUMENTED_SECRET = "whsec_plJ3nmyCDGBKInavdOK15jsl";
 const DOCUMENTED_PAYLOAD = '{"event_type":"ping","data":{"success":true}}';
@@ -17,6 +20,13 @@ function signatureFor(rawBody: string): string {
 }
 
 describe("ResendWebhookVerifier", () => {
+  it("rejects partial base64 padding while accepting canonical padded or unpadded secrets", () => {
+    const padded = Buffer.alloc(16, 9).toString("base64");
+    assert.equal(isValidResendWebhookSigningSecret(`whsec_${padded}`), true);
+    assert.equal(isValidResendWebhookSigningSecret(`whsec_${padded.replace(/=+$/u, "")}`), true);
+    assert.equal(isValidResendWebhookSigningSecret(`whsec_${padded.slice(0, -1)}`), false);
+  });
+
   it("accepts the published vector at the time boundary and rejects a modified raw body", () => {
     const verifier = new ResendWebhookVerifier({
       signingSecret: DOCUMENTED_SECRET,

--- a/tests/services/resend-webhook-verifier.test.ts
+++ b/tests/services/resend-webhook-verifier.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { describe, it } from "node:test";
+import { ResendWebhookVerifier } from "../../src/services/resend-webhook-verifier.js";
+
+const DOCUMENTED_SECRET = "whsec_plJ3nmyCDGBKInavdOK15jsl";
+const DOCUMENTED_PAYLOAD = '{"event_type":"ping","data":{"success":true}}';
+const DOCUMENTED_MESSAGE_ID = "msg_loFOjxBNrRLzqYUf";
+const DOCUMENTED_TIMESTAMP = "1731705121";
+const DOCUMENTED_SIGNATURE = "v1,rAvfW3dJ/X/qxhsaXPOyyCGmRKsaKWcsNccKXlIktD0=";
+
+function signatureFor(rawBody: string): string {
+  const secret = Buffer.from(DOCUMENTED_SECRET.slice("whsec_".length), "base64");
+  return `v1,${createHmac("sha256", secret)
+    .update(`${DOCUMENTED_MESSAGE_ID}.${DOCUMENTED_TIMESTAMP}.${rawBody}`, "utf8")
+    .digest("base64")}`;
+}
+
+describe("ResendWebhookVerifier", () => {
+  it("accepts the published vector at the time boundary and rejects a modified raw body", () => {
+    const verifier = new ResendWebhookVerifier({
+      signingSecret: DOCUMENTED_SECRET,
+      clock: () => new Date((Number(DOCUMENTED_TIMESTAMP) + 300) * 1_000),
+    });
+
+    assert.deepEqual(
+      verifier.verify({
+        rawBody: DOCUMENTED_PAYLOAD,
+        messageId: DOCUMENTED_MESSAGE_ID,
+        timestamp: DOCUMENTED_TIMESTAMP,
+        signature: `v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= ${DOCUMENTED_SIGNATURE}`,
+      }),
+      { event_type: "ping", data: { success: true } },
+    );
+    assert.throws(
+      () =>
+        verifier.verify({
+          rawBody: `${DOCUMENTED_PAYLOAD} `,
+          messageId: DOCUMENTED_MESSAGE_ID,
+          timestamp: DOCUMENTED_TIMESTAMP,
+          signature: DOCUMENTED_SIGNATURE,
+        }),
+      /InvalidResendWebhookSignature/,
+    );
+  });
+
+  it("rejects otherwise-valid signatures outside the five-minute timestamp window", () => {
+    const oldVerifier = new ResendWebhookVerifier({
+      signingSecret: DOCUMENTED_SECRET,
+      clock: () => new Date((Number(DOCUMENTED_TIMESTAMP) + 301) * 1_000),
+    });
+    const futureVerifier = new ResendWebhookVerifier({
+      signingSecret: DOCUMENTED_SECRET,
+      clock: () => new Date((Number(DOCUMENTED_TIMESTAMP) - 301) * 1_000),
+    });
+    const input = {
+      rawBody: DOCUMENTED_PAYLOAD,
+      messageId: DOCUMENTED_MESSAGE_ID,
+      timestamp: DOCUMENTED_TIMESTAMP,
+      signature: DOCUMENTED_SIGNATURE,
+    };
+
+    assert.throws(() => oldVerifier.verify(input), /InvalidResendWebhookTimestamp/);
+    assert.throws(() => futureVerifier.verify(input), /InvalidResendWebhookTimestamp/);
+  });
+
+  it("fails closed on malformed secrets, event ids, timestamps, signatures, and JSON", () => {
+    for (const signingSecret of ["not-a-secret", "whsec_%%%", "whsec_YQ=="]) {
+      assert.throws(() => new ResendWebhookVerifier({ signingSecret }), /InvalidResendWebhookSigningSecret/);
+    }
+
+    const verifier = new ResendWebhookVerifier({
+      signingSecret: DOCUMENTED_SECRET,
+      clock: () => new Date(Number(DOCUMENTED_TIMESTAMP) * 1_000),
+    });
+    const validInput = {
+      rawBody: DOCUMENTED_PAYLOAD,
+      messageId: DOCUMENTED_MESSAGE_ID,
+      timestamp: DOCUMENTED_TIMESTAMP,
+      signature: DOCUMENTED_SIGNATURE,
+    };
+
+    assert.throws(
+      () => verifier.verify({ ...validInput, messageId: "m".repeat(257) }),
+      /InvalidResendWebhookMessageId/,
+    );
+    assert.throws(() => verifier.verify({ ...validInput, timestamp: "1.5" }), /InvalidResendWebhookTimestamp/);
+    assert.throws(() => verifier.verify({ ...validInput, signature: "v1,%%%" }), /InvalidResendWebhookSignature/);
+    assert.throws(
+      () => verifier.verify({ ...validInput, rawBody: "{", signature: signatureFor("{") }),
+      /InvalidResendWebhookPayload/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a signed, no-login unsubscribe confirmation page and exact RFC 8058 one-click POST that durably updates product-owned optional-mail preferences
- add strict Svix-compatible raw-body verification with canonical secret/signature decoding and a five-minute replay window
- add durable webhook replay persistence plus complaint, permanent-bounce, and provider-suppression handling correlated through optional-email send history
- accept signed Svix control envelopes as durably ignored while rejecting conflicting `type`/`event_type` aliases
- return a retryable `503` when a valid suppression event arrives before its optional send-history correlation is visible
- register each public safety route only when its independent signing secret is explicitly configured

This is slice 2 of the sequential replacement for closed draft #85. It is based on the current remote `master` after merged data-layer PR #86 and preserves the review-hardened repository contracts from that merge.

## Series plan

This is **slice 2 of 5**. Base: `master` at `02761c9`, which includes #86 merge commit `f601af3`.

1. **Dormant optional-email data layer:** #86 — merged.
2. **This PR — unsubscribe and webhook safety ingress:** 1,472 additions, 0 deletions.
3. **Fail-closed eligibility and aggregate dry run:** waits for this PR to merge and must be recounted against its actual base.
4. **Guarded Resend delivery core:** waits for slice 3.
5. **Single-recipient test operator path and runbook:** waits for slice 4.

No later series branch or PR has been pushed/opened. The full saved plan and production blockers are in:

`/Users/alexandrudochioiu/sesori-ai/sesori-distribution/Research/Resend Integration Readiness.md`

## Runtime and safety behavior

- both ingress routes are absent by default and appear only when their independent signing secrets are explicitly configured
- the unsubscribe GET only confirms intent; mutation requires the signed token plus the exact `List-Unsubscribe=One-Click` form POST
- unsubscribe tokens are persistent, purpose-bound, user-bound, HMAC-signed, canonical-encoded, and carry no address
- unsubscribe responses are non-cacheable and use a no-referrer policy; generated email headers require an HTTPS public base URL
- the signed one-click POST is exempt from the shared client-IP limiter so mailbox-provider egress cannot block removals; GET confirmation remains limited
- webhook signatures cover the exact raw UTF-8 JSON body, event ID, and timestamp; malformed, stale, future-stale, oversized, or conflicting-alias requests fail closed
- the HMAC-authenticated, 256 KiB-bounded webhook route is exempt from the shared client-IP limiter so callback bursts do not delay suppression
- only optional setup-reminder events can mutate optional-mail state; essential/security mail remains separate
- complaint, permanent-bounce, and provider-suppression events set durable product-owned suppression state
- valid suppression events without visible send correlation return `503` with `Retry-After` and are not recorded as processed
- the replay collection/index from #86 makes completed event IDs durable
- concurrent copies may repeat the idempotent suppression write before one replay insert wins; this bounded race is covered by a test and remains documented
- a suppression may commit before its event record; a retry repeats the idempotent write if event persistence fails
- no Resend API key, sender config, delivery adapter, eligibility/dry-run path, operator-send CLI, campaign, or scheduler exists in this slice
- no actual email, credential, production database, deployment, DNS, or provider-account operation was used

## Verification

Node `v22.23.2`:

- `git diff --check` — passed
- focused ingress/config files — 57/57 passed, including 26 new slice test cases
- `npm test` — 980 total, 979 passed, one pre-existing skip, zero failed
- `npm run build` — passed
- `npm run lint` — passed
- `npm run format:check` — passed
- `npm run circular-dependencies` — passed; no circular dependency
- staged credential/conflict/forbidden-scope scans — clean
- diff — 19 files, 1,472 additions, 0 deletions; 28 lines below the 1,500-line soft cap

## Review state

Final head: `550e9ca2324027f25278106c1822a364aa9f2b30`.

- `cla`: passed
- `test`: passed
- `docker`: passed on retry attempt 2; attempt 1 failed before reading repository layers when Docker Hub returned HTTP 500 for the pinned Node base image
- optional `[code]smith`: skipped
- Cubic: approved with 0 issues on the final head
- Codex: completed on the final head with no new inline finding
- GitHub review decision: approved
- all CI/checks are terminal; all issue comments, reviews, and inline findings were inspected
- GraphQL review-thread readback: 11 total, 0 unresolved

The initial CI and review rounds produced substantive security/correctness fixes for canonical unsubscribe signatures, Zod form validation, event alias conflicts, provider-shared rate limits, signed control events, exact webhook-secret padding, retry replay semantics, and default-off wiring. Every valid finding was fixed with tests and answered. One duplicate-key Cubic finding was inspected and rejected with existing test and runtime evidence.

No merge authorization is given. Stop for founder review and merge before slice 3.
