### PR TITLE
feat(optional-email): add address suppression foundation

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import { clientIpSourceSchema, ClientIpSource, trustedIngressCidrsSchema } from 
 import { productAnalyticsPseudonymizationKeySchema } from "./types/product-analytics.js";
 import { isValidResendWebhookSigningSecret } from "./services/resend-webhook-verifier.js";
 import { OPTIONAL_EMAIL_MAX_DAILY_CAP, OptionalEmailRecipientBasis } from "./types/optional-email.js";
+import { OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_MIN_BYTES } from "./lib/optional-email-address-key.js";
 
 const appleConfigSchema = z.object({
   APPLE_CLIENT_ID: z.string().min(1, "APPLE_CLIENT_ID is required"),
@@ -97,6 +98,13 @@ const baseConfigSchema = z.object({
     .refine(
       (value) => Buffer.byteLength(value, "utf8") >= 32,
       "OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET must be at least 32 bytes",
+    )
+    .optional(),
+  OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_V1: z
+    .string()
+    .refine(
+      (value) => Buffer.byteLength(value, "utf8") >= OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_MIN_BYTES,
+      "OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_V1 must be at least 32 bytes",
     )
     .optional(),
   OPENAI_API_KEY: z.string().min(1, "OPENAI_API_KEY is required"),
@@ -194,6 +202,28 @@ const validatedConfigSchema = baseConfigSchema.superRefine((config, ctx) => {
       code: "custom",
       path: ["REALTIME_MAX_CONCURRENT_SESSIONS_PER_USER"],
       message: "REALTIME_MAX_CONCURRENT_SESSIONS_PER_USER cannot exceed REALTIME_MAX_CONCURRENT_SESSIONS",
+    });
+  }
+
+  const optionalEmailAddressKeySecret = config.OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_V1;
+  const optionalEmailAddressKeySecretBytes =
+    optionalEmailAddressKeySecret === undefined ? undefined : Buffer.from(optionalEmailAddressKeySecret, "utf8");
+  if (
+    optionalEmailAddressKeySecret !== undefined &&
+    optionalEmailAddressKeySecretBytes !== undefined &&
+    (optionalEmailAddressKeySecret === config.OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET ||
+      optionalEmailAddressKeySecret === config.RESEND_WEBHOOK_SECRET ||
+      (config.RESEND_WEBHOOK_SECRET !== undefined &&
+        isValidResendWebhookSigningSecret(config.RESEND_WEBHOOK_SECRET) &&
+        optionalEmailAddressKeySecretBytes.equals(
+          Buffer.from(config.RESEND_WEBHOOK_SECRET.slice("whsec_".length), "base64"),
+        )) ||
+      optionalEmailAddressKeySecretBytes.equals(config.PRODUCT_ANALYTICS_PSEUDONYMIZATION_KEY))
+  ) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_V1"],
+      message: "OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_V1 must be purpose-specific and independent",
     });
   }
 

