### PR TITLE
feat(optional-email): add provider-neutral recipient resolver

### DIFF
--- a/src/repositories/optional-email-recipient-repo.ts
+++ b/src/repositories/optional-email-recipient-repo.ts
@@ -1,0 +1,126 @@
+import { Collection, ObjectId } from "mongodb";
+import { z } from "zod";
+import type { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import type { OAuthAccount, PasswordAccount } from "../models/documents.js";
+import { AUTH_PROVIDER_EMAIL, OAuthProviderName } from "../types/oauth.js";
+import {
+  OptionalEmailRecipientAccountKind,
+  OptionalEmailRecipientField,
+  type OptionalEmailRecipientResolution,
+  OptionalEmailRecipientResolutionStatus,
+} from "../types/optional-email.js";
+import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
+
+const normalizedEmailSchema = z
+  .string()
+  .trim()
+  .email()
+  .transform((value) => value.toLowerCase());
+
+/**
+ * Resolves only persisted identity fields linked to one user. `Resolved` means
+ * syntactically valid and unambiguous within that user; it does not establish
+ * verification, deliverability, permission, eligibility, or cross-user
+ * uniqueness.
+ */
+export class OptionalEmailRecipientRepository {
+  readonly #oauthAccounts: Collection<OAuthAccount>;
+  readonly #passwordAccounts: Collection<PasswordAccount>;
+
+  constructor(accessor: MongoDbAccessor) {
+    this.#oauthAccounts = accessor.getCollection<OAuthAccount>(MongoDbDatabase.Auth, AuthDbCollection.OAuthAccounts);
+    this.#passwordAccounts = accessor.getCollection<PasswordAccount>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.PasswordAccounts,
+    );
+  }
+
+  async resolve(input: { userId: string }): Promise<OptionalEmailRecipientResolution> {
+    if (!ObjectId.isValid(input.userId)) {
+      return { status: OptionalEmailRecipientResolutionStatus.Missing };
+    }
+
+    const userId = new ObjectId(input.userId);
+    const [oauthAccounts, passwordAccounts] = await Promise.all([
+      this.#oauthAccounts.find({ userId }, { projection: { provider: 1, providerUsername: 1, email: 1 } }).toArray(),
+      this.#passwordAccounts.find({ userId }, { projection: { email: 1 } }).toArray(),
+    ]);
+    if (oauthAccounts.some((account) => typeof account.provider !== "string")) {
+      return { status: OptionalEmailRecipientResolutionStatus.Ambiguous };
+    }
+
+    const candidates = [
+      ...oauthAccounts.flatMap((account) => {
+        const accountCandidates = [];
+        if (account.email !== null && account.email !== undefined) {
+          accountCandidates.push({
+            value: account.email,
+            provenance: {
+              accountKind: OptionalEmailRecipientAccountKind.OAuth,
+              provider: account.provider,
+              field: OptionalEmailRecipientField.Email,
+            },
+          });
+        }
+
+        // Both released Apple auth paths map the authenticated token's email
+        // claim into providerUsername, and upsert retains it when later tokens
+        // omit email. No other providerUsername field has an address-bearing
+        // contract.
+        if (
+          account.provider === OAuthProviderName.Apple &&
+          account.providerUsername !== null &&
+          account.providerUsername !== undefined
+        ) {
+          accountCandidates.push({
+            value: account.providerUsername,
+            provenance: {
+              accountKind: OptionalEmailRecipientAccountKind.OAuth,
+              provider: account.provider,
+              field: OptionalEmailRecipientField.LegacyAppleProviderUsername,
+            },
+          });
+        }
+
+        return accountCandidates;
+      }),
+      ...passwordAccounts.map((account) => ({
+        value: account.email,
+        provenance: {
+          accountKind: OptionalEmailRecipientAccountKind.Password,
+          provider: AUTH_PROVIDER_EMAIL,
+          field: OptionalEmailRecipientField.Email,
+        },
+      })),
+    ];
+    if (candidates.length === 0) {
+      return { status: OptionalEmailRecipientResolutionStatus.Missing };
+    }
+
+    const parsed = candidates.map((candidate) => ({
+      result: normalizedEmailSchema.safeParse(candidate.value),
+      provenance: candidate.provenance,
+    }));
+    if (parsed.some((candidate) => !candidate.result.success)) {
+      return { status: OptionalEmailRecipientResolutionStatus.Ambiguous };
+    }
+
+    const addresses = new Set(parsed.map((candidate) => (candidate.result.success ? candidate.result.data : "")));
+    if (addresses.size !== 1) {
+      return { status: OptionalEmailRecipientResolutionStatus.Ambiguous };
+    }
+
+    return {
+      status: OptionalEmailRecipientResolutionStatus.Resolved,
+      address: [...addresses][0] as string,
+      provenance: parsed
+        .map((candidate) => candidate.provenance)
+        .sort(
+          (left, right) =>
+            left.accountKind.localeCompare(right.accountKind) ||
+            left.provider.localeCompare(right.provider) ||
+            left.field.localeCompare(right.field),
+        ),
+    };
+  }
+}

