### PR TITLE
⚙️ [macos-darkwake-notifications] Filter connection-status pushes independently of availability [step 1/3]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ The activation-reminder feature is intentionally split into independently deploy
 
 Desktop bridge instances register via `POST /auth/bridges` (idempotent: clients resend their `bridgeId`; an owned non-revoked id updates in place, anything else mints a new `br_` id). `GET /auth/me` returns `bridges[]` (id, name, platform, addedAt, lastSeenAt — no live status; clients get live connectivity from the relay). The relay reports per-bridge connect/disconnect to `POST /internal/bridge-status`, which requires `bridgeId`; missing or malformed IDs get a 400. Unknown/revoked bridgeIds get a 404, which the relay turns into a WS close 4006 so the bridge re-registers. Bridges authenticate to the relay with the **user access token** — there is no bridge-scoped token. Bridge-scoped JWTs were prototyped and dropped (`8b600dd`): they added a second credential lifecycle (24h TTL, no re-issue path) and a synchronous relay→auth call per connect without buying real revocation, since the bridge host holds the user refresh token regardless. Re-evaluate only if bridge auth must outlive user sessions.
 
-Push notifications debounce through `BridgeStateTracker` (120s), keyed per bridge by `(userId, bridgeId)`.
+Connection-status pushes debounce through `BridgeStateTracker`, keyed per bridge by `(userId, bridgeId)`: conservative/unknown online and genuine offline reports use 120 seconds; confirmed full-wake online reports use five seconds. Suppressed DarkWake episodes remain quiet without cancelling a genuine pending offline notification. Device observations exclude only that device from the pending online push and never mutate persisted connectivity. These policies never control bridge transport.
 
 ## ASYNC TRANSCRIPTION
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,12 @@ Push notifications are forwarded to Firebase Cloud Messaging. Every notification
 | `system_update`    | `systemUpdate`     | Bridge, plus activation reminders             |
 | `connection_status`| `connectionStatus` | Server, on bridge connect/disconnect          |
 
-`connection_status` is server-originated and is rejected on `POST /notifications/send`.
+`connection_status` is server-originated and is rejected on `POST /notifications/send`. macOS bridges may attach an
+advisory connection-notification policy: detected full wakes use a short online settlement delay, system-sleep episodes
+without a public full-wake callback suppress connection pushes, and missing/failed detection retains the conservative
+two-minute debounce. Offline debounce remains two minutes. Policy and per-socket observation state are in memory only;
+no database fields are added. A mobile surface that restores the exact E2E connection may exclude only its own device
+ID from that pending online push. Other notification categories never accept or apply this exclusion.
 
 | Method   | Path                            | Auth   | Description                                                                                     |
 | -------- | ------------------------------- | ------ | ----------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -195,9 +195,10 @@ Push notifications are forwarded to Firebase Cloud Messaging. Every notification
 | `connection_status`| `connectionStatus` | Server, on bridge connect/disconnect          |
 
 `connection_status` is server-originated and is rejected on `POST /notifications/send`. macOS bridges may attach an