--- a/src/db/mongo-db-accessor.ts
+++ b/src/db/mongo-db-accessor.ts
@@ -68,6 +68,9 @@ const DATABASE_CONFIG: Record<MongoDbDatabase, DatabaseConfig<string>> = {
       // enforces that invariant and serves the sole read path (findByUserAndDevice).
       [AuthDbCollection.SettingsConfiguration]: [{ spec: { userId: 1, deviceId: 1 }, options: { unique: true } }],
       [AuthDbCollection.OptionalEmailPreferences]: [{ spec: { userId: 1 }, options: { unique: true } }],
+      [AuthDbCollection.OptionalEmailAddressSuppressions]: [
+        { spec: { addressKeyVersion: 1, addressKey: 1 }, options: { unique: true } },
+      ],
       [AuthDbCollection.OptionalEmailWebhookEvents]: [{ spec: { eventId: 1 }, options: { unique: true } }],
       [AuthDbCollection.OptionalEmailSends]: [
         { spec: { sendKey: 1 }, options: { unique: true } },

--- a/src/lib/optional-email-address-key.ts
+++ b/src/lib/optional-email-address-key.ts
@@ -1,0 +1,46 @@
+import { createHmac } from "node:crypto";
+import { z } from "zod";
+import { InternalServerError } from "./errors.js";
+import { type OptionalEmailAddressKey, OptionalEmailAddressKeyVersion } from "../types/optional-email.js";
+
+const normalizedOptionalEmailAddressSchema = z
+  .string()
+  .trim()
+  .email()
+  .transform((value) => value.toLowerCase());
+
+const OPTIONAL_EMAIL_ADDRESS_KEY_PURPOSE = "optional_email_address_suppression";
+export const OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_MIN_BYTES = 32;
+
+export function normalizeOptionalEmailAddress(input: { address: unknown }): string | null {
+  const parsed = normalizedOptionalEmailAddressSchema.safeParse(input.address);
+  return parsed.success ? parsed.data : null;
+}
+
+/**
+ * Derives a purpose- and version-separated key from the same conservative
+ * normalization used by recipient resolution. Rotating the secret requires a
+ * new version; suppression checks must derive every retained version.
+ */
+export function deriveOptionalEmailAddressKey(input: {
+  address: string;
+  secret: string;
+  version: OptionalEmailAddressKeyVersion;
+}): OptionalEmailAddressKey {
+  const normalizedAddress = normalizeOptionalEmailAddress({ address: input.address });
+  if (!Object.values(OptionalEmailAddressKeyVersion).includes(input.version)) {
+    throw new InternalServerError({ debugMessage: "Invalid optional email address-key version" });
+  }
+  if (normalizedAddress === null) {
+    throw new InternalServerError({ debugMessage: "Invalid optional email address-key address" });
+  }
+  if (Buffer.byteLength(input.secret, "utf8") < OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_MIN_BYTES) {
+    throw new InternalServerError({ debugMessage: "Invalid optional email address-key secret" });
+  }
+
+  const message = `${OPTIONAL_EMAIL_ADDRESS_KEY_PURPOSE}\0${input.version}\0${normalizedAddress}`;
+  return {
+    addressKeyVersion: input.version,
+    addressKey: createHmac("sha256", input.secret).update(message, "utf8").digest("hex"),
+  };
+}

--- a/src/models/documents.ts
+++ b/src/models/documents.ts
@@ -10,6 +10,7 @@ import {
 } from "../types/product-analytics.js";
 import { normalizedGlossaryWordSchema, projectGlossaryScopeSchema } from "./voice.js";
 import {
+  OptionalEmailAddressKeyVersion,
   OptionalEmailReminderKind,
   OptionalEmailSendBlockReason,
   OptionalEmailSendDeferralReason,
@@ -186,6 +187,41 @@ export const optionalEmailPreferenceSchema = z.object({
 });
 
 export type OptionalEmailPreference = z.infer<typeof optionalEmailPreferenceSchema>;
+
+/**
+ * Address-level optional-mail do-not-contact tombstone. It deliberately stores
+ * neither a raw address nor a user ID so it can outlive account deletion
+ * without retaining an account link.
+ */
+export const optionalEmailAddressSuppressionSchema = z
+  .object({
+    _id: z.instanceof(ObjectId),
+    addressKeyVersion: z.nativeEnum(OptionalEmailAddressKeyVersion),
+    addressKey: z.string().regex(/^[a-f0-9]{64}$/),
+    unsubscribedAt: z.date().optional(),
+    suppressedAt: z.date().optional(),
+    suppressionReason: z.nativeEnum(OptionalEmailSuppressionReason).optional(),
+    createdAt: z.date(),
+    updatedAt: z.date(),
+  })
+  .strict()
+  .superRefine((record, ctx) => {
+    const hasSuppressedAt = record.suppressedAt !== undefined;
+    const hasSuppressionReason = record.suppressionReason !== undefined;
+    if (hasSuppressedAt !== hasSuppressionReason) {
+      ctx.addIssue({
+        code: "custom",
+        path: hasSuppressedAt ? ["suppressionReason"] : ["suppressedAt"],
+        message: "suppressedAt and suppressionReason must be present together",
+      });
+    }
+
+    if (record.unsubscribedAt === undefined && !hasSuppressedAt) {
+      ctx.addIssue({ code: "custom", message: "must contain an unsubscribe or suppression block marker" });
+    }
+  });
+
+export type OptionalEmailAddressSuppression = z.infer<typeof optionalEmailAddressSuppressionSchema>;
 
 export const optionalEmailWebhookEventSchema = z.object({
   _id: z.instanceof(ObjectId),

--- a/src/repositories/optional-email-address-suppression-repo.ts
+++ b/src/repositories/optional-email-address-suppression-repo.ts
@@ -1,0 +1,158 @@
+import { Collection, MongoServerError } from "mongodb";
+import type { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import { InternalServerError } from "../lib/errors.js";
+import { optionalEmailAddressSuppressionSchema, type OptionalEmailAddressSuppression } from "../models/documents.js";
+import {
+  type OptionalEmailAddressKey,
+  OptionalEmailAddressKeyVersion,
+  OptionalEmailBlockReason,
+  OptionalEmailSuppressionReason,
+} from "../types/optional-email.js";
+import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
+
+const ADDRESS_KEY_PATTERN = /^[a-f0-9]{64}$/;
+
+export class OptionalEmailAddressSuppressionRepository {
+  readonly #collection: Collection<OptionalEmailAddressSuppression>;
+
+  constructor(accessor: MongoDbAccessor) {
+    this.#collection = accessor.getCollection<OptionalEmailAddressSuppression>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.OptionalEmailAddressSuppressions,
+    );
+  }
+
+  async findBlockReason(input: {
+    addressKeys: readonly OptionalEmailAddressKey[];
+  }): Promise<OptionalEmailBlockReason | null> {
+    this.#assertAddressKeys(input.addressKeys);
+    const unvalidatedRecords = await this.#collection
+      .find({
+        $or: input.addressKeys.map((addressKey) => ({
+          addressKeyVersion: addressKey.addressKeyVersion,
+          addressKey: addressKey.addressKey,
+        })),
+      })
+      .toArray();
+    const records = unvalidatedRecords.map((record) => {
+      const parsed = optionalEmailAddressSuppressionSchema.safeParse(record);
+      if (!parsed.success) {
+        throw new InternalServerError({
+          debugMessage: "Malformed optional email address suppression record",
+          nestedError: parsed.error,
+        });
+      }
+
+      return parsed.data;
+    });
+    if (records.some((record) => record.unsubscribedAt !== undefined)) {
+      return OptionalEmailBlockReason.Unsubscribed;
+    }
+
+    if (records.some((record) => record.suppressedAt !== undefined)) {
+      return OptionalEmailBlockReason.Suppressed;
+    }
+
+    return null;
+  }
+
+  async unsubscribe(input: {
+    addressKey: OptionalEmailAddressKey;
+    at: Date;
+  }): Promise<OptionalEmailAddressSuppression> {
+    this.#assertInput(input);
+    return this.#upsertOnce({
+      ...input,
+      fields: { unsubscribedAt: { $ifNull: ["$unsubscribedAt", input.at] } },
+    });
+  }
+
+  async suppress(input: {
+    addressKey: OptionalEmailAddressKey;
+    reason: OptionalEmailSuppressionReason;
+    at: Date;
+  }): Promise<OptionalEmailAddressSuppression> {
+    this.#assertInput(input);
+    if (!Object.values(OptionalEmailSuppressionReason).includes(input.reason)) {
+      throw new InternalServerError({ debugMessage: "Invalid optional email address suppression reason" });
+    }
+
+    return this.#upsertOnce({
+      ...input,
+      fields: {
+        suppressedAt: { $ifNull: ["$suppressedAt", input.at] },
+        suppressionReason: { $ifNull: ["$suppressionReason", input.reason] },
+      },
+    });
+  }
+
+  async #upsertOnce(input: {
+    addressKey: OptionalEmailAddressKey;
+    at: Date;
+    fields: Record<string, unknown>;
+  }): Promise<OptionalEmailAddressSuppression> {
+    const filter = {
+      addressKeyVersion: input.addressKey.addressKeyVersion,
+      addressKey: input.addressKey.addressKey,
+    };
+    const update = [
+      {
+        $set: {
+          ...input.fields,
+          createdAt: { $ifNull: ["$createdAt", input.at] },
+          updatedAt: input.at,
+        },
+      },
+    ];
+    try {
+      const record = await this.#collection.findOneAndUpdate(filter, update, {
+        upsert: true,
+        returnDocument: "after",
+      });
+      if (record) {
+        return record;
+      }
+    } catch (error) {
+      if (!(error instanceof MongoServerError) || error.code !== 11000) {
+        throw error;
+      }
+
+      const record = await this.#collection.findOneAndUpdate(filter, update, {
+        upsert: false,
+        returnDocument: "after",
+      });
+      if (record) {
+        return record;
+      }
+    }
+
+    const winner = await this.#collection.findOne(filter);
+    if (!winner) {
+      throw new InternalServerError({ debugMessage: "Failed to persist optional email address suppression" });
+    }
+
+    return winner;
+  }
+
+  #assertInput(input: { addressKey: OptionalEmailAddressKey; at: Date }): void {
+    this.#assertAddressKeys([input.addressKey]);
+    if (!(input.at instanceof Date) || Number.isNaN(input.at.getTime())) {
+      throw new InternalServerError({ debugMessage: "Invalid optional email address suppression input" });
+    }
+  }
+
+  #assertAddressKeys(addressKeys: readonly OptionalEmailAddressKey[]): void {
+    const versions = new Set(addressKeys.map((addressKey) => addressKey.addressKeyVersion));
+    if (
+      addressKeys.length === 0 ||
+      versions.size !== addressKeys.length ||
+      addressKeys.some(
+        (addressKey) =>
+          !Object.values(OptionalEmailAddressKeyVersion).includes(addressKey.addressKeyVersion) ||
+          !ADDRESS_KEY_PATTERN.test(addressKey.addressKey),
+      )
+    ) {
+      throw new InternalServerError({ debugMessage: "Invalid optional email address key" });
+    }
+  }
+}