--- a/src/repositories/optional-email-recipient-repo.ts
+++ b/src/repositories/optional-email-recipient-repo.ts
@@ -45,6 +45,9 @@ export class OptionalEmailRecipientRepository {
       this.#oauthAccounts.find({ userId }, { projection: { provider: 1, providerUsername: 1, email: 1 } }).toArray(),
       this.#passwordAccounts.find({ userId }, { projection: { email: 1 } }).toArray(),
     ]);
+    if (passwordAccounts.length > 1) {
+      return { status: OptionalEmailRecipientResolutionStatus.Ambiguous };
+    }
     if (oauthAccounts.some((account) => typeof account.provider !== "string")) {
       return { status: OptionalEmailRecipientResolutionStatus.Ambiguous };
     }

--- a/src/repositories/optional-email-recipient-repo.ts
+++ b/src/repositories/optional-email-recipient-repo.ts
@@ -17,6 +17,16 @@ const normalizedEmailSchema = z
   .email()
   .transform((value) => value.toLowerCase());
 
+function compareStrings(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+}
+
 /**
  * Resolves only persisted identity fields linked to one user. `Resolved` means
  * syntactically valid and unambiguous within that user; it does not establish
@@ -48,7 +58,7 @@ export class OptionalEmailRecipientRepository {
     if (passwordAccounts.length > 1) {
       return { status: OptionalEmailRecipientResolutionStatus.Ambiguous };
     }
-    if (oauthAccounts.some((account) => typeof account.provider !== "string")) {
+    if (oauthAccounts.some((account) => typeof account.provider !== "string" || account.provider.trim().length === 0)) {
       return { status: OptionalEmailRecipientResolutionStatus.Ambiguous };
     }
 
@@ -120,9 +130,9 @@ export class OptionalEmailRecipientRepository {
         .map((candidate) => candidate.provenance)
         .sort(
           (left, right) =>
-            left.accountKind.localeCompare(right.accountKind) ||
-            left.provider.localeCompare(right.provider) ||
-            left.field.localeCompare(right.field),
+            compareStrings(left.accountKind, right.accountKind) ||
+            compareStrings(left.provider, right.provider) ||
+            compareStrings(left.field, right.field),
         ),
     };
   }

--- a/src/repositories/optional-email-recipient-repo.ts
+++ b/src/repositories/optional-email-recipient-repo.ts
@@ -21,6 +21,7 @@ function compareStrings(left: string, right: string): number {
   if (left < right) {
     return -1;
   }
+
   if (left > right) {
     return 1;
   }

--- a/src/repositories/optional-email-recipient-repo.ts
+++ b/src/repositories/optional-email-recipient-repo.ts
@@ -58,6 +58,7 @@ export class OptionalEmailRecipientRepository {
     if (passwordAccounts.length > 1) {
       return { status: OptionalEmailRecipientResolutionStatus.Ambiguous };
     }
+
     if (oauthAccounts.some((account) => typeof account.provider !== "string" || account.provider.trim().length === 0)) {
       return { status: OptionalEmailRecipientResolutionStatus.Ambiguous };
     }

--- a/src/types/optional-email.ts
+++ b/src/types/optional-email.ts
@@ -3,6 +3,38 @@ export enum OptionalEmailRecipientBasis {
   AccountActivityApproved = "account_activity_approved",
 }
 
+export enum OptionalEmailRecipientResolutionStatus {
+  Resolved = "resolved",
+  Missing = "missing_recipient",
+  Ambiguous = "ambiguous_recipient",
+}
+
+export enum OptionalEmailRecipientAccountKind {
+  OAuth = "oauth",
+  Password = "password",
+}
+
+export enum OptionalEmailRecipientField {
+  Email = "email",
+  LegacyAppleProviderUsername = "legacy_apple_provider_username",
+}
+
+export type OptionalEmailRecipientProvenance = {
+  accountKind: OptionalEmailRecipientAccountKind;
+  provider: string;
+  field: OptionalEmailRecipientField;
+};
+
+export type OptionalEmailRecipientResolution =
+  | {
+      status: OptionalEmailRecipientResolutionStatus.Resolved;
+      address: string;
+      provenance: OptionalEmailRecipientProvenance[];
+    }
+  | {
+      status: OptionalEmailRecipientResolutionStatus.Missing | OptionalEmailRecipientResolutionStatus.Ambiguous;
+    };
+
 export enum OptionalEmailDryRunMode {
   DryRun = "dry_run",
 }

--- a/tests/repositories/optional-email-recipient-repo.test.ts
+++ b/tests/repositories/optional-email-recipient-repo.test.ts
@@ -271,7 +271,7 @@ describe("OptionalEmailRecipientRepository", () => {
       {
         _id: new ObjectId(),
         userId,
-        email: "second@example.test",
+        email: "FIRST@example.test",
         passwordHash: "fixture-only-hash",
         createdAt: new Date(2),
         updatedAt: new Date(2),

--- a/tests/repositories/optional-email-recipient-repo.test.ts
+++ b/tests/repositories/optional-email-recipient-repo.test.ts
@@ -191,7 +191,7 @@ describe("OptionalEmailRecipientRepository", () => {
   });
 
   it("retains every linked source in deterministic order when all identities resolve to one address", async () => {
-    const user = await ctx.createUser({ provider: "zeta-provider" });
+    const user = await ctx.createUser({ provider: "alpha-provider" });
     const userId = new ObjectId(user.userId);
     const oauthAccounts = ctx.dbAccessor.getCollection<OAuthAccount>(
       MongoDbDatabase.Auth,
@@ -201,7 +201,7 @@ describe("OptionalEmailRecipientRepository", () => {
     await oauthAccounts.insertOne({
       _id: new ObjectId(),
       userId,
-      provider: "alpha-provider",
+      provider: "Zeta-provider",
       providerUserId: new ObjectId().toHexString(),
       providerUsername: "Display Name",
       email: "same@example.test",
@@ -223,15 +223,16 @@ describe("OptionalEmailRecipientRepository", () => {
       status: "resolved",
       address: "same@example.test",
       provenance: [
+        { accountKind: "oauth", provider: "Zeta-provider", field: "email" },
         { accountKind: "oauth", provider: "alpha-provider", field: "email" },
-        { accountKind: "oauth", provider: "zeta-provider", field: "email" },
         { accountKind: "password", provider: "email", field: "email" },
       ],
     });
   });
 
-  it("fails closed when OAuth provenance is missing or non-string", async () => {
+  it("fails closed when OAuth provenance is missing, blank, or non-string", async () => {
     const missing = await ctx.createUser({ provider: "future-provider" });
+    const blank = await ctx.createUser({ provider: "future-provider" });
     const malformed = await ctx.createUser({ provider: "future-provider" });
     const accounts = ctx.dbAccessor.getCollection<Document>(MongoDbDatabase.Auth, AuthDbCollection.OAuthAccounts);
     await accounts.updateOne(
@@ -239,11 +240,18 @@ describe("OptionalEmailRecipientRepository", () => {
       { $set: { email: "valid@example.test" }, $unset: { provider: "" } },
     );
     await accounts.updateOne(
+      { userId: new ObjectId(blank.userId) },
+      { $set: { email: "valid@example.test", provider: "   " } },
+    );
+    await accounts.updateOne(
       { userId: new ObjectId(malformed.userId) },
       { $set: { email: "valid@example.test", provider: 42 } },
     );
 
     assert.deepEqual(await repository.resolve({ userId: missing.userId }), {
+      status: "ambiguous_recipient",
+    });
+    assert.deepEqual(await repository.resolve({ userId: blank.userId }), {
       status: "ambiguous_recipient",
     });
     assert.deepEqual(await repository.resolve({ userId: malformed.userId }), {
@@ -259,27 +267,32 @@ describe("OptionalEmailRecipientRepository", () => {
       AuthDbCollection.PasswordAccounts,
     );
     await accounts.dropIndex("userId_1");
-    await accounts.insertMany([
-      {
-        _id: new ObjectId(),
-        userId,
-        email: "first@example.test",
-        passwordHash: "fixture-only-hash",
-        createdAt: new Date(1),
-        updatedAt: new Date(1),
-      },
-      {
-        _id: new ObjectId(),
-        userId,
-        email: "FIRST@example.test",
-        passwordHash: "fixture-only-hash",
-        createdAt: new Date(2),
-        updatedAt: new Date(2),
-      },
-    ]);
+    try {
+      await accounts.insertMany([
+        {
+          _id: new ObjectId(),
+          userId,
+          email: "first@example.test",
+          passwordHash: "fixture-only-hash",
+          createdAt: new Date(1),
+          updatedAt: new Date(1),
+        },
+        {
+          _id: new ObjectId(),
+          userId,
+          email: "FIRST@example.test",
+          passwordHash: "fixture-only-hash",
+          createdAt: new Date(2),
+          updatedAt: new Date(2),
+        },
+      ]);
 
-    assert.deepEqual(await repository.resolve({ userId: user.userId }), {
-      status: "ambiguous_recipient",
-    });
+      assert.deepEqual(await repository.resolve({ userId: user.userId }), {
+        status: "ambiguous_recipient",
+      });
+    } finally {
+      await accounts.deleteMany({ userId });
+      await accounts.createIndex({ userId: 1 }, { unique: true });
+    }
   });
 });

--- a/tests/repositories/optional-email-recipient-repo.test.ts
+++ b/tests/repositories/optional-email-recipient-repo.test.ts
@@ -1,0 +1,285 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { ObjectId, type Document } from "mongodb";
+import type { OAuthAccount, PasswordAccount } from "../../src/models/documents.js";
+import { OptionalEmailRecipientRepository } from "../../src/repositories/optional-email-recipient-repo.js";
+import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+describe("OptionalEmailRecipientRepository", () => {
+  let ctx: TestContext;
+  let repository: OptionalEmailRecipientRepository;
+
+  before(async () => {
+    ctx = await createTestApp();
+    repository = new OptionalEmailRecipientRepository(ctx.dbAccessor);
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("resolves a valid stored OAuth email without a provider allowlist", async () => {
+    const user = await ctx.createUser({ provider: "future-provider" });
+    const userId = new ObjectId(user.userId);
+    await ctx.dbAccessor
+      .getCollection<OAuthAccount>(MongoDbDatabase.Auth, AuthDbCollection.OAuthAccounts)
+      .updateOne({ userId }, { $set: { email: " Person@Example.test " } });
+
+    assert.deepEqual(await repository.resolve({ userId: user.userId }), {
+      status: "resolved",
+      address: "person@example.test",
+      provenance: [{ accountKind: "oauth", provider: "future-provider", field: "email" }],
+    });
+  });
+
+  it("returns typed missing when the user id is invalid or no linked identity stores an address", async () => {
+    assert.deepEqual(await repository.resolve({ userId: "not-an-object-id" }), {
+      status: "missing_recipient",
+    });
+
+    const user = await ctx.createUser();
+    assert.deepEqual(await repository.resolve({ userId: user.userId }), {
+      status: "missing_recipient",
+    });
+  });
+
+  it("uses the validated legacy Apple address field without treating it as verified", async () => {
+    const user = await ctx.createUser({ provider: "apple" });
+    const userId = new ObjectId(user.userId);
+    await ctx.dbAccessor
+      .getCollection<OAuthAccount>(MongoDbDatabase.Auth, AuthDbCollection.OAuthAccounts)
+      .updateOne({ userId }, { $set: { providerUsername: "Legacy@Example.test" }, $unset: { email: "" } });
+
+    assert.deepEqual(await repository.resolve({ userId: user.userId }), {
+      status: "resolved",
+      address: "legacy@example.test",
+      provenance: [
+        {
+          accountKind: "oauth",
+          provider: "apple",
+          field: "legacy_apple_provider_username",
+        },
+      ],
+    });
+  });
+
+  it("retains both Apple field provenances when the current and legacy values agree", async () => {
+    const user = await ctx.createUser({ provider: "apple" });
+    await ctx.dbAccessor.getCollection<OAuthAccount>(MongoDbDatabase.Auth, AuthDbCollection.OAuthAccounts).updateOne(
+      { userId: new ObjectId(user.userId) },
+      {
+        $set: {
+          email: "same@example.test",
+          providerUsername: "Same@Example.test",
+        },
+      },
+    );
+
+    assert.deepEqual(await repository.resolve({ userId: user.userId }), {
+      status: "resolved",
+      address: "same@example.test",
+      provenance: [
+        { accountKind: "oauth", provider: "apple", field: "email" },
+        {
+          accountKind: "oauth",
+          provider: "apple",
+          field: "legacy_apple_provider_username",
+        },
+      ],
+    });
+  });
+
+  it("ignores non-Apple usernames and an absent Apple legacy field", async () => {
+    const other = await ctx.createUser({ provider: "future-provider" });
+    const apple = await ctx.createUser({ provider: "apple" });
+    const oauthAccounts = ctx.dbAccessor.getCollection<OAuthAccount>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.OAuthAccounts,
+    );
+    await oauthAccounts.updateOne(
+      { userId: new ObjectId(other.userId) },
+      { $set: { providerUsername: "not-a-contact@example.test" }, $unset: { email: "" } },
+    );
+    await oauthAccounts.updateOne(
+      { userId: new ObjectId(apple.userId) },
+      { $unset: { providerUsername: "", email: "" } },
+    );
+
+    assert.deepEqual(await repository.resolve({ userId: other.userId }), {
+      status: "missing_recipient",
+    });
+    assert.deepEqual(await repository.resolve({ userId: apple.userId }), {
+      status: "missing_recipient",
+    });
+  });
+
+  it("resolves a password-only address with its actual persisted provenance", async () => {
+    const user = await ctx.createUser();
+    const userId = new ObjectId(user.userId);
+    const oauthAccounts = ctx.dbAccessor.getCollection<OAuthAccount>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.OAuthAccounts,
+    );
+    await oauthAccounts.updateOne({ userId }, { $unset: { email: "" } });
+    await ctx.dbAccessor
+      .getCollection<PasswordAccount>(MongoDbDatabase.Auth, AuthDbCollection.PasswordAccounts)
+      .insertOne({
+        _id: new ObjectId(),
+        userId,
+        email: "password@example.test",
+        passwordHash: "fixture-only-hash",
+        createdAt: new Date(3),
+        updatedAt: new Date(3),
+      });
+
+    assert.deepEqual(await repository.resolve({ userId: user.userId }), {
+      status: "resolved",
+      address: "password@example.test",
+      provenance: [{ accountKind: "password", provider: "email", field: "email" }],
+    });
+  });
+
+  it("fails closed for conflicting valid addresses or any populated malformed address field", async () => {
+    const conflicting = await ctx.createUser({ provider: "github" });
+    const conflictingId = new ObjectId(conflicting.userId);
+    const oauthAccounts = ctx.dbAccessor.getCollection<OAuthAccount>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.OAuthAccounts,
+    );
+    await oauthAccounts.updateOne({ userId: conflictingId }, { $set: { email: "one@example.test" } });
+    await ctx.dbAccessor
+      .getCollection<PasswordAccount>(MongoDbDatabase.Auth, AuthDbCollection.PasswordAccounts)
+      .insertOne({
+        _id: new ObjectId(),
+        userId: conflictingId,
+        email: "two@example.test",
+        passwordHash: "fixture-only-hash",
+        createdAt: new Date(4),
+        updatedAt: new Date(4),
+      });
+
+    const malformed = await ctx.createUser({ provider: "future-provider" });
+    await oauthAccounts.updateOne(
+      { userId: new ObjectId(malformed.userId) },
+      { $set: { email: "not-an-email-address" } },
+    );
+
+    assert.deepEqual(await repository.resolve({ userId: conflicting.userId }), {
+      status: "ambiguous_recipient",
+    });
+    assert.deepEqual(await repository.resolve({ userId: malformed.userId }), {
+      status: "ambiguous_recipient",
+    });
+  });
+
+  it("treats disagreeing current and legacy Apple address fields as ambiguous", async () => {
+    const user = await ctx.createUser({ provider: "apple" });
+    await ctx.dbAccessor.getCollection<OAuthAccount>(MongoDbDatabase.Auth, AuthDbCollection.OAuthAccounts).updateOne(
+      { userId: new ObjectId(user.userId) },
+      {
+        $set: {
+          email: "current@example.test",
+          providerUsername: "legacy@example.test",
+        },
+      },
+    );
+
+    assert.deepEqual(await repository.resolve({ userId: user.userId }), {
+      status: "ambiguous_recipient",
+    });
+  });
+
+  it("retains every linked source in deterministic order when all identities resolve to one address", async () => {
+    const user = await ctx.createUser({ provider: "zeta-provider" });
+    const userId = new ObjectId(user.userId);
+    const oauthAccounts = ctx.dbAccessor.getCollection<OAuthAccount>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.OAuthAccounts,
+    );
+    await oauthAccounts.updateOne({ userId }, { $set: { email: "Same@Example.test" } });
+    await oauthAccounts.insertOne({
+      _id: new ObjectId(),
+      userId,
+      provider: "alpha-provider",
+      providerUserId: new ObjectId().toHexString(),
+      providerUsername: "Display Name",
+      email: "same@example.test",
+      createdAt: new Date(1),
+      updatedAt: new Date(1),
+    });
+    await ctx.dbAccessor
+      .getCollection<PasswordAccount>(MongoDbDatabase.Auth, AuthDbCollection.PasswordAccounts)
+      .insertOne({
+        _id: new ObjectId(),
+        userId,
+        email: "same@example.test",
+        passwordHash: "fixture-only-hash",
+        createdAt: new Date(2),
+        updatedAt: new Date(2),
+      });
+
+    assert.deepEqual(await repository.resolve({ userId: user.userId }), {
+      status: "resolved",
+      address: "same@example.test",
+      provenance: [
+        { accountKind: "oauth", provider: "alpha-provider", field: "email" },
+        { accountKind: "oauth", provider: "zeta-provider", field: "email" },
+        { accountKind: "password", provider: "email", field: "email" },
+      ],
+    });
+  });
+
+  it("fails closed when OAuth provenance is missing or non-string", async () => {
+    const missing = await ctx.createUser({ provider: "future-provider" });
+    const malformed = await ctx.createUser({ provider: "future-provider" });
+    const accounts = ctx.dbAccessor.getCollection<Document>(MongoDbDatabase.Auth, AuthDbCollection.OAuthAccounts);
+    await accounts.updateOne(
+      { userId: new ObjectId(missing.userId) },
+      { $set: { email: "valid@example.test" }, $unset: { provider: "" } },
+    );
+    await accounts.updateOne(
+      { userId: new ObjectId(malformed.userId) },
+      { $set: { email: "valid@example.test", provider: 42 } },
+    );
+
+    assert.deepEqual(await repository.resolve({ userId: missing.userId }), {
+      status: "ambiguous_recipient",
+    });
+    assert.deepEqual(await repository.resolve({ userId: malformed.userId }), {
+      status: "ambiguous_recipient",
+    });
+  });
+
+  it("fails closed for duplicate password identities", async () => {
+    const user = await ctx.createUser();
+    const userId = new ObjectId(user.userId);
+    const accounts = ctx.dbAccessor.getCollection<PasswordAccount>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.PasswordAccounts,
+    );
+    await accounts.dropIndex("userId_1");
+    await accounts.insertMany([
+      {
+        _id: new ObjectId(),
+        userId,
+        email: "first@example.test",
+        passwordHash: "fixture-only-hash",
+        createdAt: new Date(1),
+        updatedAt: new Date(1),
+      },
+      {
+        _id: new ObjectId(),
+        userId,
+        email: "second@example.test",
+        passwordHash: "fixture-only-hash",
+        createdAt: new Date(2),
+        updatedAt: new Date(2),
+      },
+    ]);
+
+    assert.deepEqual(await repository.resolve({ userId: user.userId }), {
+      status: "ambiguous_recipient",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Reuses the existing unmerged `OptionalEmailRecipientRepository` handle from `4bd4d1a9fc0807729a5f61fe8176319391799e25` rather than creating a second resolver.
- Inspects every OAuth and password identity linked by `userId`, accepts explicit OAuth `email` fields without a provider allowlist, and uses `providerUsername` only for the released Apple legacy contract.
- Returns one normalized, syntactically valid address with factual account/provider/field provenance only when every populated candidate converges; otherwise returns typed `missing_recipient` or `ambiguous_recipient`.
- Fails closed for malformed provenance, malformed addresses, conflicting addresses, and duplicate legacy/corrupt password records.

## Safety boundaries

- The resolver is inert and is not composed into eligibility, dry-run output, sending, configuration, or scheduling.
- `recipient_safety_unverified` remains the terminal eligibility block.
- A resolved result does not establish verification, permission, deliverability, campaign eligibility, or cross-user uniqueness.
- No provider calls, production access, migrations, telemetry, deployment, or send path.
- Mobile and deletion gates are unchanged; strict A/B/C cohort selection remains blocked outside this PR.

## Verification

- [x] Focused recipient/eligibility/dry-run checks: 28/28
- [x] Full test suite: 1,014 passed, 1 existing skip, 0 failed
- [x] Build
- [x] ESLint
- [x] Prettier
- [x] Circular-dependency check
- [x] `git diff --check`
- [x] Added-line security scan
- [x] 471 additions, 0 deletions