-advisory connection-notification policy: detected full wakes use a short online settlement delay, system-sleep episodes
-without a public full-wake callback suppress connection pushes, and missing/failed detection retains the conservative
-two-minute debounce. Offline debounce remains two minutes. Policy and per-socket observation state are in memory only;
+advisory connection-notification policy: detected full wakes use a short online settlement delay, DarkWake-only socket
+episodes suppress connection pushes, and missing/failed detection retains the conservative two-minute debounce. A
+socket established while normally awake remains eligible for the two-minute offline debounce if it disconnects during
+sleep suppression; same-socket full wake also promotes a DarkWake socket. Policy and per-socket observation state are in memory only;
 no database fields are added. A mobile surface that restores the exact E2E connection may exclude only its own device
 ID from that pending online push. Other notification categories never accept or apply this exclusion.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ async function main() {
 
   const settingsService = new SettingsService({ settingsRepo });
   const notificationService = new NotificationService(deviceTokenRepo, messaging, settingsService);
-  const bridgeStateTracker = new BridgeStateTracker(notificationService);
+  const bridgeStateTracker = new BridgeStateTracker({ notificationService });
   const bridgeService = new BridgeService({ bridgeRepo, glossaryRepo, bridgeStateTracker });
   const activationService = new ActivationService({
     activationStateRepo,

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
-import { BridgePlatform, bridgeIdSchema, bridgePlatformSchema } from "./bridge.js";
+import {
+  BridgeConnectionNotificationPolicy,
+  BridgePlatform,
+  BridgeStatusEvent,
+  bridgeIdSchema,
+  bridgePlatformSchema,
+} from "./bridge.js";
 import { devicePlatformSchema } from "./device.js";
 import { CLIENT_SENDABLE_NOTIFICATION_CATEGORIES } from "./notification.js";
 import { deviceIdSchema } from "./settings.js";
@@ -269,12 +275,32 @@ export const sendNotificationBodySchema = z.object({
 });
 export type SendNotificationBody = z.infer<typeof sendNotificationBodySchema>;
 
-export const bridgeStatusBodySchema = z.object({
+const bridgeStatusBaseSchema = z.object({
   userId: z.string().min(1),
   bridgeId: bridgeIdSchema,
-  status: z.enum(["connected", "disconnected"]),
   timestamp: z.string(),
 });
+const connectionIdSchema = z.string().regex(/^[0-9a-f]{32}$/);
+export const bridgeStatusBodySchema = z.union([
+  bridgeStatusBaseSchema.extend({
+    event: z.undefined().optional(),
+    status: z.enum(["connected", "disconnected"]),
+    notificationPolicy: z.enum(BridgeConnectionNotificationPolicy).optional(),
+    connectionId: connectionIdSchema.optional(),
+  }),
+  bridgeStatusBaseSchema.extend({
+    event: z.literal(BridgeStatusEvent.NotificationPolicy),
+    status: z.literal("connected"),
+    notificationPolicy: z.enum(BridgeConnectionNotificationPolicy),
+    connectionId: connectionIdSchema,
+  }),
+  bridgeStatusBaseSchema.extend({
+    event: z.literal(BridgeStatusEvent.ConnectionObserved),
+    status: z.literal("connected"),
+    connectionId: connectionIdSchema,
+    deviceId: deviceIdSchema,
+  }),
+]);
 export type BridgeStatusBody = z.infer<typeof bridgeStatusBodySchema>;
 
 export type BridgeSummary = {

--- a/src/models/bridge.ts
+++ b/src/models/bridge.ts
@@ -14,6 +14,17 @@ export enum BridgeStatus {
   inactive = "inactive",
 }
 
+export enum BridgeConnectionNotificationPolicy {
+  Normal = "normal",
+  Suppress = "suppress",
+  Conservative = "conservative",
+}
+
+export enum BridgeStatusEvent {
+  NotificationPolicy = "notification_policy",
+  ConnectionObserved = "connection_observed",
+}
+
 export const bridgeIdSchema = z.string().regex(/^br_[A-Za-z0-9_-]{8,32}$/);
 export const bridgePlatformSchema = z.enum(BridgePlatform);
 export const bridgeStatusSchema = z.enum(BridgeStatus);

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -8,7 +8,7 @@ import {
   type SendNotificationBody,
   type BridgeStatusBody,
 } from "../models/api.js";
-import { bridgeStatusFromWire } from "../models/bridge.js";
+import { BridgeConnectionNotificationPolicy, BridgeStatusEvent, bridgeStatusFromWire } from "../models/bridge.js";
 import type { DeviceTokenRepository } from "../repositories/device-token-repo.js";
 import type { BridgeService } from "../services/bridge-service.js";
 import type { NotificationService } from "../services/notification-service.js";
@@ -128,12 +128,25 @@ export const notificationRoutes: FastifyPluginAsync<NotificationRouteOptions> = 
         throw new BadRequestError({ debugMessage: "Timestamp is too far in the future" });
       }
 
-      const { found } = await bridgeService.recordStatusChange(
-        bodyResult.data.bridgeId,
-        bodyResult.data.userId,
-        internalStatus,
-        at,
-      );
+      const report = bodyResult.data;
+      const { found } =
+        report.event === BridgeStatusEvent.ConnectionObserved
+          ? await bridgeService.recordConnectionObservation({
+              bridgeId: report.bridgeId,
+              userId: report.userId,
+              at,
+              connectionId: report.connectionId,
+              deviceId: report.deviceId,
+            })
+          : await bridgeService.recordStatusReport({
+              bridgeId: report.bridgeId,
+              userId: report.userId,
+              status: internalStatus,
+              at,
+              notificationPolicy: report.notificationPolicy ?? BridgeConnectionNotificationPolicy.Conservative,
+              connectionId: report.connectionId ?? null,
+              policyOnly: report.event === BridgeStatusEvent.NotificationPolicy,
+            });
       if (!found) {
         // Contract with the relay: this 404 becomes WS close 4006, telling
         // the bridge to re-register. Do not weaken to a 200 — see AGENTS.md

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -134,7 +134,6 @@ export const notificationRoutes: FastifyPluginAsync<NotificationRouteOptions> = 
           ? await bridgeService.recordConnectionObservation({
               bridgeId: report.bridgeId,
               userId: report.userId,
-              at,
               connectionId: report.connectionId,
               deviceId: report.deviceId,
             })

--- a/src/services/bridge-service.ts
+++ b/src/services/bridge-service.ts
@@ -179,12 +179,11 @@ export class BridgeService {
   async recordConnectionObservation(args: {
     bridgeId: string;
     userId: string;
-    at: Date;
     connectionId: string;
     deviceId: string;
   }): Promise<{ found: boolean }> {
-    const result = await this.#bridgeRepo.recordStatusChange(args.bridgeId, args.userId, BridgeStatus.active, args.at);
-    if (!result.found || !result.updated) return { found: result.found };
+    const bridge = await this.#bridgeRepo.findByIdForUser(args.bridgeId, args.userId);
+    if (!bridge) return { found: false };
     this.#bridgeStateTracker.markConnectionObserved(args);
     return { found: true };
   }

--- a/src/services/bridge-service.ts
+++ b/src/services/bridge-service.ts
@@ -130,29 +130,6 @@ export class BridgeService {
   // the 404 the relay converts to WS close 4006. A stale (out-of-order) event
   // on a live bridge reports found=true and is dropped silently: surfacing it
   // as 404 would make the relay close a live bridge over event reordering.
-  async recordStatusChange(
-    bridgeId: string,
-    userId: string,
-    status: BridgeStatus,
-    at: Date,
-  ): Promise<{ found: boolean }> {
-    const result = await this.#bridgeRepo.recordStatusChange(bridgeId, userId, status, at);
-    if (!result.found || !result.updated) {
-      return { found: result.found };
-    }
-
-    if (result.statusChanged) {
-      this.#bridgeStateTracker.handleStatusChangeForBridge({
-        userId,
-        bridgeId,
-        status,
-        notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
-        connectionId: null,
-      });
-    }
-    return { found: true };
-  }
-
   async recordStatusReport(args: {
     bridgeId: string;
     userId: string;
@@ -163,7 +140,10 @@ export class BridgeService {
     policyOnly: boolean;
   }): Promise<{ found: boolean }> {
     const result = await this.#bridgeRepo.recordStatusChange(args.bridgeId, args.userId, args.status, args.at);
-    if (!result.found || !result.updated) return { found: result.found };
+    if (!result.found || !result.updated) {
+      return { found: result.found };
+    }
+
     if (result.statusChanged || args.policyOnly) {
       this.#bridgeStateTracker.handleStatusChangeForBridge({
         userId: args.userId,
@@ -183,7 +163,9 @@ export class BridgeService {
     deviceId: string;
   }): Promise<{ found: boolean }> {
     const bridge = await this.#bridgeRepo.findByIdForUser(args.bridgeId, args.userId);
-    if (!bridge) return { found: false };
+    if (!bridge) {
+      return { found: false };
+    }
     this.#bridgeStateTracker.markConnectionObserved(args);
     return { found: true };
   }

--- a/src/services/bridge-service.ts
+++ b/src/services/bridge-service.ts
@@ -1,7 +1,7 @@
 import { BadRequestError } from "../lib/errors.js";
 import type { Bridge as BridgeDoc } from "../models/documents.js";
 import type { BridgePlatform, BridgeSummary } from "../models/api.js";
-import type { BridgeStatus } from "../models/bridge.js";
+import { BridgeConnectionNotificationPolicy, BridgeStatus } from "../models/bridge.js";
 import type { BridgeRepository } from "../repositories/bridge-repo.js";
 import type { GlossaryEntryRepository } from "../repositories/glossary-entry-repo.js";
 import type { BridgeStateTracker } from "./bridge-state-tracker.js";
@@ -142,8 +142,50 @@ export class BridgeService {
     }
 
     if (result.statusChanged) {
-      this.#bridgeStateTracker.handleStatusChangeForBridge(userId, bridgeId, status);
+      this.#bridgeStateTracker.handleStatusChangeForBridge({
+        userId,
+        bridgeId,
+        status,
+        notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+        connectionId: null,
+      });
     }
+    return { found: true };
+  }
+
+  async recordStatusReport(args: {
+    bridgeId: string;
+    userId: string;
+    status: BridgeStatus;
+    at: Date;
+    notificationPolicy: BridgeConnectionNotificationPolicy;
+    connectionId: string | null;
+    policyOnly: boolean;
+  }): Promise<{ found: boolean }> {
+    const result = await this.#bridgeRepo.recordStatusChange(args.bridgeId, args.userId, args.status, args.at);
+    if (!result.found || !result.updated) return { found: result.found };
+    if (result.statusChanged || args.policyOnly) {
+      this.#bridgeStateTracker.handleStatusChangeForBridge({
+        userId: args.userId,
+        bridgeId: args.bridgeId,
+        status: args.status,
+        notificationPolicy: args.notificationPolicy,
+        connectionId: args.connectionId,
+      });
+    }
+    return { found: true };
+  }
+
+  async recordConnectionObservation(args: {
+    bridgeId: string;
+    userId: string;
+    at: Date;
+    connectionId: string;
+    deviceId: string;
+  }): Promise<{ found: boolean }> {
+    const result = await this.#bridgeRepo.recordStatusChange(args.bridgeId, args.userId, BridgeStatus.active, args.at);
+    if (!result.found || !result.updated) return { found: result.found };
+    this.#bridgeStateTracker.markConnectionObserved(args);
     return { found: true };
   }
 }

--- a/src/services/bridge-state-tracker.ts
+++ b/src/services/bridge-state-tracker.ts
@@ -57,19 +57,27 @@ export class BridgeStateTracker {
     notificationPolicy: BridgeConnectionNotificationPolicy;
     connectionId: string | null;
   }): void {
-    if (!this.#accepting) return;
+    if (!this.#accepting) {
+      return;
+    }
+
     const key = instanceKey(args);
     const entry = this.#getOrCreateEntry(key);
 
     if (args.notificationPolicy === BridgeConnectionNotificationPolicy.Suppress) {
-      if (entry.pending?.status === BridgeStatus.active) this.#cancelPending(entry);
+      if (entry.pending?.status === BridgeStatus.active) {
+        this.#cancelPending(entry);
+      }
       return;
     }
 
     if (args.status === BridgeStatus.active && entry.pending?.status === BridgeStatus.inactive) {
       this.#cancelPending(entry);
     }
-    if (entry.lastNotifiedStatus === args.status && entry.pending === null) return;
+
+    if (entry.lastNotifiedStatus === args.status && entry.pending === null) {
+      return;
+    }
 
     const delay =
       args.status === BridgeStatus.active && args.notificationPolicy === BridgeConnectionNotificationPolicy.Normal
@@ -83,7 +91,6 @@ export class BridgeStateTracker {
     ) {
       return;
     }
-    this.#cancelPending(entry);
     this.#schedule({
       entry,
       userId: args.userId,
@@ -95,7 +102,10 @@ export class BridgeStateTracker {
   }
 
   markConnectionObserved(args: { userId: string; bridgeId: string; connectionId: string; deviceId: string }): void {
-    if (!this.#accepting) return;
+    if (!this.#accepting) {
+      return;
+    }
+
     const entry = this.#getOrCreateEntry(instanceKey(args));
     const pending = entry.pending;
     if (pending?.status === BridgeStatus.active && pending.connectionId === args.connectionId) {
@@ -110,10 +120,15 @@ export class BridgeStateTracker {
   }
 
   cancelPendingForBridge(userId: string, bridgeId: string): void {
-    if (!this.#accepting) return;
+    if (!this.#accepting) {
+      return;
+    }
+
     const key = instanceKey({ userId, bridgeId });
     const entry = this.#state.get(key);
-    if (!entry) return;
+    if (!entry) {
+      return;
+    }
     this.#cancelPending(entry);
     this.#state.delete(key);
   }
@@ -126,14 +141,23 @@ export class BridgeStateTracker {
     policy: BridgeConnectionNotificationPolicy;
     delay: number;
   }): void {
+    const previousPending = args.entry.pending;
+    this.#cancelPending(args.entry);
     args.entry.generation += 1;
     const generation = args.entry.generation;
     const earlyObservation = args.entry.earlyConnectionObservation;
     const excludedDeviceIds =
-      args.status === BridgeStatus.active && earlyObservation?.connectionId === args.connectionId
-        ? new Set(earlyObservation.deviceIds)
+      args.status === BridgeStatus.active &&
+      previousPending?.status === BridgeStatus.active &&
+      previousPending.connectionId === args.connectionId
+        ? previousPending.excludedDeviceIds
         : new Set<string>();
-    if (args.status === BridgeStatus.active) args.entry.earlyConnectionObservation = null;
+    if (args.status === BridgeStatus.active && earlyObservation?.connectionId === args.connectionId) {
+      for (const deviceId of earlyObservation.deviceIds) {
+        excludedDeviceIds.add(deviceId);
+      }
+      args.entry.earlyConnectionObservation = null;
+    }
     const pending: PendingNotification = {
       status: args.status,
       connectionId: args.connectionId,
@@ -141,7 +165,9 @@ export class BridgeStateTracker {
       excludedDeviceIds,
       generation,
       timer: setTimeout(() => {
-        if (args.entry.pending !== pending || pending.generation !== generation) return;
+        if (args.entry.pending !== pending || pending.generation !== generation) {
+          return;
+        }
         const callback = this.#send({ entry: args.entry, pending, userId: args.userId });
         this.#inFlight.add(callback);
         void callback.finally(() => this.#inFlight.delete(callback));
@@ -155,7 +181,7 @@ export class BridgeStateTracker {
     try {
       await this.#notificationService.sendToUser(
         args.userId,
-        this.#buildPayload(args.pending.status, new Set(args.pending.excludedDeviceIds)),
+        this.#buildPayload(args.pending.status, args.pending.excludedDeviceIds),
       );
     } catch (err) {
       console.warn("Bridge notification failed", { userId: args.userId, status: args.pending.status, err });
@@ -168,7 +194,9 @@ export class BridgeStateTracker {
   }
 
   #cancelPending(entry: BridgeStateEntry): void {
-    if (!entry.pending) return;
+    if (!entry.pending) {
+      return;
+    }
     clearTimeout(entry.pending.timer);
     entry.pending = null;
     entry.generation += 1;
@@ -181,17 +209,25 @@ export class BridgeStateTracker {
   }
 
   async #disposeOnce(): Promise<void> {
-    for (const entry of this.#state.values()) this.#cancelPending(entry);
+    for (const entry of this.#state.values()) {
+      this.#cancelPending(entry);
+    }
     this.#state.clear();
     const callbacks = Array.from(this.#inFlight);
-    if (callbacks.length === 0) return;
+    if (callbacks.length === 0) {
+      return;
+    }
     await withDisposeTimeout(Promise.allSettled(callbacks).then(() => undefined));
-    if (this.#inFlight.size > 0) throw new BridgeStateTrackerDrainTimeout();
+    if (this.#inFlight.size > 0) {
+      throw new BridgeStateTrackerDrainTimeout();
+    }
   }
 
   #getOrCreateEntry(key: string): BridgeStateEntry {
     const existing = this.#state.get(key);
-    if (existing) return existing;
+    if (existing) {
+      return existing;
+    }
     const entry: BridgeStateEntry = {
       pending: null,
       earlyConnectionObservation: null,

--- a/src/services/bridge-state-tracker.ts
+++ b/src/services/bridge-state-tracker.ts
@@ -1,148 +1,157 @@
-import { BridgeStatus } from "../models/bridge.js";
-import type { NotificationPayload, NotificationService } from "./notification-service.js";
+import { BridgeConnectionNotificationPolicy, BridgeStatus } from "../models/bridge.js";
 import { NotificationCategory } from "../models/notification.js";
+import type { ConnectionStatusNotificationPayload, NotificationService } from "./notification-service.js";
 
-/**
- * Debounces bridge online/offline push notifications so transient relay
- * reconnects don't spam the user. State is keyed by (userId, bridgeId) so
- * each registered bridge is debounced independently.
- *
- * State is in-process and unbounded: entries accrue per (userId, bridgeId)
- * for the process lifetime (the last-notified status is kept for dedupe).
- * That is acceptable for the current single-instance deployment with a
- * per-user bridge cap; see AGENTS.md "SCALING CONSTRAINTS" before reusing
- * this in a multi-instance topology — timers also do not survive restarts.
- */
-// 120s: long enough to swallow relay restarts and flapping reconnects,
-// short enough that a real offline event still notifies promptly.
 const DEFAULT_BRIDGE_NOTIFICATION_DEBOUNCE_MS = 120_000;
+const DEFAULT_NORMAL_WAKE_ONLINE_DELAY_MS = 5_000;
 const BRIDGE_STATE_TRACKER_DISPOSE_TIMEOUT_MS = 15_000;
 
-type BridgeStateEntry = {
-  pendingStatus: BridgeStatus | null;
-  lastNotifiedStatus: BridgeStatus | null;
-  timer: ReturnType<typeof setTimeout> | null;
+type PendingNotification = {
+  status: BridgeStatus;
+  connectionId: string | null;
+  policy: BridgeConnectionNotificationPolicy;
+  excludedDeviceIds: Set<string>;
+  timer: ReturnType<typeof setTimeout>;
   generation: number;
 };
 
-function instanceKey(userId: string, bridgeId: string): string {
-  return `${userId}::${bridgeId}`;
+type BridgeStateEntry = {
+  pending: PendingNotification | null;
+  lastNotifiedStatus: BridgeStatus | null;
+  generation: number;
+};
+
+function instanceKey(args: { userId: string; bridgeId: string }): string {
+  return `${args.userId}::${args.bridgeId}`;
 }
 
 export class BridgeStateTracker {
   readonly #notificationService: NotificationService;
-  readonly #debounceMs: number;
+  readonly #conservativeDelayMs: number;
+  readonly #normalOnlineDelayMs: number;
   readonly #state = new Map<string, BridgeStateEntry>();
   readonly #inFlight = new Set<Promise<void>>();
   #accepting = true;
   #disposePromise: Promise<void> | null = null;
 
-  constructor(notificationService: NotificationService, debounceMs: number = DEFAULT_BRIDGE_NOTIFICATION_DEBOUNCE_MS) {
-    this.#notificationService = notificationService;
-    this.#debounceMs = debounceMs;
+  constructor(args: {
+    notificationService: NotificationService;
+    conservativeDelayMs?: number;
+    normalOnlineDelayMs?: number;
+  }) {
+    this.#notificationService = args.notificationService;
+    this.#conservativeDelayMs = args.conservativeDelayMs ?? DEFAULT_BRIDGE_NOTIFICATION_DEBOUNCE_MS;
+    this.#normalOnlineDelayMs = args.normalOnlineDelayMs ?? DEFAULT_NORMAL_WAKE_ONLINE_DELAY_MS;
   }
 
-  handleStatusChangeForBridge(userId: string, bridgeId: string, status: BridgeStatus): void {
-    if (!this.#accepting) {
+  handleStatusChangeForBridge(args: {
+    userId: string;
+    bridgeId: string;
+    status: BridgeStatus;
+    notificationPolicy: BridgeConnectionNotificationPolicy;
+    connectionId: string | null;
+  }): void {
+    if (!this.#accepting) return;
+    const key = instanceKey(args);
+    const entry = this.#getOrCreateEntry(key);
+
+    if (args.notificationPolicy === BridgeConnectionNotificationPolicy.Suppress) {
+      if (entry.pending?.status === BridgeStatus.active) this.#cancelPending(entry);
       return;
     }
 
-    this.#dispatch(userId, instanceKey(userId, bridgeId), status);
+    if (args.status === BridgeStatus.active && entry.pending?.status === BridgeStatus.inactive) {
+      this.#cancelPending(entry);
+    }
+    if (entry.lastNotifiedStatus === args.status && entry.pending === null) return;
+
+    const delay =
+      args.status === BridgeStatus.active && args.notificationPolicy === BridgeConnectionNotificationPolicy.Normal
+        ? this.#normalOnlineDelayMs
+        : this.#conservativeDelayMs;
+    if (
+      entry.pending?.status === args.status &&
+      entry.pending.connectionId === args.connectionId &&
+      (entry.pending.policy === BridgeConnectionNotificationPolicy.Normal ||
+        args.notificationPolicy !== BridgeConnectionNotificationPolicy.Normal)
+    ) {
+      return;
+    }
+    this.#cancelPending(entry);
+    this.#schedule({
+      entry,
+      userId: args.userId,
+      status: args.status,
+      connectionId: args.connectionId,
+      policy: args.notificationPolicy,
+      delay,
+    });
+  }
+
+  markConnectionObserved(args: { userId: string; bridgeId: string; connectionId: string; deviceId: string }): void {
+    if (!this.#accepting) return;
+    const pending = this.#state.get(instanceKey(args))?.pending;
+    if (pending?.status !== BridgeStatus.active || pending.connectionId !== args.connectionId) return;
+    pending.excludedDeviceIds.add(args.deviceId);
   }
 
   cancelPendingForBridge(userId: string, bridgeId: string): void {
-    if (!this.#accepting) {
-      return;
-    }
-
-    const key = instanceKey(userId, bridgeId);
-    this.#cancelPendingForKey(key);
-  }
-
-  // Deliberate "forget everything" semantics: deleting the entry also drops
-  // lastNotifiedStatus, so a bridge that is revoked and later re-registered
-  // under the same bridgeId is treated as brand new and may re-notify a
-  // status that was already pushed before the cancel. That is acceptable —
-  // a re-registered bridge is a new bridge from the user's perspective —
-  // and it keeps cancellation the only place entries are removed, bounding
-  // the map by active (not historical) keys.
-  #cancelPendingForKey(key: string): void {
+    if (!this.#accepting) return;
+    const key = instanceKey({ userId, bridgeId });
     const entry = this.#state.get(key);
-    if (!entry) {
-      return;
-    }
-
-    entry.generation += 1;
-    entry.pendingStatus = null;
-    if (entry.timer) {
-      clearTimeout(entry.timer);
-      entry.timer = null;
-    }
+    if (!entry) return;
+    this.#cancelPending(entry);
     this.#state.delete(key);
   }
 
-  #dispatch(userId: string, key: string, status: BridgeStatus): void {
-    const entry = this.#getOrCreateEntry(key);
-
-    if (status === entry.pendingStatus) {
-      return;
-    }
-
-    if (entry.timer) {
-      clearTimeout(entry.timer);
-      entry.timer = null;
-      entry.pendingStatus = null;
-    }
-
-    if (status === entry.lastNotifiedStatus) {
-      return;
-    }
-
-    entry.generation += 1;
-    const capturedGeneration = entry.generation;
-    entry.pendingStatus = status;
-    entry.timer = setTimeout(() => {
-      if (entry.generation !== capturedGeneration) {
-        return;
-      }
-
-      const callback = this.#runCallback({ entry, capturedGeneration, userId, status });
-      this.#inFlight.add(callback);
-      void callback.finally(() => {
-        this.#inFlight.delete(callback);
-      });
-    }, this.#debounceMs);
-    // A pending debounce must not keep the process alive on shutdown
-    // (dispose() is not on every exit path). Optional call: the mocked
-    // timers used in tests do not implement unref.
-    entry.timer.unref?.();
+  #schedule(args: {
+    entry: BridgeStateEntry;
+    userId: string;
+    status: BridgeStatus;
+    connectionId: string | null;
+    policy: BridgeConnectionNotificationPolicy;
+    delay: number;
+  }): void {
+    args.entry.generation += 1;
+    const generation = args.entry.generation;
+    const pending: PendingNotification = {
+      status: args.status,
+      connectionId: args.connectionId,
+      policy: args.policy,
+      excludedDeviceIds: new Set<string>(),
+      generation,
+      timer: setTimeout(() => {
+        if (args.entry.pending !== pending || pending.generation !== generation) return;
+        const callback = this.#send({ entry: args.entry, pending, userId: args.userId });
+        this.#inFlight.add(callback);
+        void callback.finally(() => this.#inFlight.delete(callback));
+      }, args.delay),
+    };
+    pending.timer.unref?.();
+    args.entry.pending = pending;
   }
 
-  async #runCallback(args: {
-    readonly entry: BridgeStateEntry;
-    readonly capturedGeneration: number;
-    readonly userId: string;
-    readonly status: BridgeStatus;
-  }): Promise<void> {
-    const { entry, capturedGeneration, userId, status } = args;
-    // No `#accepting` re-check here, deliberately. This runs synchronously up to
-    // the send, and `dispose()` clears `#accepting`, every timer and the whole
-    // map synchronously before its first await — so a callback either started
-    // before dispose (and must be drained, which is what `#inFlight` is for) or
-    // its timer was cancelled and it never starts. A guard would have read as
-    // live shutdown handling while being unreachable, and the `finally` that
-    // re-cleared `#state` only ever cleared a map dispose had already emptied.
+  async #send(args: { entry: BridgeStateEntry; pending: PendingNotification; userId: string }): Promise<void> {
     try {
-      await this.#notificationService.sendToUser(userId, this.#buildPayload(status));
+      await this.#notificationService.sendToUser(
+        args.userId,
+        this.#buildPayload(args.pending.status, new Set(args.pending.excludedDeviceIds)),
+      );
     } catch (err) {
-      console.warn("Bridge notification failed", { userId, status, err });
+      console.warn("Bridge notification failed", { userId: args.userId, status: args.pending.status, err });
     } finally {
-      if (entry.generation === capturedGeneration) {
-        entry.lastNotifiedStatus = status;
-        entry.pendingStatus = null;
-        entry.timer = null;
+      if (args.entry.pending === args.pending) {
+        args.entry.lastNotifiedStatus = args.pending.status;
+        args.entry.pending = null;
       }
     }
+  }
+
+  #cancelPending(entry: BridgeStateEntry): void {
+    if (!entry.pending) return;
+    clearTimeout(entry.pending.timer);
+    entry.pending = null;
+    entry.generation += 1;
   }
 
   dispose(): Promise<void> {
@@ -152,57 +161,38 @@ export class BridgeStateTracker {
   }
 
   async #disposeOnce(): Promise<void> {
-    for (const entry of this.#state.values()) {
-      if (entry.timer) {
-        clearTimeout(entry.timer);
-        entry.timer = null;
-      }
-    }
-
+    for (const entry of this.#state.values()) this.#cancelPending(entry);
     this.#state.clear();
     const callbacks = Array.from(this.#inFlight);
-    if (callbacks.length === 0) {
-      return;
-    }
-
+    if (callbacks.length === 0) return;
     await withDisposeTimeout(Promise.allSettled(callbacks).then(() => undefined));
-    if (this.#inFlight.size > 0) {
-      throw new BridgeStateTrackerDrainTimeout();
-    }
+    if (this.#inFlight.size > 0) throw new BridgeStateTrackerDrainTimeout();
   }
 
   #getOrCreateEntry(key: string): BridgeStateEntry {
-    const existingEntry = this.#state.get(key);
-    if (existingEntry) {
-      return existingEntry;
-    }
-
-    const entry: BridgeStateEntry = {
-      pendingStatus: null,
-      lastNotifiedStatus: null,
-      timer: null,
-      generation: 0,
-    };
+    const existing = this.#state.get(key);
+    if (existing) return existing;
+    const entry: BridgeStateEntry = { pending: null, lastNotifiedStatus: null, generation: 0 };
     this.#state.set(key, entry);
     return entry;
   }
 
-  #buildPayload(status: BridgeStatus): NotificationPayload {
-    if (status === BridgeStatus.active) {
-      return {
-        category: NotificationCategory.ConnectionStatus,
-        title: "Bridge Online",
-        body: "Your bridge has reconnected.",
-        collapseKey: "connection_status",
-      };
-    }
-
-    return {
-      category: NotificationCategory.ConnectionStatus,
-      title: "Bridge Offline",
-      body: "Your bridge has disconnected. AI sessions are paused.",
-      collapseKey: "connection_status",
-    };
+  #buildPayload(status: BridgeStatus, excludedDeviceIds: ReadonlySet<string>): ConnectionStatusNotificationPayload {
+    return status === BridgeStatus.active
+      ? {
+          category: NotificationCategory.ConnectionStatus,
+          title: "Bridge Online",
+          body: "Your bridge has reconnected.",
+          collapseKey: "connection_status",
+          excludedDeviceIds,
+        }
+      : {
+          category: NotificationCategory.ConnectionStatus,
+          title: "Bridge Offline",
+          body: "Your bridge has disconnected. AI sessions are paused.",
+          collapseKey: "connection_status",
+          excludedDeviceIds,
+        };
   }
 }
 

--- a/src/services/bridge-state-tracker.ts
+++ b/src/services/bridge-state-tracker.ts
@@ -15,8 +15,14 @@ type PendingNotification = {
   generation: number;
 };
 
+type EarlyConnectionObservation = {
+  connectionId: string;
+  deviceIds: Set<string>;
+};
+
 type BridgeStateEntry = {
   pending: PendingNotification | null;
+  earlyConnectionObservation: EarlyConnectionObservation | null;
   lastNotifiedStatus: BridgeStatus | null;
   generation: number;
 };
@@ -90,9 +96,17 @@ export class BridgeStateTracker {
 
   markConnectionObserved(args: { userId: string; bridgeId: string; connectionId: string; deviceId: string }): void {
     if (!this.#accepting) return;
-    const pending = this.#state.get(instanceKey(args))?.pending;
-    if (pending?.status !== BridgeStatus.active || pending.connectionId !== args.connectionId) return;
-    pending.excludedDeviceIds.add(args.deviceId);
+    const entry = this.#getOrCreateEntry(instanceKey(args));
+    const pending = entry.pending;
+    if (pending?.status === BridgeStatus.active && pending.connectionId === args.connectionId) {
+      pending.excludedDeviceIds.add(args.deviceId);
+      return;
+    }
+
+    if (entry.earlyConnectionObservation?.connectionId !== args.connectionId) {
+      entry.earlyConnectionObservation = { connectionId: args.connectionId, deviceIds: new Set<string>() };
+    }
+    entry.earlyConnectionObservation.deviceIds.add(args.deviceId);
   }
 
   cancelPendingForBridge(userId: string, bridgeId: string): void {
@@ -114,11 +128,17 @@ export class BridgeStateTracker {
   }): void {
     args.entry.generation += 1;
     const generation = args.entry.generation;
+    const earlyObservation = args.entry.earlyConnectionObservation;
+    const excludedDeviceIds =
+      args.status === BridgeStatus.active && earlyObservation?.connectionId === args.connectionId
+        ? new Set(earlyObservation.deviceIds)
+        : new Set<string>();
+    if (args.status === BridgeStatus.active) args.entry.earlyConnectionObservation = null;
     const pending: PendingNotification = {
       status: args.status,
       connectionId: args.connectionId,
       policy: args.policy,
-      excludedDeviceIds: new Set<string>(),
+      excludedDeviceIds,
       generation,
       timer: setTimeout(() => {
         if (args.entry.pending !== pending || pending.generation !== generation) return;
@@ -172,7 +192,12 @@ export class BridgeStateTracker {
   #getOrCreateEntry(key: string): BridgeStateEntry {
     const existing = this.#state.get(key);
     if (existing) return existing;
-    const entry: BridgeStateEntry = { pending: null, lastNotifiedStatus: null, generation: 0 };
+    const entry: BridgeStateEntry = {
+      pending: null,
+      earlyConnectionObservation: null,
+      lastNotifiedStatus: null,
+      generation: 0,
+    };
     this.#state.set(key, entry);
     return entry;
   }

--- a/src/services/notification-service.ts
+++ b/src/services/notification-service.ts
@@ -12,13 +12,23 @@ export interface NotificationData {
   projectId?: string | null;
 }
 
-export interface NotificationPayload {
-  category: NotificationCategory;
+interface BaseNotificationPayload {
   title: string;
   body: string;
   collapseKey?: string | null;
   data?: NotificationData | null;
 }
+
+export interface ConnectionStatusNotificationPayload extends BaseNotificationPayload {
+  category: NotificationCategory.ConnectionStatus;
+  excludedDeviceIds: ReadonlySet<string>;
+}
+
+export interface OtherNotificationPayload extends BaseNotificationPayload {
+  category: Exclude<NotificationCategory, NotificationCategory.ConnectionStatus>;
+}
+
+export type NotificationPayload = ConnectionStatusNotificationPayload | OtherNotificationPayload;
 
 export interface NotificationSettingsResolver {
   resolveNotificationsByDevice(userId: string): Promise<Map<string, NotificationSettings>>;
@@ -95,7 +105,11 @@ export class NotificationService {
       return { devicesNotified: 0, retryableFailures: 0 };
     }
 
-    const deliverableTokens = await this.#selectOptedInTokens(userId, tokens, payload.category);
+    const eligibleTokens =
+      payload.category === NotificationCategory.ConnectionStatus
+        ? tokens.filter((token) => !token.deviceId || !payload.excludedDeviceIds.has(token.deviceId))
+        : tokens;
+    const deliverableTokens = await this.#selectOptedInTokens(userId, eligibleTokens, payload.category);
     abortSignal?.throwIfAborted();
     if (deliverableTokens.length === 0) {
       return { devicesNotified: 0, retryableFailures: 0 };

--- a/src/services/notification-service.ts
+++ b/src/services/notification-service.ts
@@ -105,12 +105,14 @@ export class NotificationService {
       return { devicesNotified: 0, retryableFailures: 0 };
     }
 
-    const eligibleTokens =
-      payload.category === NotificationCategory.ConnectionStatus
-        ? tokens.filter((token) => !token.deviceId || !payload.excludedDeviceIds.has(token.deviceId))
-        : tokens;
-    const deliverableTokens = await this.#selectOptedInTokens(userId, eligibleTokens, payload.category);
+    const optedInTokens = await this.#selectOptedInTokens(userId, tokens, payload.category);
     abortSignal?.throwIfAborted();
+    // Observations may arrive during either lookup. Read their live exclusion
+    // set after the final await before submitting messages to FCM.
+    const deliverableTokens =
+      payload.category === NotificationCategory.ConnectionStatus
+        ? optedInTokens.filter((token) => !token.deviceId || !payload.excludedDeviceIds.has(token.deviceId))
+        : optedInTokens;
     if (deliverableTokens.length === 0) {
       return { devicesNotified: 0, retryableFailures: 0 };
     }
@@ -121,9 +123,15 @@ export class NotificationService {
     // device opted out of — or a server-only one — after filtering already ran.
     const flatData: Record<string, string> = { category: payload.category };
     if (payload.data) {
-      if (payload.data.eventType) flatData["eventType"] = payload.data.eventType;
-      if (payload.data.sessionId) flatData["sessionId"] = payload.data.sessionId;
-      if (payload.data.projectId) flatData["projectId"] = payload.data.projectId;
+      if (payload.data.eventType) {
+        flatData["eventType"] = payload.data.eventType;
+      }
+      if (payload.data.sessionId) {
+        flatData["sessionId"] = payload.data.sessionId;
+      }
+      if (payload.data.projectId) {
+        flatData["projectId"] = payload.data.projectId;
+      }
     }
 
     const messages: Array<BaseMessage & { token: string }> = deliverableTokens.map((t) => ({

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -213,7 +213,7 @@ export async function createTestApp(overrides?: TestAppOverrides): Promise<TestC
   const settingsService = overrides?.settingsService ?? new SettingsService({ settingsRepo });
   const notificationService =
     overrides?.notificationService ?? new NotificationService(deviceTokenRepo, null, settingsService);
-  const bridgeStateTracker = overrides?.bridgeStateTracker ?? new BridgeStateTracker(notificationService);
+  const bridgeStateTracker = overrides?.bridgeStateTracker ?? new BridgeStateTracker({ notificationService });
   const bridgeService = overrides?.bridgeService ?? new BridgeService({ bridgeRepo, glossaryRepo, bridgeStateTracker });
   const activationService =
     overrides?.activationService ??

--- a/tests/notifications/bridge-darkwake-policy.test.ts
+++ b/tests/notifications/bridge-darkwake-policy.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it, mock } from "node:test";
 import { BridgeConnectionNotificationPolicy, BridgeStatus } from "../../src/models/bridge.js";
 import { BridgeStateTracker } from "../../src/services/bridge-state-tracker.js";
-import type { NotificationPayload, NotificationService } from "../../src/services/notification-service.js";
+import type { Messaging } from "firebase-admin/messaging";
+import type { DeviceTokenRepository } from "../../src/repositories/device-token-repo.js";
+import { NotificationService, type NotificationPayload } from "../../src/services/notification-service.js";
 
 const bridgeId = "br_bridge0001";
 const connectionId = "0123456789abcdef0123456789abcdef";
@@ -116,9 +118,117 @@ describe("BridgeStateTracker DarkWake policy", () => {
     assert.equal(calls.length, 1);
     const payload = calls[0];
     assert.equal(payload.category, "connection_status");
-    if (payload.category === "connection_status")
+    if (payload.category === "connection_status") {
       assert.deepEqual([...payload.excludedDeviceIds], ["123e4567-e89b-42d3-a456-426614174000"]);
+    }
   });
+
+  for (const scenario of [
+    { name: "same-connection full-wake promotion", observeEarly: false, initialConnectionId: connectionId },
+    {
+      name: "an earlier connection report arriving before the observed connection",
+      observeEarly: true,
+      initialConnectionId: "1123456789abcdef0123456789abcdef",
+    },
+  ]) {
+    it(`preserves exclusions through ${scenario.name}`, async () => {
+      const calls: NotificationPayload[] = [];
+      const notificationService = {
+        sendToUser: async (_: string, payload: NotificationPayload) => {
+          calls.push(payload);
+          return { devicesNotified: 1, retryableFailures: 0 };
+        },
+      } as NotificationService;
+      const tracker = new BridgeStateTracker({ notificationService, conservativeDelayMs: 100, normalOnlineDelayMs: 5 });
+      const observation = { userId: "u", bridgeId, connectionId, deviceId: "123e4567-e89b-42d3-a456-426614174000" };
+      if (scenario.observeEarly) {
+        tracker.markConnectionObserved(observation);
+      }
+      tracker.handleStatusChangeForBridge({
+        userId: "u",
+        bridgeId,
+        status: BridgeStatus.active,
+        notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+        connectionId: scenario.initialConnectionId,
+      });
+      if (!scenario.observeEarly) {
+        tracker.markConnectionObserved(observation);
+      }
+      tracker.handleStatusChangeForBridge({
+        userId: "u",
+        bridgeId,
+        status: BridgeStatus.active,
+        notificationPolicy: BridgeConnectionNotificationPolicy.Normal,
+        connectionId,
+      });
+      mock.timers.tick(5);
+      await flush();
+      assert.equal(calls.length, 1);
+      const payload = calls[0];
+      assert.equal(payload.category, "connection_status");
+      if (payload.category === "connection_status") {
+        assert.deepEqual([...payload.excludedDeviceIds], [observation.deviceId]);
+      }
+      await tracker.dispose();
+    });
+  }
+
+  for (const blockedLookup of ["tokens", "settings"]) {
+    it(`honors observations received while awaiting ${blockedLookup} before FCM submission`, async () => {
+      const deviceId = "123e4567-e89b-42d3-a456-426614174000";
+      const messages: unknown[][] = [];
+      let release: () => void = () => assert.fail("lookup gate was not initialized");
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const notificationService = new NotificationService(
+        {
+          findByUserId: async () => {
+            if (blockedLookup === "tokens") {
+              await gate;
+            }
+            return [
+              { token: "observing-phone", deviceId },
+              { token: "other-phone", deviceId: null },
+            ];
+          },
+        } as unknown as DeviceTokenRepository,
+        {
+          sendEach: async (batch: unknown[]) => {
+            messages.push(batch);
+            return { successCount: batch.length, responses: batch.map(() => ({ success: true })) };
+          },
+        } as unknown as Messaging,
+        {
+          resolveNotificationsByDevice: async () => {
+            if (blockedLookup === "settings") {
+              await gate;
+            }
+            return new Map();
+          },
+        },
+      );
+      const tracker = new BridgeStateTracker({ notificationService, normalOnlineDelayMs: 5 });
+      tracker.handleStatusChangeForBridge({
+        userId: "u",
+        bridgeId,
+        status: BridgeStatus.active,
+        notificationPolicy: BridgeConnectionNotificationPolicy.Normal,
+        connectionId,
+      });
+      mock.timers.tick(5);
+      await flush();
+      assert.deepEqual(messages, []);
+      tracker.markConnectionObserved({ userId: "u", bridgeId, connectionId, deviceId });
+      release();
+      await flush();
+      assert.deepEqual(
+        messages.flat().map((message) => (message as { token: string }).token),
+        ["other-phone"],
+      );
+      await tracker.dispose();
+    });
+  }
 
   it("full wake on the same socket schedules fast online and exact-device exclusion", async () => {
     const calls: NotificationPayload[] = [];
@@ -154,7 +264,8 @@ describe("BridgeStateTracker DarkWake policy", () => {
     assert.equal(calls.length, 1);
     const payload = calls[0];
     assert.equal(payload.category, "connection_status");
-    if (payload.category === "connection_status")
+    if (payload.category === "connection_status") {
       assert.deepEqual([...payload.excludedDeviceIds], ["123e4567-e89b-42d3-a456-426614174000"]);
+    }
   });
 });

--- a/tests/notifications/bridge-darkwake-policy.test.ts
+++ b/tests/notifications/bridge-darkwake-policy.test.ts
@@ -57,6 +57,69 @@ describe("BridgeStateTracker DarkWake policy", () => {
     assert.equal(calls[1].title, "Bridge Offline");
   });
 
+  it("keeps a DarkWake-only suppress connection episode quiet", async () => {
+    const calls: NotificationPayload[] = [];
+    const notificationService = {
+      sendToUser: async (_: string, payload: NotificationPayload) => {
+        calls.push(payload);
+        return { devicesNotified: 1, retryableFailures: 0 };
+      },
+    } as NotificationService;
+    const tracker = new BridgeStateTracker({ notificationService, conservativeDelayMs: 100, normalOnlineDelayMs: 5 });
+    tracker.handleStatusChangeForBridge({
+      userId: "u",
+      bridgeId,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Suppress,
+      connectionId,
+    });
+    tracker.handleStatusChangeForBridge({
+      userId: "u",
+      bridgeId,
+      status: BridgeStatus.inactive,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Suppress,
+      connectionId,
+    });
+
+    mock.timers.tick(100);
+    await flush();
+
+    assert.deepEqual(calls, []);
+  });
+
+  it("buffers exact-device observation when relay delivery beats connected status", async () => {
+    const calls: NotificationPayload[] = [];
+    const notificationService = {
+      sendToUser: async (_: string, payload: NotificationPayload) => {
+        calls.push(payload);
+        return { devicesNotified: 1, retryableFailures: 0 };
+      },
+    } as NotificationService;
+    const tracker = new BridgeStateTracker({ notificationService, conservativeDelayMs: 100, normalOnlineDelayMs: 5 });
+    tracker.markConnectionObserved({
+      userId: "u",
+      bridgeId,
+      connectionId,
+      deviceId: "123e4567-e89b-42d3-a456-426614174000",
+    });
+    tracker.handleStatusChangeForBridge({
+      userId: "u",
+      bridgeId,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Normal,
+      connectionId,
+    });
+
+    mock.timers.tick(5);
+    await flush();
+
+    assert.equal(calls.length, 1);
+    const payload = calls[0];
+    assert.equal(payload.category, "connection_status");
+    if (payload.category === "connection_status")
+      assert.deepEqual([...payload.excludedDeviceIds], ["123e4567-e89b-42d3-a456-426614174000"]);
+  });
+
   it("full wake on the same socket schedules fast online and exact-device exclusion", async () => {
     const calls: NotificationPayload[] = [];
     const notificationService = {

--- a/tests/notifications/bridge-darkwake-policy.test.ts
+++ b/tests/notifications/bridge-darkwake-policy.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it, mock } from "node:test";
+import { BridgeConnectionNotificationPolicy, BridgeStatus } from "../../src/models/bridge.js";
+import { BridgeStateTracker } from "../../src/services/bridge-state-tracker.js";
+import type { NotificationPayload, NotificationService } from "../../src/services/notification-service.js";
+
+const bridgeId = "br_bridge0001";
+const connectionId = "0123456789abcdef0123456789abcdef";
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+describe("BridgeStateTracker DarkWake policy", () => {
+  beforeEach(() => mock.timers.enable({ apis: ["setTimeout"] }));
+  afterEach(() => mock.timers.reset());
+
+  it("suppresses a sleep-only episode without clearing a genuine pending offline", async () => {
+    const calls: NotificationPayload[] = [];
+    const notificationService = {
+      sendToUser: async (_: string, payload: NotificationPayload) => {
+        calls.push(payload);
+        return { devicesNotified: 1, retryableFailures: 0 };
+      },
+    } as NotificationService;
+    const tracker = new BridgeStateTracker({ notificationService, conservativeDelayMs: 100, normalOnlineDelayMs: 5 });
+    tracker.handleStatusChangeForBridge({
+      userId: "u",
+      bridgeId,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Normal,
+      connectionId,
+    });
+    mock.timers.tick(5);
+    await flush();
+    tracker.handleStatusChangeForBridge({
+      userId: "u",
+      bridgeId,
+      status: BridgeStatus.inactive,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId,
+    });
+    tracker.handleStatusChangeForBridge({
+      userId: "u",
+      bridgeId,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Suppress,
+      connectionId: "1123456789abcdef0123456789abcdef",
+    });
+    tracker.handleStatusChangeForBridge({
+      userId: "u",
+      bridgeId,
+      status: BridgeStatus.inactive,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Suppress,
+      connectionId: "1123456789abcdef0123456789abcdef",
+    });
+    mock.timers.tick(100);
+    await flush();
+    assert.equal(calls.length, 2);
+    assert.equal(calls[1].title, "Bridge Offline");
+  });
+
+  it("full wake on the same socket schedules fast online and exact-device exclusion", async () => {
+    const calls: NotificationPayload[] = [];
+    const notificationService = {
+      sendToUser: async (_: string, payload: NotificationPayload) => {
+        calls.push(payload);
+        return { devicesNotified: 1, retryableFailures: 0 };
+      },
+    } as NotificationService;
+    const tracker = new BridgeStateTracker({ notificationService, conservativeDelayMs: 100, normalOnlineDelayMs: 5 });
+    tracker.handleStatusChangeForBridge({
+      userId: "u",
+      bridgeId,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Suppress,
+      connectionId,
+    });
+    tracker.handleStatusChangeForBridge({
+      userId: "u",
+      bridgeId,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Normal,
+      connectionId,
+    });
+    tracker.markConnectionObserved({
+      userId: "u",
+      bridgeId,
+      connectionId,
+      deviceId: "123e4567-e89b-42d3-a456-426614174000",
+    });
+    mock.timers.tick(5);
+    await flush();
+    assert.equal(calls.length, 1);
+    const payload = calls[0];
+    assert.equal(payload.category, "connection_status");
+    if (payload.category === "connection_status")
+      assert.deepEqual([...payload.excludedDeviceIds], ["123e4567-e89b-42d3-a456-426614174000"]);
+  });
+});

--- a/tests/notifications/bridge-state-tracker.test.ts
+++ b/tests/notifications/bridge-state-tracker.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it, mock } from "node:test";
-import { BridgeStatus } from "../../src/models/bridge.js";
+import { BridgeConnectionNotificationPolicy, BridgeStatus } from "../../src/models/bridge.js";
 import { NotificationCategory } from "../../src/models/notification.js";
 import { BridgeStateTracker } from "../../src/services/bridge-state-tracker.js";
 import type { NotificationPayload, NotificationService } from "../../src/services/notification-service.js";
@@ -41,6 +41,7 @@ function connectedPayload(): NotificationPayload {
     title: "Bridge Online",
     body: "Your bridge has reconnected.",
     collapseKey: "connection_status",
+    excludedDeviceIds: new Set<string>(),
   };
 }
 
@@ -50,6 +51,7 @@ function disconnectedPayload(): NotificationPayload {
     title: "Bridge Offline",
     body: "Your bridge has disconnected. AI sessions are paused.",
     collapseKey: "connection_status",
+    excludedDeviceIds: new Set<string>(),
   };
 }
 
@@ -70,9 +72,15 @@ describe("BridgeStateTracker", () => {
         return { devicesNotified: 1 };
       },
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock);
+    const tracker = new BridgeStateTracker({ notificationService: notificationServiceMock });
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
 
     mock.timers.tick(HALF_DEBOUNCE_MS);
     await flushMicrotasks();
@@ -93,9 +101,18 @@ describe("BridgeStateTracker", () => {
         return { devicesNotified: 1 };
       },
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+    const tracker = new BridgeStateTracker({
+      notificationService: notificationServiceMock,
+      conservativeDelayMs: DEBOUNCE_MS,
+    });
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
 
     mock.timers.tick(HALF_DEBOUNCE_MS);
     await flushMicrotasks();
@@ -116,9 +133,18 @@ describe("BridgeStateTracker", () => {
         return { devicesNotified: 1 };
       },
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+    const tracker = new BridgeStateTracker({
+      notificationService: notificationServiceMock,
+      conservativeDelayMs: DEBOUNCE_MS,
+    });
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.inactive);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.inactive,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
 
     mock.timers.tick(HALF_DEBOUNCE_MS);
     await flushMicrotasks();
@@ -139,13 +165,34 @@ describe("BridgeStateTracker", () => {
         return { devicesNotified: 1 };
       },
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+    const tracker = new BridgeStateTracker({
+      notificationService: notificationServiceMock,
+      conservativeDelayMs: DEBOUNCE_MS,
+    });
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(HALF_DEBOUNCE_MS);
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.inactive);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.inactive,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(HALF_DEBOUNCE_MS);
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
 
     mock.timers.tick(DEBOUNCE_MS);
     await flushMicrotasks();
@@ -162,15 +209,42 @@ describe("BridgeStateTracker", () => {
         return { devicesNotified: 1 };
       },
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+    const tracker = new BridgeStateTracker({
+      notificationService: notificationServiceMock,
+      conservativeDelayMs: DEBOUNCE_MS,
+    });
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(5_000);
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.inactive);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.inactive,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(5_000);
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(5_000);
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.inactive);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.inactive,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
 
     mock.timers.tick(DEBOUNCE_MS);
     await flushMicrotasks();
@@ -186,11 +260,26 @@ describe("BridgeStateTracker", () => {
         return { devicesNotified: 1 };
       },
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+    const tracker = new BridgeStateTracker({
+      notificationService: notificationServiceMock,
+      conservativeDelayMs: DEBOUNCE_MS,
+    });
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(HALF_DEBOUNCE_MS);
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(HALF_DEBOUNCE_MS);
     await flushMicrotasks();
 
@@ -205,13 +294,28 @@ describe("BridgeStateTracker", () => {
         return { devicesNotified: 1 };
       },
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+    const tracker = new BridgeStateTracker({
+      notificationService: notificationServiceMock,
+      conservativeDelayMs: DEBOUNCE_MS,
+    });
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(DEBOUNCE_MS);
     await flushMicrotasks();
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(DEBOUNCE_MS);
     await flushMicrotasks();
 
@@ -226,10 +330,25 @@ describe("BridgeStateTracker", () => {
         return { devicesNotified: 1 };
       },
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+    const tracker = new BridgeStateTracker({
+      notificationService: notificationServiceMock,
+      conservativeDelayMs: DEBOUNCE_MS,
+    });
 
-    tracker.handleStatusChangeForBridge("user-a", BRIDGE_ID, BridgeStatus.active);
-    tracker.handleStatusChangeForBridge("user-b", BRIDGE_ID, BridgeStatus.inactive);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-a",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
+    tracker.handleStatusChangeForBridge({
+      userId: "user-b",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.inactive,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
 
     mock.timers.tick(DEBOUNCE_MS);
     await flushMicrotasks();
@@ -248,15 +367,36 @@ describe("BridgeStateTracker", () => {
         return { devicesNotified: 1 };
       },
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+    const tracker = new BridgeStateTracker({
+      notificationService: notificationServiceMock,
+      conservativeDelayMs: DEBOUNCE_MS,
+    });
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(DEBOUNCE_MS);
     await flushMicrotasks();
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.inactive);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.inactive,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(HALF_DEBOUNCE_MS);
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(DEBOUNCE_MS);
     await flushMicrotasks();
 
@@ -271,11 +411,32 @@ describe("BridgeStateTracker", () => {
         return { devicesNotified: 1 };
       },
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+    const tracker = new BridgeStateTracker({
+      notificationService: notificationServiceMock,
+      conservativeDelayMs: DEBOUNCE_MS,
+    });
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
-    tracker.handleStatusChangeForBridge("user-2", BRIDGE_ID, BridgeStatus.inactive);
-    tracker.handleStatusChangeForBridge("user-3", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
+    tracker.handleStatusChangeForBridge({
+      userId: "user-2",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.inactive,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
+    tracker.handleStatusChangeForBridge({
+      userId: "user-3",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     await tracker.dispose();
 
     mock.timers.tick(DEBOUNCE_MS);
@@ -292,10 +453,25 @@ describe("BridgeStateTracker", () => {
         return { devicesNotified: 1 };
       },
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+    const tracker = new BridgeStateTracker({
+      notificationService: notificationServiceMock,
+      conservativeDelayMs: DEBOUNCE_MS,
+    });
 
-    tracker.handleStatusChangeForBridge("user-1", "br_target0001", BridgeStatus.inactive);
-    tracker.handleStatusChangeForBridge("user-1", "br_other0001", BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: "br_target0001",
+      status: BridgeStatus.inactive,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: "br_other0001",
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     tracker.cancelPendingForBridge("user-1", "br_target0001");
 
     mock.timers.tick(DEBOUNCE_MS);
@@ -312,10 +488,25 @@ describe("BridgeStateTracker", () => {
         return { devicesNotified: 1 };
       },
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+    const tracker = new BridgeStateTracker({
+      notificationService: notificationServiceMock,
+      conservativeDelayMs: DEBOUNCE_MS,
+    });
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
-    tracker.handleStatusChangeForBridge("user-2", BRIDGE_ID, BridgeStatus.inactive);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
+    tracker.handleStatusChangeForBridge({
+      userId: "user-2",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.inactive,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(DEBOUNCE_MS);
     await flushMicrotasks();
 
@@ -338,14 +529,29 @@ describe("BridgeStateTracker", () => {
         return { devicesNotified: 1 };
       },
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+    const tracker = new BridgeStateTracker({
+      notificationService: notificationServiceMock,
+      conservativeDelayMs: DEBOUNCE_MS,
+    });
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(DEBOUNCE_MS);
     await flushMicrotasks();
 
     shouldReject = false;
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.inactive);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.inactive,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(DEBOUNCE_MS);
     await flushMicrotasks();
 
@@ -371,12 +577,27 @@ describe("BridgeStateTracker", () => {
         return Promise.resolve({ devicesNotified: 1 });
       },
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+    const tracker = new BridgeStateTracker({
+      notificationService: notificationServiceMock,
+      conservativeDelayMs: DEBOUNCE_MS,
+    });
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(DEBOUNCE_MS);
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.inactive);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.inactive,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     firstSend.resolve({ devicesNotified: 1 });
     await flushMicrotasks();
 
@@ -398,9 +619,18 @@ describe("BridgeStateTracker", () => {
         return sendDeferred.promise;
       },
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+    const tracker = new BridgeStateTracker({
+      notificationService: notificationServiceMock,
+      conservativeDelayMs: DEBOUNCE_MS,
+    });
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     mock.timers.tick(DEBOUNCE_MS);
     await flushMicrotasks();
 
@@ -423,9 +653,15 @@ describe("BridgeStateTracker", () => {
     const notificationServiceMock = {
       sendToUser: () => sendDeferred.promise,
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, 1);
+    const tracker = new BridgeStateTracker({ notificationService: notificationServiceMock, conservativeDelayMs: 1 });
 
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     t.mock.timers.tick(1);
     await flushMicrotasks();
 
@@ -441,7 +677,10 @@ describe("BridgeStateTracker", () => {
     const notificationServiceMock = {
       sendToUser: async () => ({ devicesNotified: 1 }),
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+    const tracker = new BridgeStateTracker({
+      notificationService: notificationServiceMock,
+      conservativeDelayMs: DEBOUNCE_MS,
+    });
 
     const first = tracker.dispose();
     const second = tracker.dispose();
@@ -463,10 +702,19 @@ describe("BridgeStateTracker", () => {
         return { devicesNotified: 1 };
       },
     } as unknown as NotificationService;
-    const tracker = new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS);
+    const tracker = new BridgeStateTracker({
+      notificationService: notificationServiceMock,
+      conservativeDelayMs: DEBOUNCE_MS,
+    });
 
     await tracker.dispose();
-    tracker.handleStatusChangeForBridge("user-1", BRIDGE_ID, BridgeStatus.active);
+    tracker.handleStatusChangeForBridge({
+      userId: "user-1",
+      bridgeId: BRIDGE_ID,
+      status: BridgeStatus.active,
+      notificationPolicy: BridgeConnectionNotificationPolicy.Conservative,
+      connectionId: null,
+    });
     tracker.cancelPendingForBridge("user-1", BRIDGE_ID);
     mock.timers.tick(DEBOUNCE_MS);
     await flushMicrotasks();

--- a/tests/notifications/notification-category-filtering.test.ts
+++ b/tests/notifications/notification-category-filtering.test.ts
@@ -68,7 +68,10 @@ function createMockSettingsResolver(
 }
 
 function buildPayload(category: NotificationCategory): NotificationPayload {
-  return { category, title: "Title", body: "Body", collapseKey: null };
+  const content = { title: "Title", body: "Body", collapseKey: null };
+  return category === NotificationCategory.ConnectionStatus
+    ? { ...content, category, excludedDeviceIds: new Set<string>() }
+    : { ...content, category };
 }
 
 function sentTokens(calls: unknown[][]): string[] {

--- a/tests/notifications/routes.test.ts
+++ b/tests/notifications/routes.test.ts
@@ -42,8 +42,8 @@ describe("Notification routes", () => {
   } as unknown as NotificationService;
 
   const bridgeStateTrackerMock = {
-    handleStatusChangeForBridge: (userId: string, bridgeId: string, status: string) => {
-      trackerCalls.push({ userId, bridgeId, status });
+    handleStatusChangeForBridge: (args: TrackerCall) => {
+      trackerCalls.push(args);
     },
     cancelPendingForBridge: () => {},
     dispose: () => {},

--- a/tests/routes/bridges.test.ts
+++ b/tests/routes/bridges.test.ts
@@ -475,7 +475,10 @@ describe("bridge revocation cancels pending notifications (end to end)", () => {
     } as unknown as NotificationService;
     ctx = await createTestApp({
       notificationService: notificationServiceMock,
-      bridgeStateTracker: new BridgeStateTracker(notificationServiceMock, DEBOUNCE_MS),
+      bridgeStateTracker: new BridgeStateTracker({
+        notificationService: notificationServiceMock,
+        conservativeDelayMs: DEBOUNCE_MS,
+      }),
     });
   });
 

--- a/tests/services/bridge-service.test.ts
+++ b/tests/services/bridge-service.test.ts
@@ -74,3 +74,35 @@ describe("BridgeService glossary cleanup", () => {
     ]);
   });
 });
+
+describe("BridgeService connection observation", () => {
+  it("validates ownership without mutating persisted bridge status", async () => {
+    const events: string[] = [];
+    const service = createService({
+      bridgeRepo: {
+        findByIdForUser: async () => {
+          events.push("validate");
+          return { bridgeId: "br_bridge0001" };
+        },
+        recordStatusChange: async () => {
+          events.push("status");
+          throw new Error("must not mutate status");
+        },
+      },
+      glossaryRepo: {},
+      bridgeStateTracker: {
+        markConnectionObserved: () => events.push("observe"),
+      },
+    });
+
+    const result = await service.recordConnectionObservation({
+      userId: "user",
+      bridgeId: "br_bridge0001",
+      connectionId: "0123456789abcdef0123456789abcdef",
+      deviceId: "123e4567-e89b-42d3-a456-426614174000",
+    });
+
+    assert.deepEqual(result, { found: true });
+    assert.deepEqual(events, ["validate", "observe"]);
+  });
+});


### PR DESCRIPTION
## Complexity
⚙️ Moderate — separates ephemeral connection-notification policy and per-device observations from persisted bridge connectivity.

## What
- Accept notification-policy and exact-connection observation metadata from the relay while preserving legacy status reports.
- Suppress DarkWake-only connection notifications, preserve genuine offline debounce, and shorten confirmed full-wake online notifications to five seconds.
- Exclude a device that already observed the restored connection from its pending online push; observations do not mark the bridge active in the database.
- Keep unknown/legacy detection on the existing conservative policy and leave every non-connection notification category unchanged.

## Why
Temporary macOS maintenance wakes should not generate misleading online/offline pushes. Real wakes should not pay the existing two-minute online debounce.

## Risk and test focus
Medium: notification ordering, deduplication, early device observations, per-device exclusions, and mixed-version relay reports. Wake policy never controls bridge connectivity. Notification state remains process-local; missed signals and delivery races can affect push accuracy.

## Expected result
Connection-status pushes ignore DarkWake-only blips and arrive promptly after a reported full wake, unless the receiving device has already observed that connection. Genuine offline handling remains. No database schema change or migration; observations no longer mutate authoritative connectivity. No change to session, permission, question, or completion pushes.

## Verification
- `npm run build`
- `npx eslint src/ tests/`
- `npm run format:check`
- Targeted node:test suites: DarkWake policy, bridge-state tracker, notification routes, bridge routes, and bridge service.
- `git diff --check`

Real macOS sleep cycles and external push delivery were not exercised. This PR does not deploy anything.

## Rollout
Deploy **auth → relay → bridge/mobile**. Existing peers retain conservative behavior.

1. Auth: https://github.com/sesori-ai/sesori_auth_server/pull/90
2. Relay: https://github.com/sesori-ai/sesori_relay_server/pull/11
3. Bridge/mobile: https://github.com/sesori-ai/sesori_apps_monorepo/pull/1451