--- a/src/repositories/optional-email-recipient-repo.ts
+++ b/src/repositories/optional-email-recipient-repo.ts
@@ -1,6 +1,6 @@
 import { Collection, ObjectId } from "mongodb";
-import { z } from "zod";
 import type { MongoDbAccessor } from "../db/mongo-db-accessor.js";
+import { normalizeOptionalEmailAddress } from "../lib/optional-email-address-key.js";
 import type { OAuthAccount, PasswordAccount } from "../models/documents.js";
 import { AUTH_PROVIDER_EMAIL, OAuthProviderName } from "../types/oauth.js";
 import {
@@ -10,12 +10,6 @@ import {
   OptionalEmailRecipientResolutionStatus,
 } from "../types/optional-email.js";
 import { AuthDbCollection, MongoDbDatabase } from "../types/mongo.js";
-
-const normalizedEmailSchema = z
-  .string()
-  .trim()
-  .email()
-  .transform((value) => value.toLowerCase());
 
 function compareStrings(left: string, right: string): number {
   if (left < right) {
@@ -112,23 +106,27 @@ export class OptionalEmailRecipientRepository {
       return { status: OptionalEmailRecipientResolutionStatus.Missing };
     }
 
-    const parsed = candidates.map((candidate) => ({
-      result: normalizedEmailSchema.safeParse(candidate.value),
-      provenance: candidate.provenance,
-    }));
-    if (parsed.some((candidate) => !candidate.result.success)) {
-      return { status: OptionalEmailRecipientResolutionStatus.Ambiguous };
+    const normalizedCandidates = [];
+    for (const candidate of candidates) {
+      const address = normalizeOptionalEmailAddress({ address: candidate.value });
+      if (address === null) {
+        return { status: OptionalEmailRecipientResolutionStatus.Ambiguous };
+      }
+
+      normalizedCandidates.push({ address, provenance: candidate.provenance });
     }
 
-    const addresses = new Set(parsed.map((candidate) => (candidate.result.success ? candidate.result.data : "")));
+    const addresses = new Set(normalizedCandidates.map((candidate) => candidate.address));
     if (addresses.size !== 1) {
       return { status: OptionalEmailRecipientResolutionStatus.Ambiguous };
     }
 
+    const [address] = addresses;
+
     return {
       status: OptionalEmailRecipientResolutionStatus.Resolved,
-      address: [...addresses][0] as string,
-      provenance: parsed
+      address,
+      provenance: normalizedCandidates
         .map((candidate) => candidate.provenance)
         .sort(
           (left, right) =>

--- a/src/types/mongo.ts
+++ b/src/types/mongo.ts
@@ -13,6 +13,7 @@ export enum AuthDbCollection {
   ActivationStates = "activationStates",
   SettingsConfiguration = "settingsConfiguration",
   OptionalEmailPreferences = "optionalEmailPreferences",
+  OptionalEmailAddressSuppressions = "optionalEmailAddressSuppressions",
   OptionalEmailWebhookEvents = "optionalEmailWebhookEvents",
   OptionalEmailSends = "optionalEmailSends",
   OptionalEmailDailyQuota = "optionalEmailDailyQuota",

--- a/src/types/optional-email.ts
+++ b/src/types/optional-email.ts
@@ -35,6 +35,15 @@ export type OptionalEmailRecipientResolution =
       status: OptionalEmailRecipientResolutionStatus.Missing | OptionalEmailRecipientResolutionStatus.Ambiguous;
     };
 
+export enum OptionalEmailAddressKeyVersion {
+  V1 = "v1",
+}
+
+export type OptionalEmailAddressKey = {
+  addressKeyVersion: OptionalEmailAddressKeyVersion;
+  addressKey: string;
+};
+
 export enum OptionalEmailDryRunMode {
   DryRun = "dry_run",
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -402,6 +402,68 @@ describe("optional email safety ingress configuration", () => {
     );
     assert.equal(shortUnsubscribe.success, false);
   });
+
+  it("declares an optional version-bound address-key secret", () => {
+    const absent = configSchema.safeParse(validEnv());
+    const configured = configSchema.safeParse(validEnv({ OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_V1: "a".repeat(32) }));
+
+    assert.equal(absent.success, true);
+    assert.equal(absent.data?.OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_V1, undefined);
+    assert.equal(configured.success, true);
+    assert.equal(configured.data?.OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_V1, "a".repeat(32));
+  });
+
+  it("rejects reuse of an optional-email signing secret as the address-key secret", () => {
+    const reusedSecret = "s".repeat(32);
+
+    const parsed = configSchema.safeParse(
+      validEnv({
+        OPTIONAL_EMAIL_UNSUBSCRIBE_SIGNING_SECRET: reusedSecret,
+        OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_V1: reusedSecret,
+      }),
+    );
+
+    assert.equal(parsed.success, false);
+  });
+
+  it("rejects reuse of the webhook verification secret as the address-key secret", () => {
+    const reusedSecret = `whsec_${Buffer.alloc(32, 11).toString("base64")}`;
+
+    const parsed = configSchema.safeParse(
+      validEnv({
+        RESEND_WEBHOOK_SECRET: reusedSecret,
+        OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_V1: reusedSecret,
+      }),
+    );
+
+    assert.equal(parsed.success, false);
+  });
+
+  it("rejects reuse of decoded webhook key material as the address-key secret", () => {
+    const reusedKeyMaterial = "w".repeat(32);
+
+    const parsed = configSchema.safeParse(
+      validEnv({
+        RESEND_WEBHOOK_SECRET: `whsec_${Buffer.from(reusedKeyMaterial, "utf8").toString("base64")}`,
+        OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_V1: reusedKeyMaterial,
+      }),
+    );
+
+    assert.equal(parsed.success, false);
+  });
+
+  it("rejects reuse of the analytics pseudonymization key as the address-key secret", () => {
+    const reusedSecret = "p".repeat(32);
+
+    const parsed = configSchema.safeParse(
+      validEnv({
+        PRODUCT_ANALYTICS_PSEUDONYMIZATION_KEY: Buffer.from(reusedSecret, "utf8").toString("base64"),
+        OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_V1: reusedSecret,
+      }),
+    );
+
+    assert.equal(parsed.success, false);
+  });
 });
 
 describe("optional email eligibility configuration", () => {

--- a/tests/db/mongo-db-accessor.test.ts
+++ b/tests/db/mongo-db-accessor.test.ts
@@ -110,6 +110,24 @@ describe("fresh glossary index normalization", () => {
   });
 });
 
+describe("optional email address suppression indexes", () => {
+  it("enforces one tombstone per key version and digest", async () => {
+    const ctx = await createTestApp();
+    try {
+      const indexes = await ctx.dbAccessor
+        .getDb(MongoDbDatabase.Auth)
+        .collection(AuthDbCollection.OptionalEmailAddressSuppressions)
+        .indexes();
+      const target = indexes.find((index) => indexKeyMatches(index.key, { addressKeyVersion: 1, addressKey: 1 }));
+
+      assert.ok(target);
+      assert.equal(target.unique, true);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+});
+
 describe("indexMatchesDesired", () => {
   it("returns true when key and unique option match", () => {
     const existing = { key: { email: 1 }, unique: true, name: "email_1", v: 2 };

--- a/tests/lib/optional-email-address-key.test.ts
+++ b/tests/lib/optional-email-address-key.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  deriveOptionalEmailAddressKey,
+  normalizeOptionalEmailAddress,
+} from "../../src/lib/optional-email-address-key.js";
+import { OptionalEmailAddressKeyVersion } from "../../src/types/optional-email.js";
+
+describe("optional email address keys", () => {
+  it("normalizes only surrounding whitespace and case", () => {
+    assert.equal(
+      normalizeOptionalEmailAddress({ address: " Person.Name+Tag@Example.test " }),
+      "person.name+tag@example.test",
+    );
+    assert.equal(normalizeOptionalEmailAddress({ address: "personname@example.test" }), "personname@example.test");
+    assert.equal(normalizeOptionalEmailAddress({ address: "person.name@example.test" }), "person.name@example.test");
+  });
+
+  it("derives a versioned purpose-specific HMAC from the normalized address", () => {
+    assert.deepEqual(
+      deriveOptionalEmailAddressKey({
+        address: " Person+Tag@Example.test ",
+        secret: "0123456789abcdef0123456789abcdef",
+        version: OptionalEmailAddressKeyVersion.V1,
+      }),
+      {
+        addressKeyVersion: OptionalEmailAddressKeyVersion.V1,
+        addressKey: "cdb54fc8180114de8d09840cfd56b299fed2e7c7e031d3edbce83974fef7787e",
+      },
+    );
+  });
+
+  it("rejects an invalid address instead of keying malformed input", () => {
+    assert.throws(
+      () =>
+        deriveOptionalEmailAddressKey({
+          address: "not-an-address",
+          secret: "s".repeat(32),
+          version: OptionalEmailAddressKeyVersion.V1,
+        }),
+      /internal_server_error/,
+    );
+  });
+
+  it("rejects an address-key secret shorter than 32 bytes", () => {
+    assert.throws(
+      () =>
+        deriveOptionalEmailAddressKey({
+          address: "person@example.test",
+          secret: "s".repeat(31),
+          version: OptionalEmailAddressKeyVersion.V1,
+        }),
+      /internal_server_error/,
+    );
+  });
+
+  it("rejects an undeclared key version", () => {
+    assert.throws(
+      () =>
+        deriveOptionalEmailAddressKey({
+          address: "person@example.test",
+          secret: "s".repeat(32),
+          version: "v2" as OptionalEmailAddressKeyVersion,
+        }),
+      /internal_server_error/,
+    );
+  });
+});

--- a/tests/repositories/optional-email-address-suppression-repo.test.ts
+++ b/tests/repositories/optional-email-address-suppression-repo.test.ts
@@ -1,0 +1,292 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { MongoServerError, ObjectId } from "mongodb";
+import type { MongoDbAccessor } from "../../src/db/mongo-db-accessor.js";
+import { InternalServerError } from "../../src/lib/errors.js";
+import type { OptionalEmailAddressSuppression } from "../../src/models/documents.js";
+import { deriveOptionalEmailAddressKey } from "../../src/lib/optional-email-address-key.js";
+import { OptionalEmailAddressSuppressionRepository } from "../../src/repositories/optional-email-address-suppression-repo.js";
+import {
+  OptionalEmailAddressKeyVersion,
+  OptionalEmailBlockReason,
+  OptionalEmailSuppressionReason,
+} from "../../src/types/optional-email.js";
+import { AuthDbCollection, MongoDbDatabase } from "../../src/types/mongo.js";
+import { createTestApp, type TestContext } from "../helpers/setup.js";
+
+const fixtureSecret = "s".repeat(32);
+
+describe("OptionalEmailAddressSuppressionRepository", () => {
+  let ctx: TestContext;
+  let repository: OptionalEmailAddressSuppressionRepository;
+
+  before(async () => {
+    ctx = await createTestApp();
+    repository = new OptionalEmailAddressSuppressionRepository(ctx.dbAccessor);
+  });
+
+  after(async () => {
+    await ctx.cleanup();
+  });
+
+  it("persists an address-level unsubscribe without a raw address or user id", async () => {
+    const addressKey = deriveOptionalEmailAddressKey({
+      address: " Shared@Example.test ",
+      secret: fixtureSecret,
+      version: OptionalEmailAddressKeyVersion.V1,
+    });
+    const at = new Date("2026-09-12T12:00:00.000Z");
+
+    await repository.unsubscribe({ addressKey, at });
+
+    const stored = await ctx.dbAccessor
+      .getCollection<OptionalEmailAddressSuppression>(
+        MongoDbDatabase.Auth,
+        AuthDbCollection.OptionalEmailAddressSuppressions,
+      )
+      .findOne(addressKey);
+    assert.equal(stored?.unsubscribedAt?.toISOString(), at.toISOString());
+    assert.equal("email" in (stored ?? {}), false);
+    assert.equal("address" in (stored ?? {}), false);
+    assert.equal("userId" in (stored ?? {}), false);
+    assert.equal(
+      await repository.findBlockReason({ addressKeys: [addressKey] }),
+      OptionalEmailBlockReason.Unsubscribed,
+    );
+  });
+
+  it("does not retain extra raw address or user id properties from a structurally typed key", async () => {
+    const addressKey = {
+      ...deriveOptionalEmailAddressKey({
+        address: "tainted@example.test",
+        secret: fixtureSecret,
+        version: OptionalEmailAddressKeyVersion.V1,
+      }),
+      address: "tainted@example.test",
+      userId: new ObjectId(),
+    };
+
+    await repository.unsubscribe({ addressKey, at: new Date("2026-09-12T12:30:00.000Z") });
+
+    const stored = await ctx.dbAccessor
+      .getCollection<OptionalEmailAddressSuppression>(
+        MongoDbDatabase.Auth,
+        AuthDbCollection.OptionalEmailAddressSuppressions,
+      )
+      .findOne({
+        addressKeyVersion: addressKey.addressKeyVersion,
+        addressKey: addressKey.addressKey,
+      });
+    assert.equal("address" in (stored ?? {}), false);
+    assert.equal("userId" in (stored ?? {}), false);
+  });
+
+  it("persists hard-bounce, complaint, and provider suppression blockers", async () => {
+    for (const reason of [
+      OptionalEmailSuppressionReason.HardBounce,
+      OptionalEmailSuppressionReason.Complaint,
+      OptionalEmailSuppressionReason.ProviderSuppressed,
+    ]) {
+      const addressKey = deriveOptionalEmailAddressKey({
+        address: `${reason}@example.test`,
+        secret: fixtureSecret,
+        version: OptionalEmailAddressKeyVersion.V1,
+      });
+      const at = new Date("2026-09-12T13:00:00.000Z");
+
+      await repository.suppress({ addressKey, reason, at });
+
+      const stored = await ctx.dbAccessor
+        .getCollection<OptionalEmailAddressSuppression>(
+          MongoDbDatabase.Auth,
+          AuthDbCollection.OptionalEmailAddressSuppressions,
+        )
+        .findOne(addressKey);
+      assert.equal(stored?.suppressedAt?.toISOString(), at.toISOString());
+      assert.equal(stored?.suppressionReason, reason);
+      assert.equal(
+        await repository.findBlockReason({ addressKeys: [addressKey] }),
+        OptionalEmailBlockReason.Suppressed,
+      );
+    }
+  });
+
+  it("fails closed for malformed matching tombstones", async () => {
+    const at = new Date("2026-09-12T13:15:00.000Z");
+    const malformedCases = [
+      { name: "missing-block-marker", fields: {} },
+      { name: "missing-suppression-reason", fields: { suppressedAt: at } },
+      {
+        name: "missing-suppressed-at",
+        fields: { suppressionReason: OptionalEmailSuppressionReason.Complaint },
+      },
+    ] satisfies ReadonlyArray<{
+      name: string;
+      fields: Partial<Pick<OptionalEmailAddressSuppression, "suppressedAt" | "suppressionReason">>;
+    }>;
+    const collection = ctx.dbAccessor.getCollection<OptionalEmailAddressSuppression>(
+      MongoDbDatabase.Auth,
+      AuthDbCollection.OptionalEmailAddressSuppressions,
+    );
+    const addressKeys = malformedCases.map(({ name }) =>
+      deriveOptionalEmailAddressKey({
+        address: `${name}@example.test`,
+        secret: fixtureSecret,
+        version: OptionalEmailAddressKeyVersion.V1,
+      }),
+    );
+    await collection.insertMany(
+      malformedCases.map(({ fields }, index) => ({
+        _id: new ObjectId(),
+        ...addressKeys[index],
+        ...fields,
+        createdAt: at,
+        updatedAt: at,
+      })),
+    );
+
+    const results = await Promise.allSettled(
+      addressKeys.map((addressKey) => repository.findBlockReason({ addressKeys: [addressKey] })),
+    );
+
+    for (const [index, result] of results.entries()) {
+      assert.equal(result.status, "rejected", malformedCases[index]?.name);
+      if (result.status === "rejected") {
+        assert.ok(result.reason instanceof InternalServerError, malformedCases[index]?.name);
+      }
+    }
+  });
+
+  it("rejects multiple keys for one version so secret rotation cannot silently reuse a version", async () => {
+    const first = deriveOptionalEmailAddressKey({
+      address: "shared@example.test",
+      secret: fixtureSecret,
+      version: OptionalEmailAddressKeyVersion.V1,
+    });
+    const second = deriveOptionalEmailAddressKey({
+      address: "shared@example.test",
+      secret: "z".repeat(32),
+      version: OptionalEmailAddressKeyVersion.V1,
+    });
+
+    await assert.rejects(() => repository.findBlockReason({ addressKeys: [first, second] }), /internal_server_error/);
+  });
+
+  it("rejects an empty retained-version lookup instead of clearing suppression", async () => {
+    await assert.rejects(() => repository.findBlockReason({ addressKeys: [] }), /internal_server_error/);
+  });
+
+  it("rejects a non-HMAC key before any raw address can be retained", async () => {
+    const rawAddress = "raw@example.test";
+
+    await assert.rejects(
+      () =>
+        repository.unsubscribe({
+          addressKey: {
+            addressKeyVersion: OptionalEmailAddressKeyVersion.V1,
+            addressKey: rawAddress,
+          },
+          at: new Date("2026-09-12T13:30:00.000Z"),
+        }),
+      /internal_server_error/,
+    );
+
+    const retained = await ctx.dbAccessor
+      .getCollection<OptionalEmailAddressSuppression>(
+        MongoDbDatabase.Auth,
+        AuthDbCollection.OptionalEmailAddressSuppressions,
+      )
+      .countDocuments({ addressKey: rawAddress });
+    assert.equal(retained, 0);
+  });
+
+  it("rejects an unsupported suppression reason", async () => {
+    const addressKey = deriveOptionalEmailAddressKey({
+      address: "invalid-reason@example.test",
+      secret: fixtureSecret,
+      version: OptionalEmailAddressKeyVersion.V1,
+    });
+
+    await assert.rejects(
+      () =>
+        repository.suppress({
+          addressKey,
+          reason: "soft_bounce" as OptionalEmailSuppressionReason,
+          at: new Date("2026-09-12T13:45:00.000Z"),
+        }),
+      /internal_server_error/,
+    );
+  });
+
+  it("rejects an invalid event timestamp", async () => {
+    const addressKey = deriveOptionalEmailAddressKey({
+      address: "invalid-date@example.test",
+      secret: fixtureSecret,
+      version: OptionalEmailAddressKeyVersion.V1,
+    });
+
+    await assert.rejects(
+      () => repository.unsubscribe({ addressKey, at: new Date("invalid") }),
+      /internal_server_error/,
+    );
+  });
+
+  it("rejects a non-Date event timestamp at the repository boundary", async () => {
+    const addressKey = deriveOptionalEmailAddressKey({
+      address: "missing-date@example.test",
+      secret: fixtureSecret,
+      version: OptionalEmailAddressKeyVersion.V1,
+    });
+
+    await assert.rejects(
+      () => repository.unsubscribe({ addressKey, at: undefined as unknown as Date }),
+      /internal_server_error/,
+    );
+  });
+
+  it("replays a losing update after a concurrent tombstone creation", async () => {
+    const addressKey = deriveOptionalEmailAddressKey({
+      address: "race@example.test",
+      secret: fixtureSecret,
+      version: OptionalEmailAddressKeyVersion.V1,
+    });
+    const at = new Date("2026-09-12T14:00:00.000Z");
+    const duplicateKeyError = new MongoServerError({ ok: 0, code: 11000, errmsg: "duplicate tombstone" });
+    const winner: OptionalEmailAddressSuppression = {
+      _id: new ObjectId(),
+      ...addressKey,
+      unsubscribedAt: at,
+      createdAt: at,
+      updatedAt: at,
+    };
+    let updateAttempts = 0;
+    const racingRepository = new OptionalEmailAddressSuppressionRepository({
+      getCollection: () => ({
+        findOneAndUpdate: async (_filter: unknown, _update: unknown, options: { upsert: boolean }) => {
+          updateAttempts += 1;
+          if (updateAttempts === 1) {
+            throw duplicateKeyError;
+          }
+
+          assert.equal(options.upsert, false);
+          return {
+            ...winner,
+            suppressedAt: at,
+            suppressionReason: OptionalEmailSuppressionReason.Complaint,
+          };
+        },
+        findOne: async () => winner,
+      }),
+    } as unknown as MongoDbAccessor);
+
+    const record = await racingRepository.suppress({
+      addressKey,
+      reason: OptionalEmailSuppressionReason.Complaint,
+      at,
+    });
+
+    assert.equal(updateAttempts, 2);
+    assert.equal(record.unsubscribedAt?.toISOString(), at.toISOString());
+    assert.equal(record.suppressionReason, OptionalEmailSuppressionReason.Complaint);
+  });
+});


### PR DESCRIPTION
## Summary

- add a versioned, purpose-separated HMAC address-key utility that reuses the recipient resolver's conservative trim/lowercase normalization without dot or plus rewriting
- add a minimal address-level optional-email do-not-contact tombstone and repository for unsubscribe, complaint, hard-bounce, and provider suppression signals
- retain only the keyed pseudonym, version, blocker timestamps/reason, and audit timestamps; no raw email address or user ID is stored
- declare a dedicated optional `OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_V1`, reject reuse of existing signing/pseudonymization key material, and enforce one record per versioned digest
- fail closed for malformed matching tombstones and handle concurrent upsert races

## Safety boundaries

- this is a dormant ledger foundation only; it is not wired into unsubscribe routes, webhook processing, eligibility, dry-run output, provider calls, or sending
- the existing user-scoped suppression remains an independent stricter block, and `recipient_safety_unverified` remains terminal
- address-binding/enforcement is intentionally deferred to the next sequential email-series integration PR after this foundation merges
- no recipient-basis enablement, mobile telemetry, copy implementation, migration, production access, provider API call, send, scheduling, or deployment

## Test plan

- focused optional-email/config/index tests: 98 passed
- full suite: 1,036 passed, 1 existing skip, 0 failed
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run circular-dependencies`
- `git diff --check`
- independent pre-commit security/logic review: passed after resolving all blocking findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dormant address-level suppression ledger for optional email, setting up do-not-contact tombstones without wiring them into sending or eligibility paths.

- New `OPTIONAL_EMAIL_ADDRESS_KEY_SECRET_V1` derives a purpose- and version-separated HMAC digest from a normalized address and rejects reuse of existing signing, pseudonymization, Firebase, or MongoDB credential key material.
- FCM config keeps the raw encoded value during validation for reuse checks, then strips it from the final config.
- New `OptionalEmailAddressSuppressionRepository` stores unsubscribe, hard-bounce, complaint, and provider suppression tombstones keyed by versioned digest, with no raw address or user ID.
- Unique index on `(addressKeyVersion, addressKey)` enforces one tombstone per digest.
- Recipient resolution now reuses the shared normalization helper, preserving its existing trim/lowercase behavior.

**Safety boundaries**
- This foundation is not connected to unsubscribe routes, webhooks, eligibility checks, dry-run output, provider calls, or sending.
- Address binding and enforcement are deferred to a later integration PR after this merges.
- Existing user-scoped suppression and `recipient_safety_unverified` behavior are unchanged.

<sup>Written for commit 50249456e6acfe9c338e42cefeb8caa3f5dcfcfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_auth_server/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

